### PR TITLE
Add Address Objects Support to SCM CLI

### DIFF
--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -11,7 +11,7 @@ import yaml
 
 from ..utils.config import load_from_yaml
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AddressGroup
+from ..utils.validators import Address, AddressGroup
 
 # Create app groups for each action type
 set_app = typer.Typer(help="Create or update objects configurations")
@@ -27,6 +27,12 @@ DESCRIPTION_OPTION = typer.Option(None, "--description", help="Description of th
 TAGS_OPTION = typer.Option(None, "--tags", help="List of tags")
 FILE_OPTION = typer.Option(..., "--file", help="YAML file to load configurations from")
 DRY_RUN_OPTION = typer.Option(False, "--dry-run", help="Simulate execution without applying changes")
+
+# Address-specific options
+IP_NETMASK_OPTION = typer.Option(None, "--ip-netmask", help="IP address with CIDR notation (e.g. 192.168.1.0/24)")
+IP_RANGE_OPTION = typer.Option(None, "--ip-range", help="IP address range (e.g. 192.168.1.1-192.168.1.10)")
+IP_WILDCARD_OPTION = typer.Option(None, "--ip-wildcard", help="IP wildcard mask (e.g. 10.20.1.0/0.0.248.255)")
+FQDN_OPTION = typer.Option(None, "--fqdn", help="Fully qualified domain name (e.g. example.com)")
 
 
 @set_app.command("address-group")
@@ -138,4 +144,131 @@ def load_address_group(
         return results
     except Exception as e:
         typer.echo(f"Error loading address groups: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("address")
+def set_address(
+    folder: str = FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    description: str | None = DESCRIPTION_OPTION,
+    tags: list[str] | None = TAGS_OPTION,
+    ip_netmask: str | None = IP_NETMASK_OPTION,
+    ip_range: str | None = IP_RANGE_OPTION,
+    ip_wildcard: str | None = IP_WILDCARD_OPTION,
+    fqdn: str | None = FQDN_OPTION,
+):
+    """Create or update an address object.
+
+    Example:
+    -------
+        scm-cli set objects address \
+        --folder Texas \
+        --name webserver \
+        --ip-netmask 192.168.1.100/32 \
+        --description "Web server" \
+        --tags ["server", "web"]
+
+    Note: Exactly one of ip-netmask, ip-range, ip-wildcard, or fqdn must be provided.
+
+    """
+    try:
+        # Validate inputs using the Pydantic model
+        address = Address(
+            folder=folder,
+            name=name,
+            description=description or "",
+            tags=tags or [],
+            ip_netmask=ip_netmask,
+            ip_range=ip_range,
+            ip_wildcard=ip_wildcard,
+            fqdn=fqdn,
+        )
+
+        # Call the SDK client to create the address
+        result = scm_client.create_address(
+            folder=address.folder,
+            name=address.name,
+            description=address.description,
+            tags=address.tags,
+            ip_netmask=address.ip_netmask,
+            ip_range=address.ip_range,
+            ip_wildcard=address.ip_wildcard,
+            fqdn=address.fqdn,
+        )
+
+        typer.echo(f"Created address: {result['name']} in folder {result['folder']}")
+        return result
+    except Exception as e:
+        typer.echo(f"Error creating address: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("address")
+def delete_address(
+    folder: str = FOLDER_OPTION,
+    name: str = NAME_OPTION,
+):
+    """Delete an address object.
+
+    Example:
+    -------
+    scm-cli delete objects address --folder Texas --name webserver
+
+    """
+    try:
+        result = scm_client.delete_address(folder=folder, name=name)
+        if result:
+            typer.echo(f"Deleted address: {name} from folder {folder}")
+        return result
+    except Exception as e:
+        typer.echo(f"Error deleting address: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("address")
+def load_address(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+):
+    """Load address objects from a YAML file.
+
+    Example:
+    -------
+    scm-cli load objects address --file config/addresses.yml
+
+    """
+    try:
+        # Load and parse the YAML file
+        config = load_from_yaml(file, "addresses")
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            typer.echo(yaml.dump(config["addresses"]))
+            return
+
+        # Apply each address
+        results = []
+        for addr_data in config["addresses"]:
+            # Validate using the Pydantic model
+            address = Address(**addr_data)
+
+            # Call the SDK client to create the address
+            result = scm_client.create_address(
+                folder=address.folder,
+                name=address.name,
+                description=address.description,
+                tags=address.tags,
+                ip_netmask=address.ip_netmask,
+                ip_range=address.ip_range,
+                ip_wildcard=address.ip_wildcard,
+                fqdn=address.fqdn,
+            )
+
+            results.append(result)
+            typer.echo(f"Applied address: {result['name']} in folder {result['folder']}")
+
+        return results
+    except Exception as e:
+        typer.echo(f"Error loading addresses: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -254,6 +254,204 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("deletion", folder, name, e)
 
+    def create_address(
+        self,
+        folder: str,
+        name: str,
+        description: str = "",
+        tags: list[str] = None,
+        ip_netmask: str = None,
+        ip_range: str = None,
+        ip_wildcard: str = None,
+        fqdn: str = None,
+    ) -> dict[str, Any]:
+        """Create an address object.
+
+        Args:
+        ----
+            folder: Folder to create the address in
+            name: Name of the address
+            description: Optional description
+            tags: Optional list of tags
+            ip_netmask: IP address with CIDR notation (e.g. "192.168.1.0/24")
+            ip_range: IP address range (e.g. "192.168.1.1-192.168.1.10")
+            ip_wildcard: IP wildcard mask (e.g. "10.20.1.0/0.0.248.255")
+            fqdn: Fully qualified domain name (e.g. "example.com")
+
+        Returns:
+        -------
+            The created address object
+
+        Note:
+        ----
+            Exactly one of ip_netmask, ip_range, ip_wildcard, or fqdn must be provided.
+
+        """
+        tags = tags or []
+        self.logger.info(f"Creating address: {name} in folder {folder}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"addr-{name}",
+                "folder": folder,
+                "name": name,
+                "description": description,
+                "tags": tags,
+                "ip_netmask": ip_netmask,
+                "ip_range": ip_range,
+                "ip_wildcard": ip_wildcard,
+                "fqdn": fqdn,
+            }
+
+        try:
+            # Create using the SDK address service
+            address_data = {
+                "name": name,
+                "folder": folder,
+                "description": description or "",
+            }
+
+            # Add exactly one address type
+            if ip_netmask:
+                address_data["ip_netmask"] = ip_netmask
+            elif ip_range:
+                address_data["ip_range"] = ip_range
+            elif ip_wildcard:
+                address_data["ip_wildcard"] = ip_wildcard
+            elif fqdn:
+                address_data["fqdn"] = fqdn
+
+            if tags:
+                address_data["tag"] = tags
+
+            # Create the address object
+            result = self.client.address.create(address_data)
+
+            # Convert SDK response to dict for compatibility
+            return result.model_dump()
+        except Exception as e:
+            self._handle_api_exception("creation", folder, name, e)
+
+    def get_address(
+        self,
+        folder: str,
+        name: str,
+    ) -> dict[str, Any]:
+        """Get an address object by name and folder.
+
+        Args:
+        ----
+            folder: Folder containing the address
+            name: Name of the address to get
+
+        Returns:
+        -------
+            The address object
+
+        """
+        self.logger.info(f"Getting address: {name} from folder {folder}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"addr-{name}",
+                "folder": folder,
+                "name": name,
+                "description": "Mock address object",
+                "tags": [],
+                "ip_netmask": "192.168.1.0/24",
+            }
+
+        try:
+            # Fetch the address using the SDK
+            result = self.client.address.fetch(name=name, folder=folder)
+
+            # Convert SDK response to dict for compatibility
+            return result.model_dump()
+        except Exception as e:
+            self._handle_api_exception("retrieval", folder, name, e)
+
+    def list_addresses(
+        self,
+        folder: str,
+    ) -> list[dict[str, Any]]:
+        """List address objects in a folder.
+
+        Args:
+        ----
+            folder: Folder to list addresses from
+
+        Returns:
+        -------
+            List of address objects
+
+        """
+        self.logger.info(f"Listing addresses in folder: {folder}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return [
+                {
+                    "id": "addr-mock1",
+                    "folder": folder,
+                    "name": "mock-address-1",
+                    "description": "Mock address 1",
+                    "tags": ["mock"],
+                    "ip_netmask": "192.168.1.0/24",
+                },
+                {
+                    "id": "addr-mock2",
+                    "folder": folder,
+                    "name": "mock-address-2",
+                    "description": "Mock address 2",
+                    "tags": ["mock"],
+                    "fqdn": "example.com",
+                },
+            ]
+
+        try:
+            # List addresses using the SDK
+            results = self.client.address.list(folder=folder)
+
+            # Convert SDK response to list of dicts for compatibility
+            return [result.model_dump() for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder, "addresses", e)
+
+    def delete_address(
+        self,
+        folder: str,
+        name: str,
+    ) -> bool:
+        """Delete an address object.
+
+        Args:
+        ----
+            folder: Folder containing the address
+            name: Name of the address to delete
+
+        Returns:
+        -------
+            True if deletion was successful
+
+        """
+        self.logger.info(f"Deleting address: {name} from folder {folder}")
+
+        if not self.client:
+            # Return mock result if no client is available
+            return True
+
+        try:
+            # Get the address first to retrieve its ID
+            address = self.client.address.fetch(name=name, folder=folder)
+
+            # Delete using the address's ID
+            self.client.address.delete(object_id=str(address.id))
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", folder, name, e)
+
     def create_zone(
         self,
         folder: str,

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -7,7 +7,7 @@ that all required fields are present and correctly formatted.
 
 from typing import Any, TypeVar
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 # Create a type variable bound to BaseModel
 ModelT = TypeVar("ModelT", bound=BaseModel)
@@ -103,6 +103,57 @@ class SecurityRule(BaseModel):
             "tags": self.tags,
             "enabled": self.enabled,
         }
+
+
+class Address(BaseModel):
+    """Model for address objects with container information.
+
+    Attributes
+    ----------
+        folder (str): The folder where the address object is located
+        name (str): The name of the address object
+        description (str): Description of the address object
+        tags (List[str]): Tags associated with the address object
+        ip_netmask (Optional[str]): IP address with CIDR notation (e.g. "192.168.1.0/24")
+        ip_range (Optional[str]): IP address range (e.g. "192.168.1.1-192.168.1.10")
+        ip_wildcard (Optional[str]): IP wildcard mask (e.g. "10.20.1.0/0.0.248.255")
+        fqdn (Optional[str]): Fully qualified domain name (e.g. "example.com")
+
+    """
+
+    folder: str = Field(..., description="Folder containing the address object")
+    name: str = Field(..., min_length=1, max_length=63, description="Name of the address object")
+    description: str = Field("", description="Description of the address object")
+    tags: list[str] = Field(default_factory=list, description="Tags associated with the address object")
+
+    # Address type fields - exactly one must be provided
+    ip_netmask: str | None = Field(None, description="IP address with CIDR notation")
+    ip_range: str | None = Field(None, description="IP address range")
+    ip_wildcard: str | None = Field(None, description="IP wildcard mask")
+    fqdn: str | None = Field(None, description="Fully qualified domain name")
+
+    @model_validator(mode="after")
+    def validate_address_type(self) -> "Address":
+        """Validate that exactly one address type is provided.
+
+        Returns
+        -------
+            Address: The validated address object
+
+        Raises
+        ------
+            ValueError: If zero or multiple address types are provided
+
+        """
+        address_fields = ["ip_netmask", "ip_range", "ip_wildcard", "fqdn"]
+        provided = [field for field in address_fields if getattr(self, field) is not None]
+
+        if len(provided) == 0:
+            raise ValueError("Exactly one of 'ip_netmask', 'ip_range', 'ip_wildcard', or 'fqdn' must be provided.")
+        elif len(provided) > 1:
+            raise ValueError("Only one of 'ip_netmask', 'ip_range', 'ip_wildcard', or 'fqdn' can be provided.")
+
+        return self
 
 
 def validate_yaml_file(data: dict[str, Any], model_class: type[ModelT], key: str) -> list[ModelT]:


### PR DESCRIPTION
### **User description**
## Overview
This PR adds full CRUD support for address objects to the SCM CLI, extending the existing object management functionality to work with address objects in Palo Alto Networks Strata Cloud Manager.

## Changes
- Added `Address` Pydantic model in `validators.py` to validate address object data
- Implemented SDK client methods in `sdk_client.py`:
  - `create_address()` - Creates a new address object
  - `get_address()` - Retrieves an address by name and folder
  - `list_addresses()` - Lists all addresses in a folder
  - `delete_address()` - Deletes an address by name and folder
- Added CLI commands in `objects.py`:
  - `set objects address` - Create or update an address object
  - `delete objects address` - Remove an address object
  - `load objects address` - Load multiple address objects from YAML

## Features
The implementation supports all four SCM address types:
- IP address with CIDR notation (`--ip-netmask`)
- IP range (`--ip-range`)
- IP wildcard mask (`--ip-wildcard`)
- Fully qualified domain name (`--fqdn`)

## Examples

### Creating an address with IP/CIDR
```bash
scm-cli set objects address \
  --folder Texas \
  --name webserver \
  --ip-netmask 192.168.1.100/32 \
  --description "Web server" \
  --tags ["server", "web"]
```

### Creating an address with FQDN
```bash
scm-cli set objects address \
  --folder Texas \
  --name website \
  --fqdn example.com \
  --description "Website" \
  --tags ["external"]
```

### Deleting an address
```bash
scm-cli delete objects address --folder Texas --name webserver
```

### Loading addresses from YAML
```bash
scm-cli load objects address --file config/addresses.yml
```

## Testing
The implementation includes mock mode support for testing without SDK connectivity.

## Follows Project Patterns
This implementation follows the same patterns as the existing address-group implementation to maintain consistency across the codebase.


___

### **PR Type**
Enhancement


___

### **Description**
- Add CRUD support for address objects

- Implement SDK client methods for addresses

- Add CLI commands for address management

- Support multiple address types (IP, range, wildcard, FQDN)


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>objects.py</strong><dd><code>Implement CLI commands for address object management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/scm_cli/commands/objects.py

<li>Added set, delete, and load commands for address objects<br> <li> Implemented address-specific CLI options<br> <li> Added error handling and dry run support


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-cli/pull/6/files#diff-38d6d16e0fe15439adadf387ab59cbf10ad1ce5d8ad26885393996798412866c">+134/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sdk_client.py</strong><dd><code>Add SDK client methods for address object operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/scm_cli/utils/sdk_client.py

<li>Added create_address, get_address, list_addresses, and delete_address <br>methods<br> <li> Implemented mock data support for testing<br> <li> Added error handling and logging


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-cli/pull/6/files#diff-c24d35d30386e4b0edc94ee235ad7de49dd5c856d5670e99fed0245f358c9687">+198/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>validators.py</strong><dd><code>Add Address model and validation for address objects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/scm_cli/utils/validators.py

<li>Added Address Pydantic model for validation<br> <li> Implemented address type validation logic


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-cli/pull/6/files#diff-7987fa3736552c6a3894e937a49482afa3d1dd1762c24b382c09a066a8925ebd">+52/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>