### PR TITLE
hotfix to help windows not be so dumb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "0.3.1"
+version = "0.3.2"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/utils/config.py
+++ b/src/scm_cli/utils/config.py
@@ -97,9 +97,9 @@ def get_auth_config() -> dict[str, str]:
 
     # First try environment variables (PREFIX_client_id)
     auth = {
-        "client_id": settings.get("client_id"),
-        "client_secret": settings.get("client_secret"),
-        "tsg_id": settings.get("tsg_id"),
+        "client_id": str(settings.get("client_id")),
+        "client_secret": str(settings.get("client_secret")),
+        "tsg_id": str(settings.get("tsg_id")),
     }
 
     # For backward compatibility, also check the scm_ prefixed settings


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Convert client_id, client_secret, and tsg_id to strings

- Bump version from 0.3.1 to 0.3.2


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.py</strong><dd><code>Convert authentication settings to strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/scm_cli/utils/config.py

<li>Convert <code>client_id</code>, <code>client_secret</code>, and <code>tsg_id</code> to strings using <code>str()</code> <br>function<br> <li> Ensures compatibility with different data types for authentication <br>settings


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-cli/pull/29/files#diff-e390cc47c5bc0772ec2a42975b84f7ca932a4273011b11feacd1d1ab4ccd56cf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Version update</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump version to 0.3.2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Update version number from 0.3.1 to 0.3.2


</details>


  </td>
  <td><a href="https://github.com/cdot65/pan-scm-cli/pull/29/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>