### PR TITLE
feat: SDK parity batch 1 - schedule, region, quarantined device, IKE crypto

### DIFF
--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -13,7 +13,7 @@ from pydantic import ValidationError
 
 from ..utils.config import load_from_yaml
 from ..utils.sdk_client import scm_client
-from ..utils.validators import Zone
+from ..utils.validators import IKECryptoProfile, Zone
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -136,6 +136,222 @@ def get_default_backup_filename(object_type: str, location_type: str, location_v
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     safe_location = location_value.lower().replace(" ", "-").replace("/", "-")
     return f"{object_type}_{location_type}_{safe_location}_{timestamp}.yaml"
+
+
+# ========================================================================================================================================================================================
+# IKE CRYPTO PROFILE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("ike-crypto-profile", help="Export IKE crypto profiles to a YAML file.")
+def backup_ike_crypto_profile(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export IKE crypto profiles from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving IKE crypto profiles from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_ike_crypto_profiles(**kwargs)
+        if not profiles:
+            typer.echo(f"No IKE crypto profiles found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"ike_crypto_profiles": profiles}
+        filename = Path(file or get_default_backup_filename("ike-crypto-profile", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(profiles)} IKE crypto profiles to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up IKE crypto profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("ike-crypto-profile", help="Delete an IKE crypto profile.")
+def delete_ike_crypto_profile(
+    name: str = typer.Argument(..., help="Name of the IKE crypto profile to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete an IKE crypto profile."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        profile = scm_client.get_ike_crypto_profile(name=name, folder=folder, snippet=snippet, device=device)
+        if not profile:
+            typer.echo(f"IKE crypto profile '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete IKE crypto profile '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_ike_crypto_profile(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted IKE crypto profile: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting IKE crypto profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("ike-crypto-profile", help="Load IKE crypto profiles from a YAML file.")
+def load_ike_crypto_profile(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+) -> None:
+    """Load IKE crypto profiles from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "ike_crypto_profiles" not in data:
+            typer.echo("No IKE crypto profiles found in file", err=True)
+            raise typer.Exit(code=1)
+        profiles = data["ike_crypto_profiles"]
+        if not isinstance(profiles, list):
+            profiles = [profiles]
+        created_count = 0
+        for profile_data in profiles:
+            try:
+                validated_profile = IKECryptoProfile(**profile_data)
+                if folder:
+                    validated_profile.folder = folder
+                    validated_profile.snippet = None
+                    validated_profile.device = None
+                elif snippet:
+                    validated_profile.snippet = snippet
+                    validated_profile.folder = None
+                    validated_profile.device = None
+                elif device:
+                    validated_profile.device = device
+                    validated_profile.folder = None
+                    validated_profile.snippet = None
+                sdk_data = validated_profile.to_sdk_model()
+                scm_client.create_ike_crypto_profile(sdk_data)
+                created_count += 1
+                container = validated_profile.folder or validated_profile.snippet or validated_profile.device
+                typer.echo(f"Created IKE crypto profile: {validated_profile.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing IKE crypto profile: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count} IKE crypto profiles")
+    except Exception as e:
+        typer.echo(f"Error loading IKE crypto profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("ike-crypto-profile", help="Create or update an IKE crypto profile.")
+def set_ike_crypto_profile(
+    name: str = typer.Argument(..., help="Name of the IKE crypto profile"),
+    hash: list[str] = typer.Option(..., "--hash", help="Hash algorithms (sha256, sha384, sha512, sha1, md5)"),
+    dh_group: list[str] = typer.Option(..., "--dh-group", help="DH groups (group1, group2, group5, group14, group19, group20)"),
+    encryption: list[str] = typer.Option(..., "--encryption", help="Encryption algorithms (aes-256-cbc, aes-128-cbc, etc.)"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    lifetime_seconds: int = typer.Option(None, "--lifetime-seconds", help="Lifetime in seconds (180-65535)"),
+    lifetime_minutes: int = typer.Option(None, "--lifetime-minutes", help="Lifetime in minutes (3-65535)"),
+    lifetime_hours: int = typer.Option(None, "--lifetime-hours", help="Lifetime in hours (1-65535)"),
+    lifetime_days: int = typer.Option(None, "--lifetime-days", help="Lifetime in days (1-365)"),
+    authentication_multiple: int = typer.Option(None, "--authentication-multiple", help="IKEv2 SA reauthentication interval (0-50)"),
+) -> None:
+    """Create or update an IKE crypto profile."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        profile_data = {"name": name, "hash": hash, "dh_group": dh_group, "encryption": encryption, location_type: location_value}
+        if lifetime_seconds is not None:
+            profile_data["lifetime_seconds"] = lifetime_seconds
+        if lifetime_minutes is not None:
+            profile_data["lifetime_minutes"] = lifetime_minutes
+        if lifetime_hours is not None:
+            profile_data["lifetime_hours"] = lifetime_hours
+        if lifetime_days is not None:
+            profile_data["lifetime_days"] = lifetime_days
+        if authentication_multiple is not None:
+            profile_data["authentication_multiple"] = authentication_multiple
+        validated_profile = IKECryptoProfile(**profile_data)
+        sdk_data = validated_profile.to_sdk_model()
+        result = scm_client.create_ike_crypto_profile(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created IKE crypto profile: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated IKE crypto profile: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for IKE crypto profile: {name} in {location_value}")
+    except Exception as e:
+        typer.echo(f"Error creating/updating IKE crypto profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("ike-crypto-profile", help="Show IKE crypto profile details.")
+def show_ike_crypto_profile(
+    name: str = typer.Option(None, "--name", help="Name of specific IKE crypto profile to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show IKE crypto profile details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            profile = scm_client.get_ike_crypto_profile(name=name, folder=folder, snippet=snippet, device=device)
+            if not profile:
+                typer.echo(f"IKE crypto profile '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nIKE Crypto Profile: {profile['name']}")
+            typer.echo("=" * 60)
+            location = profile.get("folder") or profile.get("snippet") or profile.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if profile.get("hash"):
+                typer.echo(f"Hash: {', '.join(profile['hash'])}")
+            if profile.get("dh_group"):
+                typer.echo(f"DH Group: {', '.join(profile['dh_group'])}")
+            if profile.get("encryption"):
+                typer.echo(f"Encryption: {', '.join(profile['encryption'])}")
+            lifetime = profile.get("lifetime")
+            if lifetime and isinstance(lifetime, dict):
+                for unit, value in lifetime.items():
+                    typer.echo(f"Lifetime: {value} {unit}")
+            if profile.get("authentication_multiple") is not None:
+                typer.echo(f"Authentication Multiple: {profile['authentication_multiple']}")
+            if profile.get("id"):
+                typer.echo(f"\nID: {profile['id']}")
+            return profile
+        else:
+            profiles = scm_client.list_ike_crypto_profiles(folder=folder, snippet=snippet, device=device)
+            if not profiles:
+                typer.echo("No IKE crypto profiles found")
+                return
+            typer.echo("\nIKE Crypto Profiles:")
+            typer.echo("-" * 80)
+            for profile in profiles:
+                location = profile.get("folder") or profile.get("snippet") or profile.get("device", "N/A")
+                typer.echo(f"Name: {profile.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                typer.echo(f"  Hash: {', '.join(profile.get('hash', []))}")
+                typer.echo(f"  DH Group: {', '.join(profile.get('dh_group', []))}")
+                typer.echo(f"  Encryption: {', '.join(profile.get('encryption', []))}")
+                lifetime = profile.get("lifetime")
+                if lifetime and isinstance(lifetime, dict):
+                    for unit, value in lifetime.items():
+                        typer.echo(f"  Lifetime: {value} {unit}")
+                if profile.get("authentication_multiple") is not None:
+                    typer.echo(f"  Authentication Multiple: {profile['authentication_multiple']}")
+                if profile.get("id"):
+                    typer.echo(f"  ID: {profile['id']}")
+                typer.echo("-" * 80)
+            return profiles
+    except Exception as e:
+        typer.echo(f"Error showing IKE crypto profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
 
 
 # ========================================================================================================================================================================================

--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -26,6 +26,7 @@ from ..utils.validators import (
     HIPProfile,
     HTTPServerProfile,
     LogForwardingProfile,
+    QuarantinedDevice,
     Region,
     Schedule,
     Service,
@@ -4999,6 +5000,77 @@ def load_region(
         raise typer.Exit(code=1) from e
 
 
+# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# QUARANTINED DEVICE COMMANDS
+# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+@delete_app.command("quarantined-device", help="Delete a quarantined device.")
+def delete_quarantined_device(
+    host_id: str = typer.Argument(..., help="Host ID of the quarantined device to delete"),
+) -> None:
+    """Delete a quarantined device by host ID."""
+    try:
+        show_context_info()
+
+        scm_client.delete_quarantined_device(host_id=host_id)
+        typer.echo(f"Deleted quarantined device: {host_id}")
+
+    except Exception as e:
+        typer.echo(f"Error deleting quarantined device: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("quarantined-device", help="Load quarantined devices from a YAML file.")
+def load_quarantined_device(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+) -> None:
+    """Load quarantined devices from a YAML file."""
+    try:
+        # Validate file exists
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+
+        # Load YAML data
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+
+        if not data or "quarantined_devices" not in data:
+            typer.echo("No quarantined_devices found in file", err=True)
+            raise typer.Exit(code=1)
+
+        devices = data["quarantined_devices"]
+        if not isinstance(devices, list):
+            devices = [devices]
+
+        # Process each device
+        created_count = 0
+        for device_data in devices:
+            try:
+                # Validate with Pydantic model
+                validated_device = QuarantinedDevice(**device_data)
+
+                # Convert to SDK format
+                sdk_data = validated_device.to_sdk_model()
+
+                # Create the quarantined device
+                scm_client.create_quarantined_device(sdk_data)
+
+                created_count += 1
+                typer.echo(f"Created quarantined device: {validated_device.host_id}")
+
+            except Exception as e:
+                typer.echo(f"Error processing quarantined device: {str(e)}", err=True)
+                continue
+
+        typer.echo(f"\nSummary: Processed {created_count} quarantined devices")
+
+    except Exception as e:
+        typer.echo(f"Error loading quarantined devices: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
 @set_app.command("region", help="Create or update a region.")
 def set_region(
     name: str = typer.Argument(..., help="Name of the region"),
@@ -5149,6 +5221,83 @@ def show_region(
 
     except Exception as e:
         typer.echo(f"Error showing region: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("quarantined-device", help="Create a quarantined device entry.")
+def set_quarantined_device(
+    host_id: str = typer.Argument(..., help="Host ID of the device to quarantine"),
+    serial_number: str = typer.Option(None, "--serial-number", help="Serial number of the device"),
+) -> None:
+    """Create a quarantined device entry."""
+    try:
+        show_context_info()
+
+        # Build device data
+        device_data: dict[str, Any] = {
+            "host_id": host_id,
+        }
+
+        if serial_number:
+            device_data["serial_number"] = serial_number
+
+        # Validate with Pydantic model
+        validated_device = QuarantinedDevice(**device_data)
+
+        # Convert to SDK format
+        sdk_data = validated_device.to_sdk_model()
+
+        # Create the quarantined device
+        scm_client.create_quarantined_device(sdk_data)
+
+        typer.echo(f"Created quarantined device: {host_id}")
+
+    except Exception as e:
+        typer.echo(f"Error creating quarantined device: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("quarantined-device", help="Show quarantined devices.")
+def show_quarantined_device(
+    host_id: str = typer.Option(None, "--host-id", help="Filter by host ID"),
+    serial_number: str = typer.Option(None, "--serial-number", help="Filter by serial number"),
+) -> None:
+    """Show quarantined devices.
+
+    Examples
+    --------
+        # List all quarantined devices
+        scm show object quarantined-device
+
+        # Filter by host ID
+        scm show object quarantined-device --host-id abc123
+
+    """
+    try:
+        show_context_info()
+
+        devices = scm_client.list_quarantined_devices(
+            host_id=host_id,
+            serial_number=serial_number,
+        )
+
+        if not devices:
+            typer.echo("No quarantined devices found")
+            return
+
+        # Display in table format
+        typer.echo("\nQuarantined Devices:")
+        typer.echo("-" * 80)
+
+        for device in devices:
+            typer.echo(f"\nHost ID: {device.get('host_id', 'N/A')}")
+            if device.get("serial_number"):
+                typer.echo(f"Serial Number: {device['serial_number']}")
+
+        typer.echo(f"\nTotal: {len(devices)} quarantined devices")
+
+    except Exception as e:
+        typer.echo(f"Error showing quarantined devices: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 

--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -26,6 +26,7 @@ from ..utils.validators import (
     HIPProfile,
     HTTPServerProfile,
     LogForwardingProfile,
+    Schedule,
     Service,
     ServiceGroup,
     SyslogServerProfile,
@@ -351,6 +352,20 @@ BACKUP_FILE_OPTION = typer.Option(
     "--file",
     help="Output file path (optional, defaults to {type}-{location}.yaml)",
 )
+
+# Schedule-specific options
+SCHEDULE_TIME_RANGE_OPTION = typer.Option(
+    None,
+    "--time-range",
+    help="Time ranges (e.g., 09:00-17:00 for daily, YYYY/MM/DD@HH:MM-YYYY/MM/DD@HH:MM for non-recurring)",
+)
+SCHEDULE_MONDAY_OPTION = typer.Option(None, "--monday", help="Time ranges for Monday (weekly only)")
+SCHEDULE_TUESDAY_OPTION = typer.Option(None, "--tuesday", help="Time ranges for Tuesday (weekly only)")
+SCHEDULE_WEDNESDAY_OPTION = typer.Option(None, "--wednesday", help="Time ranges for Wednesday (weekly only)")
+SCHEDULE_THURSDAY_OPTION = typer.Option(None, "--thursday", help="Time ranges for Thursday (weekly only)")
+SCHEDULE_FRIDAY_OPTION = typer.Option(None, "--friday", help="Time ranges for Friday (weekly only)")
+SCHEDULE_SATURDAY_OPTION = typer.Option(None, "--saturday", help="Time ranges for Saturday (weekly only)")
+SCHEDULE_SUNDAY_OPTION = typer.Option(None, "--sunday", help="Time ranges for Sunday (weekly only)")
 
 # Container override options for load commands
 LOAD_FOLDER_OPTION = typer.Option(
@@ -5938,6 +5953,353 @@ def show_syslog_server_profile(
 
     except Exception as e:
         typer.echo(f"Error showing syslog server profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# SCHEDULE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("schedule", help="Export schedules to a YAML file.")
+def backup_schedule(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export schedules from a specified location to a YAML file.
+
+    Examples
+    --------
+        # Backup from a folder
+        scm backup object schedule --folder Austin
+
+        # Backup with custom output file
+        scm backup object schedule --folder Austin --file schedules.yaml
+
+    """
+    try:
+        # Validate location parameters
+        location_type, location_value = validate_location_params(folder, snippet, device)
+
+        # List all schedules based on location type
+        typer.echo(f"Retrieving schedules from {location_type} '{location_value}'...")
+
+        # Build kwargs based on location type
+        kwargs = {location_type: location_value}
+        schedules = scm_client.list_schedules(**kwargs)
+
+        if not schedules:
+            typer.echo(f"No schedules found in {location_type} '{location_value}'", err=True)
+            return
+
+        # Prepare data for export
+        export_data = {"schedules": schedules}
+
+        # Generate filename if not provided
+        filename = Path(file or get_default_backup_filename("schedule", location_type, location_value))
+
+        # Write to file
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(schedules)} schedules to {filename}")
+
+    except Exception as e:
+        typer.echo(f"Error backing up schedules: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("schedule", help="Delete a schedule.")
+def delete_schedule(
+    name: str = typer.Argument(..., help="Name of the schedule to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a schedule."""
+    try:
+        # Determine container location
+        if not any([folder, snippet, device]):
+            folder = "Texas"  # Default to Texas folder
+
+        # Retrieve the schedule first to confirm it exists
+        schedule = scm_client.get_schedule(
+            name=name,
+            folder=folder,
+            snippet=snippet,
+            device=device,
+        )
+
+        if not schedule:
+            typer.echo(f"Schedule '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+
+        # Confirm deletion
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete schedule '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+
+        # Delete the schedule
+        scm_client.delete_schedule(
+            name=name,
+            folder=folder,
+            snippet=snippet,
+            device=device,
+        )
+
+        container = folder or snippet or device
+        typer.echo(f"Deleted schedule: {name} from {container}")
+
+    except Exception as e:
+        typer.echo(f"❌ Error deleting schedule: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("schedule", help="Load schedules from a YAML file.")
+def load_schedule(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+) -> None:
+    """Load schedules from a YAML file."""
+    try:
+        # Validate file exists
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+
+        # Load YAML data
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+
+        if not data or "schedules" not in data:
+            typer.echo("No schedules found in file", err=True)
+            raise typer.Exit(code=1)
+
+        schedules = data["schedules"]
+        if not isinstance(schedules, list):
+            schedules = [schedules]
+
+        # Process each schedule
+        created_count = 0
+        for schedule_data in schedules:
+            try:
+                # Create/update the schedule directly (YAML already has SDK format)
+                scm_client.create_schedule(schedule_data)
+
+                created_count += 1
+
+                container = schedule_data.get("folder") or schedule_data.get("snippet") or schedule_data.get("device")
+                typer.echo(f"Created schedule: {schedule_data['name']} in {container}")
+
+            except Exception as e:
+                typer.echo(f"❌ Error processing schedule: {str(e)}", err=True)
+                continue
+
+        typer.echo(f"\n✅ Summary: Processed {created_count} schedules")
+
+    except Exception as e:
+        typer.echo(f"❌ Error loading schedules: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("schedule", help="Create or update a schedule.")
+def set_schedule(
+    name: str = typer.Argument(..., help="Name of the schedule"),
+    schedule_type: str = typer.Option(..., "--schedule-type", help="Schedule type: recurring-daily, recurring-weekly, or non-recurring"),
+    time_ranges: list[str] | None = SCHEDULE_TIME_RANGE_OPTION,
+    days_monday: list[str] | None = SCHEDULE_MONDAY_OPTION,
+    days_tuesday: list[str] | None = SCHEDULE_TUESDAY_OPTION,
+    days_wednesday: list[str] | None = SCHEDULE_WEDNESDAY_OPTION,
+    days_thursday: list[str] | None = SCHEDULE_THURSDAY_OPTION,
+    days_friday: list[str] | None = SCHEDULE_FRIDAY_OPTION,
+    days_saturday: list[str] | None = SCHEDULE_SATURDAY_OPTION,
+    days_sunday: list[str] | None = SCHEDULE_SUNDAY_OPTION,
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Create or update a schedule."""
+    try:
+        # Determine container location
+        if not any([folder, snippet, device]):
+            folder = "Texas"  # Default to Texas folder
+
+        # Build days mapping for weekly schedules
+        days = None
+        if schedule_type == "recurring-weekly":
+            days = {}
+            if days_monday:
+                days["monday"] = days_monday
+            if days_tuesday:
+                days["tuesday"] = days_tuesday
+            if days_wednesday:
+                days["wednesday"] = days_wednesday
+            if days_thursday:
+                days["thursday"] = days_thursday
+            if days_friday:
+                days["friday"] = days_friday
+            if days_saturday:
+                days["saturday"] = days_saturday
+            if days_sunday:
+                days["sunday"] = days_sunday
+
+        # Build schedule data
+        schedule_data: dict[str, Any] = {
+            "name": name,
+            "schedule_type": schedule_type,
+        }
+
+        # Add container
+        if folder:
+            schedule_data["folder"] = folder
+        elif snippet:
+            schedule_data["snippet"] = snippet
+        elif device:
+            schedule_data["device"] = device
+
+        # Add schedule-type-specific fields
+        if time_ranges:
+            schedule_data["time_ranges"] = time_ranges
+        if days:
+            schedule_data["days"] = days
+
+        # Validate with Pydantic model
+        validated_schedule = Schedule(**schedule_data)
+
+        # Convert to SDK format
+        sdk_data = validated_schedule.to_sdk_model()
+
+        # Create/update the schedule
+        result = scm_client.create_schedule(sdk_data)
+
+        # Get the action performed
+        action = result.pop("__action__", "created")
+
+        container = folder or snippet or device
+        if action == "created":
+            typer.echo(f"✅ Created schedule: {name} in {container}")
+        elif action == "updated":
+            typer.echo(f"✅ Updated schedule: {name} in {container}")
+        elif action == "no_change":
+            typer.echo(f"ℹ️  No changes needed for schedule: {name} in {container}")
+
+    except Exception as e:
+        typer.echo(f"❌ Error creating/updating schedule: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("schedule", help="Show schedule details.")
+def show_schedule(
+    name: str = typer.Option(None, "--name", help="Name of specific schedule to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show schedule details.
+
+    Examples
+    --------
+        # List all schedules (default behavior)
+        scm show object schedule
+
+        # Show a specific schedule by name
+        scm show object schedule --name BusinessHours
+
+    """
+    try:
+        # Determine container location
+        if not any([folder, snippet, device]):
+            folder = "Texas"  # Default to Texas folder
+
+        if name:
+            # Show specific schedule
+            schedule = scm_client.get_schedule(
+                name=name,
+                folder=folder,
+                snippet=snippet,
+                device=device,
+            )
+
+            if not schedule:
+                typer.echo(f"Schedule '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+
+            # Display detailed information
+            typer.echo(f"\nSchedule: {schedule['name']}")
+            typer.echo("=" * 40)
+
+            location = schedule.get("folder") or schedule.get("snippet") or schedule.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+
+            # Display schedule type info
+            stype = schedule.get("schedule_type", {})
+            if "recurring" in stype:
+                recurring = stype["recurring"]
+                if "daily" in recurring:
+                    typer.echo("Type: Recurring Daily")
+                    typer.echo(f"Time Ranges: {', '.join(recurring['daily'])}")
+                elif "weekly" in recurring:
+                    typer.echo("Type: Recurring Weekly")
+                    weekly = recurring["weekly"]
+                    for day_name in ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]:
+                        if day_name in weekly:
+                            typer.echo(f"  {day_name.capitalize()}: {', '.join(weekly[day_name])}")
+            elif "non_recurring" in stype:
+                typer.echo("Type: Non-Recurring")
+                for dt_range in stype["non_recurring"]:
+                    typer.echo(f"  {dt_range}")
+
+            # Display ID if present
+            if schedule.get("id"):
+                typer.echo(f"\nID: {schedule['id']}")
+
+            return schedule
+
+        else:
+            # Default behavior: list all schedules
+            schedules = scm_client.list_schedules(
+                folder=folder,
+                snippet=snippet,
+                device=device,
+            )
+
+            if not schedules:
+                typer.echo("No schedules found")
+                return
+
+            # Display in table format
+            typer.echo("\nSchedules:")
+            typer.echo("-" * 80)
+
+            for schedule in schedules:
+                location = schedule.get("folder") or schedule.get("snippet") or schedule.get("device", "N/A")
+
+                typer.echo(f"\nName: {schedule['name']}")
+                typer.echo(f"Location: {location}")
+
+                # Summarize schedule type
+                stype = schedule.get("schedule_type", {})
+                if "recurring" in stype:
+                    recurring = stype["recurring"]
+                    if "daily" in recurring:
+                        typer.echo(f"Type: Recurring Daily ({', '.join(recurring['daily'])})")
+                    elif "weekly" in recurring:
+                        typer.echo("Type: Recurring Weekly")
+                elif "non_recurring" in stype:
+                    typer.echo(f"Type: Non-Recurring ({len(stype['non_recurring'])} ranges)")
+
+            typer.echo(f"\nTotal: {len(schedules)} schedules")
+
+    except Exception as e:
+        typer.echo(f"Error showing schedule: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 

--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -26,6 +26,7 @@ from ..utils.validators import (
     HIPProfile,
     HTTPServerProfile,
     LogForwardingProfile,
+    Region,
     Schedule,
     Service,
     ServiceGroup,
@@ -329,6 +330,12 @@ FILTER_EXPRESSION_OPTION = typer.Option(
     ...,
     "--filter",
     help="Tag-based filter expression (e.g., \"tag.Department='IT' and tag.Role='Admin'\")",
+)
+
+REGION_ADDRESSES_OPTION = typer.Option(
+    None,
+    "--address",
+    help="Address CIDRs for the region",
 )
 
 # Standardized backup command options
@@ -4815,6 +4822,333 @@ def show_log_forwarding_profile(
 
     except Exception as e:
         typer.echo(f"Error showing log forwarding profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+# REGION COMMANDS
+# -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+
+@backup_app.command("region", help="Export regions to a YAML file.")
+def backup_region(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export regions from a specified location to a YAML file.
+
+    Examples
+    --------
+        # Backup from a folder
+        scm backup object region --folder Austin
+
+        # Backup with custom output file
+        scm backup object region --folder Austin --file regions.yaml
+
+    """
+    try:
+        # Validate location parameters
+        location_type, location_value = validate_location_params(folder, snippet, device)
+
+        # List all regions based on location type
+        typer.echo(f"Retrieving regions from {location_type} '{location_value}'...")
+
+        # Build kwargs based on location type
+        kwargs = {location_type: location_value}
+        regions = scm_client.list_regions(**kwargs)
+
+        if not regions:
+            typer.echo(f"No regions found in {location_type} '{location_value}'", err=True)
+            return
+
+        # Prepare data for export
+        export_data = {"regions": regions}
+
+        # Generate filename if not provided
+        filename = Path(file or get_default_backup_filename("region", location_type, location_value))
+
+        # Write to file
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(regions)} regions to {filename}")
+
+    except Exception as e:
+        typer.echo(f"Error backing up regions: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("region", help="Delete a region.")
+def delete_region(
+    name: str = typer.Argument(..., help="Name of the region to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a region."""
+    try:
+        # Determine container location
+        if not any([folder, snippet, device]):
+            folder = "Texas"  # Default to Texas folder
+
+        # Retrieve the region first to confirm it exists
+        region = scm_client.get_region(
+            name=name,
+            folder=folder,
+            snippet=snippet,
+            device=device,
+        )
+
+        if not region:
+            typer.echo(f"Region '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+
+        # Confirm deletion
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete region '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+
+        # Delete the region
+        scm_client.delete_region(
+            name=name,
+            folder=folder,
+            snippet=snippet,
+            device=device,
+        )
+
+        container = folder or snippet or device
+        typer.echo(f"Deleted region: {name} from {container}")
+
+    except Exception as e:
+        typer.echo(f"Error deleting region: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("region", help="Load regions from a YAML file.")
+def load_region(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+) -> None:
+    """Load regions from a YAML file."""
+    try:
+        # Validate file exists
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+
+        # Load YAML data
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+
+        if not data or "regions" not in data:
+            typer.echo("No regions found in file", err=True)
+            raise typer.Exit(code=1)
+
+        regions = data["regions"]
+        if not isinstance(regions, list):
+            regions = [regions]
+
+        # Process each region
+        created_count = 0
+        for region_data in regions:
+            try:
+                # Validate with Pydantic model
+                validated_region = Region(**region_data)
+
+                # Override container if specified
+                if folder:
+                    validated_region.folder = folder
+                    validated_region.snippet = None
+                    validated_region.device = None
+                elif snippet:
+                    validated_region.snippet = snippet
+                    validated_region.folder = None
+                    validated_region.device = None
+                elif device:
+                    validated_region.device = device
+                    validated_region.folder = None
+                    validated_region.snippet = None
+
+                # Convert to SDK format
+                sdk_data = validated_region.to_sdk_model()
+
+                # Create/update the region
+                scm_client.create_region(sdk_data)
+
+                created_count += 1
+
+                container = validated_region.folder or validated_region.snippet or validated_region.device
+                typer.echo(f"Created region: {validated_region.name} in {container}")
+
+            except Exception as e:
+                typer.echo(f"Error processing region: {str(e)}", err=True)
+                continue
+
+        typer.echo(f"\nSummary: Processed {created_count} regions")
+
+    except Exception as e:
+        typer.echo(f"Error loading regions: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("region", help="Create or update a region.")
+def set_region(
+    name: str = typer.Argument(..., help="Name of the region"),
+    latitude: float = typer.Option(None, "--latitude", help="Latitude of the region (-90 to 90)"),
+    longitude: float = typer.Option(None, "--longitude", help="Longitude of the region (-180 to 180)"),
+    addresses: list[str] | None = REGION_ADDRESSES_OPTION,
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Create or update a region."""
+    try:
+        # Determine container location
+        if not any([folder, snippet, device]):
+            folder = "Texas"  # Default to Texas folder
+
+        # Build region data
+        region_data: dict[str, Any] = {
+            "name": name,
+        }
+
+        # Add container
+        if folder:
+            region_data["folder"] = folder
+        elif snippet:
+            region_data["snippet"] = snippet
+        elif device:
+            region_data["device"] = device
+
+        # Add optional fields
+        if latitude is not None:
+            region_data["latitude"] = latitude
+        if longitude is not None:
+            region_data["longitude"] = longitude
+        if addresses:
+            region_data["addresses"] = addresses
+
+        # Validate with Pydantic model
+        validated_region = Region(**region_data)
+
+        # Convert to SDK format
+        sdk_data = validated_region.to_sdk_model()
+
+        # Create/update the region
+        result = scm_client.create_region(sdk_data)
+
+        # Get the action performed
+        action = result.pop("__action__", "created")
+
+        container = folder or snippet or device
+        if action == "created":
+            typer.echo(f"Created region: {name} in {container}")
+        elif action == "updated":
+            typer.echo(f"Updated region: {name} in {container}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for region: {name} in {container}")
+
+    except Exception as e:
+        typer.echo(f"Error creating/updating region: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("region", help="Show region details.")
+def show_region(
+    name: str = typer.Option(None, "--name", help="Name of specific region to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show region details.
+
+    Examples
+    --------
+        # List all regions (default behavior)
+        scm show object region
+
+        # Show a specific region by name
+        scm show object region --name US-South
+
+    """
+    try:
+        # Determine container location
+        if not any([folder, snippet, device]):
+            folder = "Texas"  # Default to Texas folder
+
+        if name:
+            # Show specific region
+            region = scm_client.get_region(
+                name=name,
+                folder=folder,
+                snippet=snippet,
+                device=device,
+            )
+
+            if not region:
+                typer.echo(f"Region '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+
+            # Display detailed information
+            typer.echo(f"\nRegion: {region['name']}")
+            typer.echo("=" * 40)
+
+            location = region.get("folder") or region.get("snippet") or region.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+
+            if region.get("geo_location"):
+                geo = region["geo_location"]
+                typer.echo(f"Latitude: {geo.get('latitude', 'N/A')}")
+                typer.echo(f"Longitude: {geo.get('longitude', 'N/A')}")
+
+            if region.get("address"):
+                typer.echo(f"Addresses: {', '.join(region['address'])}")
+
+            # Display ID if present
+            if region.get("id"):
+                typer.echo(f"\nID: {region['id']}")
+
+            return region
+
+        else:
+            # Default behavior: list all regions
+            regions = scm_client.list_regions(
+                folder=folder,
+                snippet=snippet,
+                device=device,
+            )
+
+            if not regions:
+                typer.echo("No regions found")
+                return
+
+            # Display in table format
+            typer.echo("\nRegions:")
+            typer.echo("-" * 80)
+
+            for region in regions:
+                location = region.get("folder") or region.get("snippet") or region.get("device", "N/A")
+
+                typer.echo(f"\nName: {region['name']}")
+                typer.echo(f"Location: {location}")
+                if region.get("geo_location"):
+                    geo = region["geo_location"]
+                    typer.echo(f"Geo: ({geo.get('latitude', 'N/A')}, {geo.get('longitude', 'N/A')})")
+                if region.get("address"):
+                    typer.echo(f"Addresses: {', '.join(region['address'])}")
+
+            typer.echo(f"\nTotal: {len(regions)} regions")
+
+    except Exception as e:
+        typer.echo(f"Error showing region: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -3759,6 +3759,259 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("listing", container, "log-forwarding profiles", e)
 
+    # Regions ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+    def create_region(
+        self,
+        region_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Create or update a region using smart upsert logic.
+
+        Args:
+            region_data: The region data
+
+        Returns:
+            Created/updated region data
+
+        """
+        # Determine container (folder, snippet, or device)
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+
+        for field in container_fields:
+            if field in region_data and region_data[field] is not None:
+                container_field = field
+                container_value = region_data[field]
+                break
+
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+
+        # Return mock data if no client
+        if not self.client:
+            return region_data
+
+        # Check if the region already exists
+        existing_region = None
+        try:
+            existing_region = self.client.region.fetch(name=region_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing region '{region_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"Region '{region_data['name']}' not found in {container_field} '{container_value}', will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching region '{region_data['name']}': {str(e)}")
+
+        if existing_region:
+            # Check what needs updating
+            needs_update = False
+            update_fields = []
+
+            # Compare geo_location
+            if "geo_location" in region_data and region_data["geo_location"]:
+                new_geo = region_data["geo_location"]
+                if hasattr(existing_region, "geo_location") and existing_region.geo_location:
+                    if existing_region.geo_location.latitude != new_geo.get("latitude") or existing_region.geo_location.longitude != new_geo.get("longitude"):
+                        existing_region.geo_location.latitude = new_geo["latitude"]
+                        existing_region.geo_location.longitude = new_geo["longitude"]
+                        update_fields.append("geo_location")
+                        needs_update = True
+                else:
+                    from scm.models.objects.regions import GeoLocation
+
+                    existing_region.geo_location = GeoLocation(**new_geo)
+                    update_fields.append("geo_location")
+                    needs_update = True
+
+            # Compare addresses
+            if "address" in region_data and region_data["address"] is not None:
+                existing_addresses = set(existing_region.address) if hasattr(existing_region, "address") and existing_region.address else set()
+                new_addresses = set(region_data["address"])
+                if existing_addresses != new_addresses:
+                    existing_region.address = region_data["address"]
+                    update_fields.append("address")
+                    needs_update = True
+
+            if needs_update:
+                self.logger.info(f"Updating region fields: {', '.join(update_fields)}")
+                try:
+                    updated = existing_region.update()
+                    self.logger.info(f"Successfully updated region '{region_data['name']}' in {container_field} '{container_value}'")
+                    result = json.loads(updated.model_dump_json(exclude_unset=True))
+                    result["__action__"] = "updated"
+                    return result
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"region '{region_data['name']}'", update_error)
+            else:
+                self.logger.info(f"No changes detected for region '{region_data['name']}', skipping update")
+                result = json.loads(existing_region.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            # Create new region
+            try:
+                created = self.client.region.create(region_data)
+                self.logger.info(f"Created new region '{region_data['name']}' in {container_field} '{container_value}'")
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception(
+                    "creating",
+                    str(container_value),
+                    f"region '{region_data['name']}'",
+                    create_error,
+                )
+
+    def delete_region(
+        self,
+        name: str,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+    ) -> None:
+        """Delete a region.
+
+        Args:
+            name: Name of the region to delete
+            folder: Folder location
+            snippet: Snippet location
+            device: Device location
+
+        """
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete region: {name}")
+            return
+
+        # Determine container
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+
+        try:
+            # First, fetch the region to get its ID
+            region = self.client.region.fetch(name=name, **container_kwargs)
+            self.client.region.delete(str(region.id))
+            self.logger.info(f"Deleted region: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"region '{name}'", e)
+
+    def get_region(
+        self,
+        name: str,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Get a specific region.
+
+        Args:
+            name: Name of the region to retrieve
+            folder: Folder location
+            snippet: Snippet location
+            device: Device location
+
+        Returns:
+            Region data or None if not found
+
+        """
+        if not self.client:
+            return {
+                "id": "region-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "geo_location": {"latitude": 30.2672, "longitude": -97.7431},
+                "address": ["10.0.0.0/8", "192.168.1.0/24"],
+            }
+
+        # Determine container
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+
+        try:
+            result = self.client.region.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"Region '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"region '{name}'", e)
+
+    def list_regions(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List regions in a container.
+
+        Args:
+            folder: Folder location
+            snippet: Snippet location
+            device: Device location
+            exact_match: If True, only return exact matches
+
+        Returns:
+            List of regions
+
+        """
+        if not self.client:
+            return [
+                {
+                    "id": "region-mock1",
+                    "folder": folder or "ngfw-shared",
+                    "name": "US-South",
+                    "geo_location": {"latitude": 30.2672, "longitude": -97.7431},
+                    "address": ["10.0.0.0/8"],
+                },
+                {
+                    "id": "region-mock2",
+                    "folder": folder or "ngfw-shared",
+                    "name": "US-East",
+                    "geo_location": {"latitude": 40.7128, "longitude": -74.0060},
+                    "address": ["172.16.0.0/12"],
+                },
+                {
+                    "id": "region-mock3",
+                    "folder": folder or "ngfw-shared",
+                    "name": "EU-West",
+                    "geo_location": {"latitude": 51.5074, "longitude": -0.1278},
+                    "address": ["192.168.0.0/16"],
+                },
+            ]
+
+        # Determine container
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+
+        try:
+            # List regions using the SDK
+            results = self.client.region.list(exact_match=exact_match, **container_kwargs)
+
+            # Convert SDK response to the list of dicts for compatibility
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "regions", e)
+
     # Services -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     def create_service(

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -4461,6 +4461,255 @@ class SCMClient:
                 e,
             )
 
+    # Schedules ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+    def create_schedule(
+        self,
+        schedule_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Create or update a schedule using smart upsert logic.
+
+        Args:
+            schedule_data: The schedule data
+
+        Returns:
+            Created/updated schedule data
+
+        """
+        # Determine container (folder, snippet, or device)
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+
+        for field in container_fields:
+            if field in schedule_data and schedule_data[field] is not None:
+                container_field = field
+                container_value = schedule_data[field]
+                break
+
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+
+        # Return mock data if no client
+        if not self.client:
+            return schedule_data
+
+        # Check if the schedule already exists
+        existing_schedule = None
+        try:
+            existing_schedule = self.client.schedule.fetch(name=schedule_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing schedule '{schedule_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"Schedule '{schedule_data['name']}' not found in {container_field} '{container_value}', will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching schedule '{schedule_data['name']}': {str(e)}")
+
+        if existing_schedule:
+            # Check what needs updating
+            needs_update = False
+            update_fields = []
+
+            # Compare schedule_type
+            if "schedule_type" in schedule_data:
+                existing_data = json.loads(existing_schedule.model_dump_json(exclude_unset=True))
+                if existing_data.get("schedule_type") != schedule_data["schedule_type"]:
+                    existing_schedule.schedule_type = schedule_data["schedule_type"]
+                    update_fields.append("schedule_type")
+                    needs_update = True
+
+            if needs_update:
+                self.logger.info(f"Updating schedule fields: {', '.join(update_fields)}")
+                try:
+                    updated = existing_schedule.update()
+                    self.logger.info(f"Successfully updated schedule '{schedule_data['name']}' in {container_field} '{container_value}'")
+                    result = json.loads(updated.model_dump_json(exclude_unset=True))
+                    result["__action__"] = "updated"
+                    return result
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"schedule '{schedule_data['name']}'", update_error)
+            else:
+                self.logger.info(f"No changes detected for schedule '{schedule_data['name']}', skipping update")
+                result = json.loads(existing_schedule.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            # Create new schedule
+            try:
+                created = self.client.schedule.create(schedule_data)
+                self.logger.info(f"Created new schedule '{schedule_data['name']}' in {container_field} '{container_value}'")
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception(
+                    "creating",
+                    str(container_value),
+                    f"schedule '{schedule_data['name']}'",
+                    create_error,
+                )
+
+    def delete_schedule(
+        self,
+        name: str,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+    ) -> None:
+        """Delete a schedule.
+
+        Args:
+            name: Name of the schedule to delete
+            folder: Folder location
+            snippet: Snippet location
+            device: Device location
+
+        """
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete schedule: {name}")
+            return
+
+        # Determine container
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+
+        try:
+            # First, fetch the schedule to get its ID
+            schedule = self.client.schedule.fetch(name=name, **container_kwargs)
+            self.client.schedule.delete(str(schedule.id))
+            self.logger.info(f"Deleted schedule: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"schedule '{name}'", e)
+
+    def get_schedule(
+        self,
+        name: str,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Get a specific schedule.
+
+        Args:
+            name: Name of the schedule to retrieve
+            folder: Folder location
+            snippet: Snippet location
+            device: Device location
+
+        Returns:
+            Schedule data or None if not found
+
+        """
+        if not self.client:
+            return {
+                "id": "schedule-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "schedule_type": {
+                    "recurring": {
+                        "daily": ["09:00-17:00"],
+                    },
+                },
+            }
+
+        # Determine container
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+
+        try:
+            result = self.client.schedule.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"Schedule '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"schedule '{name}'", e)
+
+    def list_schedules(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List schedules in a container.
+
+        Args:
+            folder: Folder location
+            snippet: Snippet location
+            device: Device location
+            exact_match: If True, only return exact matches
+
+        Returns:
+            List of schedules
+
+        """
+        if not self.client:
+            return [
+                {
+                    "id": "schedule-mock1",
+                    "folder": folder or "ngfw-shared",
+                    "name": "BusinessHours",
+                    "schedule_type": {
+                        "recurring": {
+                            "daily": ["09:00-17:00"],
+                        },
+                    },
+                },
+                {
+                    "id": "schedule-mock2",
+                    "folder": folder or "ngfw-shared",
+                    "name": "Weekends",
+                    "schedule_type": {
+                        "recurring": {
+                            "weekly": {
+                                "saturday": ["00:00-23:59"],
+                                "sunday": ["00:00-23:59"],
+                            },
+                        },
+                    },
+                },
+                {
+                    "id": "schedule-mock3",
+                    "folder": folder or "ngfw-shared",
+                    "name": "MaintenanceWindow",
+                    "schedule_type": {
+                        "non_recurring": ["2026/03/15@02:00-2026/03/15@06:00"],
+                    },
+                },
+            ]
+
+        # Determine container
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+
+        try:
+            # List schedules using the SDK
+            results = self.client.schedule.list(exact_match=exact_match, **container_kwargs)
+
+            # Convert SDK response to the list of dicts for compatibility
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "schedules", e)
+
     # Tags ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     def create_tag(
@@ -5863,7 +6112,7 @@ class SCMClient:
 
         """
         logger.info(f"Listing alerts (will return up to {max_results} after sorting)")
-        
+
         # Always fetch more alerts than requested to ensure we get the most recent ones
         # The API might return alerts in arbitrary order, so we need to fetch enough
         # to ensure we capture recent alerts before sorting
@@ -5963,7 +6212,7 @@ class SCMClient:
                         "impacted_resources": alert_data.get("impacted_resources") or alert_data.get("primary_impacted_objects", []),
                         "metadata": alert_data.get("metadata") or alert_data.get("resource_context"),
                     }
-                    
+
                     # Remove empty fields for cleaner output
                     alert = self._remove_empty_fields(alert)
 
@@ -5986,7 +6235,7 @@ class SCMClient:
 
                 # Sort alerts by timestamp (newest first)
                 alerts.sort(key=lambda x: x.get("timestamp", ""), reverse=True)
-                
+
                 # Limit to the requested number of results
                 return alerts[:max_results]
 

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -4011,6 +4011,92 @@ class SCMClient:
             return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
         except Exception as e:
             self._handle_api_exception("listing", folder or snippet or device or "", "regions", e)
+    # Quarantined Devices ------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+    def create_quarantined_device(
+        self,
+        device_data: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Create a quarantined device entry.
+
+        Args:
+            device_data: The quarantined device data (host_id, optional serial_number)
+
+        Returns:
+            Created quarantined device data
+
+        """
+        self.logger.info(f"Creating quarantined device: {device_data.get('host_id', 'unknown')}")
+
+        if not self.client:
+            return device_data
+
+        try:
+            created = self.client.quarantined_devices.create(device_data)
+            self.logger.info(f"Created quarantined device: {device_data.get('host_id')}")
+            return json.loads(created.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("creating", "quarantined-devices", f"device '{device_data.get('host_id')}'", e)
+
+    def delete_quarantined_device(
+        self,
+        host_id: str,
+    ) -> None:
+        """Delete a quarantined device by host ID.
+
+        Args:
+            host_id: The host ID of the quarantined device to delete
+
+        """
+        self.logger.info(f"Deleting quarantined device: {host_id}")
+
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete quarantined device: {host_id}")
+            return
+
+        try:
+            self.client.quarantined_devices.delete(host_id=host_id)
+            self.logger.info(f"Deleted quarantined device: {host_id}")
+        except Exception as e:
+            self._handle_api_exception("deleting", "quarantined-devices", f"device '{host_id}'", e)
+
+    def list_quarantined_devices(
+        self,
+        host_id: str | None = None,
+        serial_number: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List quarantined devices with optional filtering.
+
+        Args:
+            host_id: Filter by device host ID
+            serial_number: Filter by device serial number
+
+        Returns:
+            List of quarantined device objects
+
+        """
+        self.logger.info(f"Listing quarantined devices (host_id={host_id}, serial_number={serial_number})")
+
+        if not self.client:
+            return [
+                {
+                    "host_id": "mock-host-001",
+                    "serial_number": "SN-001",
+                },
+                {
+                    "host_id": "mock-host-002",
+                    "serial_number": "SN-002",
+                },
+            ]
+
+        try:
+            results = self.client.quarantined_devices.list(
+                host_id=host_id,
+                serial_number=serial_number,
+            )
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", "quarantined-devices", "quarantined devices", e)
 
     # Services -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -5294,6 +5294,182 @@ class SCMClient:
 
     # ======================================================================================================================================================================================
 
+    # --------------------------------------------------------------------------------- IKE Crypto Profiles ---------------------------------------------------------------------------------
+
+    def create_ike_crypto_profile(self, profile_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update an IKE crypto profile using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in profile_data and profile_data[field] is not None:
+                container_field = field
+                container_value = profile_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            return profile_data
+        existing_profile = None
+        try:
+            existing_profile = self.client.ike_crypto_profile.fetch(name=profile_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing IKE crypto profile '{profile_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"IKE crypto profile '{profile_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching IKE crypto profile '{profile_data['name']}': {str(e)}")
+        if existing_profile:
+            needs_update = False
+            update_fields = []
+            if "hash" in profile_data:
+                existing_hash = [h.value if hasattr(h, "value") else str(h) for h in existing_profile.hash]
+                if set(profile_data["hash"]) != set(existing_hash):
+                    needs_update = True
+                    update_fields.append("hash")
+            if "encryption" in profile_data:
+                existing_enc = [e.value if hasattr(e, "value") else str(e) for e in existing_profile.encryption]
+                if set(profile_data["encryption"]) != set(existing_enc):
+                    needs_update = True
+                    update_fields.append("encryption")
+            if "dh_group" in profile_data:
+                existing_dh = [g.value if hasattr(g, "value") else str(g) for g in existing_profile.dh_group]
+                if set(profile_data["dh_group"]) != set(existing_dh):
+                    needs_update = True
+                    update_fields.append("dh_group")
+            if "lifetime" in profile_data:
+                existing_lifetime = existing_profile.lifetime.model_dump() if existing_profile.lifetime else None
+                if profile_data["lifetime"] != existing_lifetime:
+                    needs_update = True
+                    update_fields.append("lifetime")
+            if "authentication_multiple" in profile_data and profile_data["authentication_multiple"] != existing_profile.authentication_multiple:
+                needs_update = True
+                update_fields.append("authentication_multiple")
+            if needs_update:
+                self.logger.info(f"Updating IKE crypto profile fields: {', '.join(update_fields)}")
+                try:
+                    update_data = profile_data.copy()
+                    update_data["id"] = str(existing_profile.id)
+                    result = self.client.ike_crypto_profile.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"IKE crypto profile '{profile_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_profile.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.ike_crypto_profile.create(profile_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"IKE crypto profile '{profile_data['name']}'", create_error)
+
+    def delete_ike_crypto_profile(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete an IKE crypto profile."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete IKE crypto profile: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            profile = self.client.ike_crypto_profile.fetch(name=name, **container_kwargs)
+            self.client.ike_crypto_profile.delete(str(profile.id))
+            self.logger.info(f"Deleted IKE crypto profile: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"IKE crypto profile '{name}'", e)
+
+    def get_ike_crypto_profile(
+        self,
+        name: str,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Get a specific IKE crypto profile."""
+        if not self.client:
+            return {
+                "id": "ike-crypto-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "hash": ["sha256"],
+                "dh_group": ["group14"],
+                "encryption": ["aes-256-cbc"],
+                "lifetime": {"hours": 8},
+                "authentication_multiple": 0,
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.ike_crypto_profile.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"IKE crypto profile '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"IKE crypto profile '{name}'", e)
+
+    def list_ike_crypto_profiles(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List IKE crypto profiles in a container."""
+        if not self.client:
+            return [
+                {
+                    "id": "ike-crypto-mock1",
+                    "folder": folder or "ngfw-shared",
+                    "name": "default-ike-profile",
+                    "hash": ["sha256", "sha384"],
+                    "dh_group": ["group14", "group19"],
+                    "encryption": ["aes-256-cbc"],
+                    "lifetime": {"hours": 8},
+                    "authentication_multiple": 0,
+                },
+                {
+                    "id": "ike-crypto-mock2",
+                    "folder": folder or "ngfw-shared",
+                    "name": "strong-ike-profile",
+                    "hash": ["sha512"],
+                    "dh_group": ["group20"],
+                    "encryption": ["aes-256-gcm"],
+                    "lifetime": {"hours": 4},
+                    "authentication_multiple": 3,
+                },
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.ike_crypto_profile.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "IKE crypto profiles", e)
+
     # ------------------------------------------------------------------------------------ Security Zones ----------------------------------------------------------------------------------
 
     def create_zone(

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -1702,6 +1702,104 @@ class Tag(BaseModel):
 # ========================================================================================================================================================================================
 
 
+class IKECryptoProfile(BaseModel):
+    """Model for IKE crypto profile configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the IKE crypto profile")
+    snippet: str | None = Field(None, description="Snippet path for the IKE crypto profile")
+    device: str | None = Field(None, description="Device path for the IKE crypto profile")
+    name: str = Field(
+        ...,
+        description="Name of the IKE crypto profile",
+        pattern=r"^[0-9a-zA-Z._-]+$",
+        max_length=31,
+    )
+    hash: list[str] = Field(..., description="Hashing algorithms (md5, sha1, sha256, sha384, sha512)")
+    dh_group: list[str] = Field(..., description="Phase-1 DH group (group1, group2, group5, group14, group19, group20)")
+    encryption: list[str] = Field(..., description="Encryption algorithms (des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm)")
+    lifetime_seconds: int | None = Field(None, description="Lifetime in seconds (180-65535)", ge=180, le=65535)
+    lifetime_minutes: int | None = Field(None, description="Lifetime in minutes (3-65535)", ge=3, le=65535)
+    lifetime_hours: int | None = Field(None, description="Lifetime in hours (1-65535)", ge=1, le=65535)
+    lifetime_days: int | None = Field(None, description="Lifetime in days (1-365)", ge=1, le=365)
+    authentication_multiple: int | None = Field(None, description="IKEv2 SA reauthentication interval (0-50)", ge=0, le=50)
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "IKECryptoProfile":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @model_validator(mode="after")
+    def validate_lifetime(self) -> "IKECryptoProfile":
+        """Validate that at most one lifetime field is specified."""
+        lifetime_fields = [self.lifetime_seconds, self.lifetime_minutes, self.lifetime_hours, self.lifetime_days]
+        if sum(1 for f in lifetime_fields if f is not None) > 1:
+            raise ValueError("At most one of 'lifetime_seconds', 'lifetime_minutes', 'lifetime_hours', or 'lifetime_days' may be set")
+        return self
+
+    @field_validator("hash")
+    def validate_hash(cls, v: list[str]) -> list[str]:  # noqa: N805
+        """Validate hash algorithms."""
+        valid = {"md5", "sha1", "sha256", "sha384", "sha512"}
+        for h in v:
+            if h not in valid:
+                raise ValueError(f"Invalid hash algorithm '{h}'. Must be one of: {', '.join(sorted(valid))}")
+        return v
+
+    @field_validator("dh_group")
+    def validate_dh_group(cls, v: list[str]) -> list[str]:  # noqa: N805
+        """Validate DH group values."""
+        valid = {"group1", "group2", "group5", "group14", "group19", "group20"}
+        for g in v:
+            if g not in valid:
+                raise ValueError(f"Invalid DH group '{g}'. Must be one of: {', '.join(sorted(valid))}")
+        return v
+
+    @field_validator("encryption")
+    def validate_encryption(cls, v: list[str]) -> list[str]:  # noqa: N805
+        """Validate encryption algorithms."""
+        valid = {"des", "3des", "aes-128-cbc", "aes-192-cbc", "aes-256-cbc", "aes-128-gcm", "aes-256-gcm"}
+        for e in v:
+            if e not in valid:
+                raise ValueError(f"Invalid encryption algorithm '{e}'. Must be one of: {', '.join(sorted(valid))}")
+        return v
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "name": self.name,
+            "hash": self.hash,
+            "dh_group": self.dh_group,
+            "encryption": self.encryption,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Add lifetime if specified
+        if self.lifetime_seconds is not None:
+            model_data["lifetime"] = {"seconds": self.lifetime_seconds}
+        elif self.lifetime_minutes is not None:
+            model_data["lifetime"] = {"minutes": self.lifetime_minutes}
+        elif self.lifetime_hours is not None:
+            model_data["lifetime"] = {"hours": self.lifetime_hours}
+        elif self.lifetime_days is not None:
+            model_data["lifetime"] = {"days": self.lifetime_days}
+
+        # Add authentication_multiple if specified
+        if self.authentication_multiple is not None:
+            model_data["authentication_multiple"] = self.authentication_multiple
+
+        return model_data
+
+
 class Zone(BaseModel):
     """Model for security zone configurations with folder path."""
 

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -1151,6 +1151,24 @@ class Region(BaseModel):
         return model_data
 
 
+class QuarantinedDevice(BaseModel):
+    """Model for quarantined device configurations."""
+
+    host_id: str = Field(..., description="Device host ID")
+    serial_number: str | None = Field(None, description="Device serial number")
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "host_id": self.host_id,
+        }
+
+        if self.serial_number:
+            model_data["serial_number"] = self.serial_number
+
+        return model_data
+
+
 class Service(BaseModel):
     """Model for service configurations with folder path."""
 

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -1079,6 +1079,78 @@ class LogForwardingProfile(BaseModel):
         return model_data
 
 
+class Region(BaseModel):
+    """Model for region configurations with folder path."""
+
+    folder: str = Field(..., description="Folder path for the region")
+    name: str = Field(
+        ...,
+        description="Name of the region",
+        max_length=64,
+    )
+    latitude: float | None = Field(None, description="Latitude of the region (-90 to 90)", ge=-90, le=90)
+    longitude: float | None = Field(None, description="Longitude of the region (-180 to 180)", ge=-180, le=180)
+    addresses: list[str] | None = Field(None, description="List of address CIDRs")
+    snippet: str | None = Field(None, description="Snippet location")
+    device: str | None = Field(None, description="Device location")
+
+    @field_validator("folder", "snippet", "device")
+    def validate_container(
+        cls,
+        v: str | None,
+        info: ValidationInfo,
+    ) -> str | None:
+        """Validate that exactly one container field is set."""
+        if v is not None:
+            values = info.data
+            containers = ["folder", "snippet", "device"]
+            field_name = info.field_name
+            other_containers = [c for c in containers if c != field_name]
+
+            for container in other_containers:
+                if values.get(container) is not None:
+                    raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+
+        return v
+
+    @model_validator(mode="after")
+    def check_container_set(self) -> "Region":
+        """Ensure exactly one container field is set."""
+        containers_set = sum(1 for field in ["folder", "snippet", "device"] if getattr(self, field) is not None)
+
+        if containers_set != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "name": self.name,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Add geo_location if latitude/longitude provided
+        if self.latitude is not None and self.longitude is not None:
+            model_data["geo_location"] = {
+                "latitude": self.latitude,
+                "longitude": self.longitude,
+            }
+
+        # Add addresses
+        if self.addresses:
+            model_data["address"] = self.addresses
+
+        return model_data
+
+
 class Service(BaseModel):
     """Model for service configurations with folder path."""
 

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -1366,6 +1366,123 @@ class SyslogServerProfile(BaseModel):
         return model_data
 
 
+class Schedule(BaseModel):
+    """Model for schedule configurations with folder path.
+
+    Supports three schedule types:
+    - recurring-daily: Same time ranges every day
+    - recurring-weekly: Different time ranges per day of week
+    - non-recurring: One-time date/time ranges
+    """
+
+    folder: str = Field(..., description="Folder path for the schedule")
+    name: str = Field(
+        ...,
+        description="Name of the schedule",
+        pattern=r"^[ a-zA-Z\d._-]+$",
+        max_length=31,
+    )
+    schedule_type: str = Field(
+        ...,
+        description="Schedule type: recurring-daily, recurring-weekly, or non-recurring",
+    )
+    time_ranges: list[str] | None = Field(
+        None,
+        description="List of time ranges (HH:MM-HH:MM for recurring, YYYY/MM/DD@HH:MM-YYYY/MM/DD@HH:MM for non-recurring)",
+    )
+    days: dict[str, list[str]] | None = Field(
+        None,
+        description="Day-to-time-range mapping for weekly schedules (e.g., {'monday': ['09:00-17:00']})",
+    )
+    snippet: str | None = Field(None, description="Snippet location")
+    device: str | None = Field(None, description="Device location")
+
+    @field_validator("folder", "snippet", "device")
+    def validate_container(
+        cls,
+        v: str | None,
+        info: ValidationInfo,
+    ) -> str | None:
+        """Validate that exactly one container field is set."""
+        if v is not None:
+            # Check other container fields
+            values = info.data
+            containers = ["folder", "snippet", "device"]
+            field_name = info.field_name
+            other_containers = [c for c in containers if c != field_name]
+
+            for container in other_containers:
+                if values.get(container) is not None:
+                    raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+
+        return v
+
+    @model_validator(mode="after")
+    def check_container_set(self) -> "Schedule":
+        """Ensure exactly one container field is set."""
+        containers_set = sum(1 for field in ["folder", "snippet", "device"] if getattr(self, field) is not None)
+
+        if containers_set != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+
+        return self
+
+    @field_validator("schedule_type")
+    def validate_schedule_type(cls, v: str) -> str:
+        """Validate schedule type is from allowed set."""
+        valid_types = ["recurring-daily", "recurring-weekly", "non-recurring"]
+        if v not in valid_types:
+            raise ValueError(f"Schedule type must be one of: {', '.join(valid_types)}")
+        return v
+
+    @model_validator(mode="after")
+    def validate_schedule_data(self) -> "Schedule":
+        """Validate that required data is provided for the schedule type."""
+        if self.schedule_type == "recurring-daily":
+            if not self.time_ranges:
+                raise ValueError("time_ranges is required for recurring-daily schedules")
+        elif self.schedule_type == "recurring-weekly":
+            if not self.days:
+                raise ValueError("days is required for recurring-weekly schedules")
+        elif self.schedule_type == "non-recurring" and not self.time_ranges:
+            raise ValueError("time_ranges is required for non-recurring schedules")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "name": self.name,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Build schedule_type structure
+        if self.schedule_type == "recurring-daily":
+            model_data["schedule_type"] = {
+                "recurring": {
+                    "daily": self.time_ranges,
+                },
+            }
+        elif self.schedule_type == "recurring-weekly":
+            model_data["schedule_type"] = {
+                "recurring": {
+                    "weekly": self.days,
+                },
+            }
+        elif self.schedule_type == "non-recurring":
+            model_data["schedule_type"] = {
+                "non_recurring": self.time_ranges,
+            }
+
+        return model_data
+
+
 class Tag(BaseModel):
     """Model for tag configurations with folder path."""
 

--- a/tests/test_network_commands.py
+++ b/tests/test_network_commands.py
@@ -1,7 +1,18 @@
 """Tests for the network commands module."""
 
-import typer
-from scm_cli.commands.network import delete_app, delete_zone, load_app, load_zone, set_app, set_zone
+import typer  # noqa: I001
+from scm_cli.commands.network import (
+    delete_app,
+    delete_ike_crypto_profile,
+    delete_zone,
+    load_app,
+    load_ike_crypto_profile,
+    load_security_zone as load_zone,
+    set_app,
+    set_ike_crypto_profile,
+    set_zone,
+    show_ike_crypto_profile,
+)
 
 
 class TestNetworkCommands:
@@ -222,3 +233,133 @@ class TestZoneCommands:
         assert result.exit_code == 0
         assert "Dry run mode" in result.stdout
         assert not mock_called  # Ensure the create method was not called
+
+
+class TestIKECryptoProfileCommands:
+    """Test the IKE crypto profile commands."""
+
+    def test_set_ike_crypto_profile_created(self, runner, monkeypatch):
+        """Test set ike-crypto-profile command creates a new profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(profile_data):
+            result = profile_data.copy()
+            result["id"] = "ike-12345"
+            result["__action__"] = "created"
+            return result
+
+        monkeypatch.setattr(scm_client, "create_ike_crypto_profile", mock_create)
+        test_app = typer.Typer()
+        test_app.command()(set_ike_crypto_profile)
+        result = runner.invoke(test_app, ["test-profile", "--hash", "sha256", "--dh-group", "group14", "--encryption", "aes-256-cbc", "--folder", "test-folder", "--lifetime-hours", "8"])
+        assert result.exit_code == 0
+        assert "Created IKE crypto profile" in result.stdout
+        assert "test-profile" in result.stdout
+
+    def test_set_ike_crypto_profile_error(self, runner, monkeypatch):
+        """Test set ike-crypto-profile command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create_error(profile_data):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "create_ike_crypto_profile", mock_create_error)
+        test_app = typer.Typer()
+        test_app.command()(set_ike_crypto_profile)
+        result = runner.invoke(test_app, ["test-profile", "--hash", "sha256", "--dh-group", "group14", "--encryption", "aes-256-cbc", "--folder", "test-folder"])
+        assert result.exit_code == 1
+        assert "Error" in result.stdout
+
+    def test_show_ike_crypto_profile_list(self, runner, monkeypatch):
+        """Test show ike-crypto-profile command lists profiles."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(**kwargs):
+            return [
+                {
+                    "id": "ike-1",
+                    "name": "profile-1",
+                    "folder": "test-folder",
+                    "hash": ["sha256"],
+                    "dh_group": ["group14"],
+                    "encryption": ["aes-256-cbc"],
+                    "lifetime": {"hours": 8},
+                    "authentication_multiple": 0,
+                }
+            ]
+
+        monkeypatch.setattr(scm_client, "list_ike_crypto_profiles", mock_list)
+        test_app = typer.Typer()
+        test_app.command()(show_ike_crypto_profile)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "profile-1" in result.stdout
+
+    def test_show_ike_crypto_profile_specific(self, runner, monkeypatch):
+        """Test show ike-crypto-profile command shows a specific profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(**kwargs):
+            return {
+                "id": "ike-1",
+                "name": "profile-1",
+                "folder": "test-folder",
+                "hash": ["sha256", "sha384"],
+                "dh_group": ["group14"],
+                "encryption": ["aes-256-cbc"],
+                "lifetime": {"hours": 8},
+                "authentication_multiple": 3,
+            }
+
+        monkeypatch.setattr(scm_client, "get_ike_crypto_profile", mock_get)
+        test_app = typer.Typer()
+        test_app.command()(show_ike_crypto_profile)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "profile-1"])
+        assert result.exit_code == 0
+        assert "profile-1" in result.stdout
+        assert "sha256" in result.stdout
+
+    def test_delete_ike_crypto_profile_command(self, runner, monkeypatch):
+        """Test delete ike-crypto-profile command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(**kwargs):
+            return {"id": "ike-1", "name": "test-profile", "folder": "test-folder"}
+
+        def mock_delete(**kwargs):
+            return None
+
+        monkeypatch.setattr(scm_client, "get_ike_crypto_profile", mock_get)
+        monkeypatch.setattr(scm_client, "delete_ike_crypto_profile", mock_delete)
+        test_app = typer.Typer()
+        test_app.command()(delete_ike_crypto_profile)
+        result = runner.invoke(test_app, ["test-profile", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted IKE crypto profile" in result.stdout
+
+    def test_load_ike_crypto_profile_command(self, runner, monkeypatch, tmp_path):
+        """Test load ike-crypto-profile command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {
+            "ike_crypto_profiles": [{"name": "test-profile", "folder": "test-folder", "hash": ["sha256"], "dh_group": ["group14"], "encryption": ["aes-256-cbc"], "lifetime_hours": 8}]
+        }
+        yaml_file = tmp_path / "ike-profiles.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        def mock_create(profile_data):
+            result = profile_data.copy()
+            result["id"] = "ike-12345"
+            result["__action__"] = "created"
+            return result
+
+        monkeypatch.setattr(scm_client, "create_ike_crypto_profile", mock_create)
+        test_app = typer.Typer()
+        test_app.command()(load_ike_crypto_profile)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created IKE crypto profile" in result.stdout
+        assert "test-profile" in result.stdout

--- a/tests/test_objects_commands.py
+++ b/tests/test_objects_commands.py
@@ -4,11 +4,14 @@ import typer
 from scm_cli.commands.objects import (
     delete_address_group,
     delete_app,
+    delete_schedule,
     load_address_group,
     load_app,
     set_address_group,
     set_app,
+    set_schedule,
     show_app,
+    show_schedule,
 )
 
 
@@ -472,3 +475,140 @@ class TestShowAddressGroupCommands:
 
         assert result.exit_code == 0
         assert "No address groups found in folder 'Shared'" in result.stdout
+
+
+class TestScheduleCommands:
+    """Test the schedule commands."""
+
+    def test_set_schedule_command(self, runner, monkeypatch):
+        """Test the set schedule command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "sched-12345",
+                "name": "business-hours",
+                "folder": "Texas",
+                "schedule_type": {"recurring": {"daily": ["09:00-17:00"]}},
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_schedule", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_schedule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "business-hours",
+                "--schedule-type",
+                "recurring-daily",
+                "--time-range",
+                "09:00-17:00",
+                "--folder",
+                "Texas",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created schedule" in result.stdout
+        assert "business-hours" in result.stdout
+
+    def test_set_schedule_error(self, runner, monkeypatch):
+        """Test the set schedule command with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create_error(*args, **kwargs):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "create_schedule", mock_create_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_schedule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "bad-sched",
+                "--schedule-type",
+                "recurring-daily",
+                "--time-range",
+                "09:00-17:00",
+                "--folder",
+                "Texas",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error creating/updating schedule" in result.stdout
+
+    def test_show_schedule_list(self, runner, monkeypatch):
+        """Test the show schedule command listing all."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "name": "BusinessHours",
+                    "folder": "Texas",
+                    "schedule_type": {"recurring": {"daily": ["09:00-17:00"]}},
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_schedules", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_schedule)
+
+        result = runner.invoke(test_app, ["--folder", "Texas"])
+
+        assert result.exit_code == 0
+        assert "BusinessHours" in result.stdout
+        assert "Total: 1 schedules" in result.stdout
+
+    def test_show_schedule_by_name(self, runner, monkeypatch):
+        """Test the show schedule command by name."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "sched-123",
+                "name": "BusinessHours",
+                "folder": "Texas",
+                "schedule_type": {"recurring": {"daily": ["09:00-17:00"]}},
+            }
+
+        monkeypatch.setattr(scm_client, "get_schedule", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_schedule)
+
+        result = runner.invoke(test_app, ["--folder", "Texas", "--name", "BusinessHours"])
+
+        assert result.exit_code == 0
+        assert "Schedule: BusinessHours" in result.stdout
+        assert "Recurring Daily" in result.stdout
+        assert "09:00-17:00" in result.stdout
+
+    def test_delete_schedule_command(self, runner, monkeypatch):
+        """Test the delete schedule command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {"id": "sched-123", "name": "old-sched", "folder": "Texas"}
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "get_schedule", mock_get)
+        monkeypatch.setattr(scm_client, "delete_schedule", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_schedule)
+
+        result = runner.invoke(test_app, ["old-sched", "--folder", "Texas", "--force"])
+
+        assert result.exit_code == 0
+        assert "Deleted schedule" in result.stdout
+        assert "old-sched" in result.stdout

--- a/tests/test_objects_commands.py
+++ b/tests/test_objects_commands.py
@@ -4,13 +4,17 @@ import typer
 from scm_cli.commands.objects import (
     delete_address_group,
     delete_app,
+    delete_region,
     delete_schedule,
     load_address_group,
     load_app,
+    load_region,
     set_address_group,
     set_app,
+    set_region,
     set_schedule,
     show_app,
+    show_region,
     show_schedule,
 )
 
@@ -497,6 +501,21 @@ class TestScheduleCommands:
 
         test_app = typer.Typer()
         test_app.command()(set_schedule)
+class TestRegionCommands:
+    """Test the region commands."""
+
+    def test_set_region_command(self, runner, monkeypatch):
+        """Test the set region command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(region_data):
+            result = {**region_data, "__action__": "created"}
+            return result
+
+        monkeypatch.setattr(scm_client, "create_region", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_region)
 
         result = runner.invoke(
             test_app,
@@ -508,6 +527,15 @@ class TestScheduleCommands:
                 "09:00-17:00",
                 "--folder",
                 "Texas",
+                "US-South",
+                "--folder",
+                "Texas",
+                "--latitude",
+                "30.2672",
+                "--longitude",
+                "-97.7431",
+                "--address",
+                "10.0.0.0/8",
             ],
         )
 
@@ -526,6 +554,20 @@ class TestScheduleCommands:
 
         test_app = typer.Typer()
         test_app.command()(set_schedule)
+        assert "Created region" in result.stdout
+        assert "US-South" in result.stdout
+
+    def test_set_region_error(self, runner, monkeypatch):
+        """Test the set region command with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create_error(region_data):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "create_region", mock_create_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_region)
 
         result = runner.invoke(
             test_app,
@@ -535,6 +577,7 @@ class TestScheduleCommands:
                 "recurring-daily",
                 "--time-range",
                 "09:00-17:00",
+                "US-South",
                 "--folder",
                 "Texas",
             ],
@@ -545,6 +588,40 @@ class TestScheduleCommands:
 
     def test_show_schedule_list(self, runner, monkeypatch):
         """Test the show schedule command listing all."""
+        assert "Error creating/updating region" in result.stdout
+
+    def test_delete_region_command(self, runner, monkeypatch):
+        """Test the delete region command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {"id": "region-123", "name": "US-South", "folder": "Texas"}
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "get_region", mock_get)
+        monkeypatch.setattr(scm_client, "delete_region", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_region)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "US-South",
+                "--folder",
+                "Texas",
+                "--force",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted region" in result.stdout
+        assert "US-South" in result.stdout
+
+    def test_show_region_list(self, runner, monkeypatch):
+        """Test the show region command listing all regions."""
         from scm_cli.utils.sdk_client import scm_client
 
         def mock_list(*args, **kwargs):
@@ -560,6 +637,22 @@ class TestScheduleCommands:
 
         test_app = typer.Typer()
         test_app.command()(show_schedule)
+                    "name": "US-South",
+                    "folder": "Texas",
+                    "geo_location": {"latitude": 30.2672, "longitude": -97.7431},
+                    "address": ["10.0.0.0/8"],
+                },
+                {
+                    "name": "US-East",
+                    "folder": "Texas",
+                    "geo_location": {"latitude": 40.7128, "longitude": -74.006},
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_regions", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_region)
 
         result = runner.invoke(test_app, ["--folder", "Texas"])
 
@@ -569,6 +662,12 @@ class TestScheduleCommands:
 
     def test_show_schedule_by_name(self, runner, monkeypatch):
         """Test the show schedule command by name."""
+        assert "US-South" in result.stdout
+        assert "US-East" in result.stdout
+        assert "Total: 2 regions" in result.stdout
+
+    def test_show_region_by_name(self, runner, monkeypatch):
+        """Test the show region command with --name flag."""
         from scm_cli.utils.sdk_client import scm_client
 
         def mock_get(*args, **kwargs):
@@ -612,3 +711,70 @@ class TestScheduleCommands:
         assert result.exit_code == 0
         assert "Deleted schedule" in result.stdout
         assert "old-sched" in result.stdout
+                "id": "region-123",
+                "name": "US-South",
+                "folder": "Texas",
+                "geo_location": {"latitude": 30.2672, "longitude": -97.7431},
+                "address": ["10.0.0.0/8", "192.168.1.0/24"],
+            }
+
+        monkeypatch.setattr(scm_client, "get_region", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_region)
+
+        result = runner.invoke(test_app, ["--folder", "Texas", "--name", "US-South"])
+
+        assert result.exit_code == 0
+        assert "Region: US-South" in result.stdout
+        assert "Latitude: 30.2672" in result.stdout
+        assert "Longitude: -97.7431" in result.stdout
+        assert "10.0.0.0/8" in result.stdout
+
+    def test_show_region_empty_list(self, runner, monkeypatch):
+        """Test the show region command when no regions exist."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(scm_client, "list_regions", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_region)
+
+        result = runner.invoke(test_app, ["--folder", "Texas"])
+
+        assert result.exit_code == 0
+        assert "No regions found" in result.stdout
+
+    def test_load_region_command(self, runner, monkeypatch, tmp_path):
+        """Test the load region command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        # Create a test YAML file
+        yaml_content = """
+regions:
+  - name: US-South
+    folder: Texas
+    latitude: 30.2672
+    longitude: -97.7431
+    addresses:
+      - 10.0.0.0/8
+"""
+        test_file = tmp_path / "test_regions.yml"
+        test_file.write_text(yaml_content)
+
+        def mock_create(region_data):
+            return {**region_data, "__action__": "created"}
+
+        monkeypatch.setattr(scm_client, "create_region", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_region)
+
+        result = runner.invoke(test_app, ["--file", str(test_file)])
+
+        assert result.exit_code == 0
+        assert "Created region" in result.stdout
+        assert "US-South" in result.stdout

--- a/tests/test_objects_commands.py
+++ b/tests/test_objects_commands.py
@@ -1,19 +1,24 @@
 """Tests for the objects commands module."""
 
 import typer
+
 from scm_cli.commands.objects import (
     delete_address_group,
     delete_app,
+    delete_quarantined_device,
     delete_region,
     delete_schedule,
     load_address_group,
     load_app,
+    load_quarantined_device,
     load_region,
     set_address_group,
     set_app,
+    set_quarantined_device,
     set_region,
     set_schedule,
     show_app,
+    show_quarantined_device,
     show_region,
     show_schedule,
 )
@@ -772,9 +777,137 @@ regions:
 
         test_app = typer.Typer()
         test_app.command()(load_region)
+class TestQuarantinedDeviceCommands:
+    """Test the quarantined device commands."""
+
+    def test_set_quarantined_device_command(self, runner, monkeypatch):
+        """Test the set quarantined-device command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(device_data):
+            return device_data
+
+        monkeypatch.setattr(scm_client, "create_quarantined_device", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_quarantined_device)
+
+        result = runner.invoke(test_app, ["host-123", "--serial-number", "SN-456"])
+
+        assert result.exit_code == 0
+        assert "Created quarantined device: host-123" in result.stdout
+
+    def test_set_quarantined_device_no_serial(self, runner, monkeypatch):
+        """Test the set quarantined-device command without serial number."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(device_data):
+            return device_data
+
+        monkeypatch.setattr(scm_client, "create_quarantined_device", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_quarantined_device)
+
+        result = runner.invoke(test_app, ["host-789"])
+
+        assert result.exit_code == 0
+        assert "Created quarantined device: host-789" in result.stdout
+
+    def test_delete_quarantined_device_command(self, runner, monkeypatch):
+        """Test the delete quarantined-device command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(host_id):
+            pass
+
+        monkeypatch.setattr(scm_client, "delete_quarantined_device", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_quarantined_device)
+
+        result = runner.invoke(test_app, ["host-123"])
+
+        assert result.exit_code == 0
+        assert "Deleted quarantined device: host-123" in result.stdout
+
+    def test_show_quarantined_device_list(self, runner, monkeypatch):
+        """Test the show quarantined-device command listing all devices."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(host_id=None, serial_number=None):
+            return [
+                {"host_id": "host-001", "serial_number": "SN-001"},
+                {"host_id": "host-002", "serial_number": "SN-002"},
+            ]
+
+        monkeypatch.setattr(scm_client, "list_quarantined_devices", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_quarantined_device)
+
+        result = runner.invoke(test_app, [])
+
+        assert result.exit_code == 0
+        assert "Host ID: host-001" in result.stdout
+        assert "Serial Number: SN-001" in result.stdout
+        assert "Host ID: host-002" in result.stdout
+        assert "Total: 2 quarantined devices" in result.stdout
+
+    def test_show_quarantined_device_empty(self, runner, monkeypatch):
+        """Test the show quarantined-device command when no devices found."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(host_id=None, serial_number=None):
+            return []
+
+        monkeypatch.setattr(scm_client, "list_quarantined_devices", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_quarantined_device)
+
+        result = runner.invoke(test_app, [])
+
+        assert result.exit_code == 0
+        assert "No quarantined devices found" in result.stdout
+
+    def test_load_quarantined_device_command(self, runner, monkeypatch, tmp_path):
+        """Test the load quarantined-device command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(device_data):
+            return device_data
+
+        monkeypatch.setattr(scm_client, "create_quarantined_device", mock_create)
+
+        # Create test YAML file
+        yaml_content = """
+quarantined_devices:
+  - host_id: host-001
+    serial_number: SN-001
+  - host_id: host-002
+"""
+        test_file = tmp_path / "quarantined_devices.yml"
+        test_file.write_text(yaml_content)
+
+        test_app = typer.Typer()
+        test_app.command()(load_quarantined_device)
 
         result = runner.invoke(test_app, ["--file", str(test_file)])
 
         assert result.exit_code == 0
         assert "Created region" in result.stdout
         assert "US-South" in result.stdout
+        assert "Created quarantined device: host-001" in result.stdout
+        assert "Created quarantined device: host-002" in result.stdout
+        assert "Processed 2 quarantined devices" in result.stdout
+
+    def test_load_quarantined_device_file_not_found(self, runner):
+        """Test the load quarantined-device command with missing file."""
+        test_app = typer.Typer()
+        test_app.command()(load_quarantined_device)
+
+        result = runner.invoke(test_app, ["--file", "/nonexistent/file.yml"])
+
+        assert result.exit_code == 1
+        assert "File not found" in result.stdout

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@
 
 import pytest
 from pydantic import ValidationError
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, Schedule, SecurityRule, Zone
+from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, Region, Schedule, SecurityRule, Zone
 
 
 class TestBandwidthAllocation:
@@ -271,6 +271,91 @@ class TestSchedule:
                 schedule_type="recurring-daily",
                 time_ranges=["09:00-17:00"],
             )
+
+class TestRegion:
+    """Test cases for the Region model."""
+
+    def test_valid_region(self):
+        """Test creating a valid region."""
+        region = Region(
+            name="US-South",
+            folder="Texas",
+            latitude=30.2672,
+            longitude=-97.7431,
+            addresses=["10.0.0.0/8", "192.168.1.0/24"],
+        )
+        assert region.name == "US-South"
+        assert region.folder == "Texas"
+        assert region.latitude == 30.2672
+        assert region.longitude == -97.7431
+        assert region.addresses == ["10.0.0.0/8", "192.168.1.0/24"]
+
+    def test_missing_required_fields(self):
+        """Test that required fields are enforced."""
+        with pytest.raises(ValidationError):
+            Region(
+                name="US-South",
+                # Missing folder
+            )
+
+        with pytest.raises(ValidationError):
+            Region(
+                # Missing name
+                folder="Texas",
+            )
+
+    def test_default_values(self):
+        """Test that default values are applied correctly."""
+        region = Region(name="US-South", folder="Texas")
+        assert region.latitude is None
+        assert region.longitude is None
+        assert region.addresses is None
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        region = Region(
+            name="US-South",
+            folder="Texas",
+            latitude=30.2672,
+            longitude=-97.7431,
+            addresses=["10.0.0.0/8"],
+        )
+        sdk_data = region.to_sdk_model()
+        assert sdk_data["name"] == "US-South"
+        assert sdk_data["folder"] == "Texas"
+        assert sdk_data["geo_location"] == {"latitude": 30.2672, "longitude": -97.7431}
+        assert sdk_data["address"] == ["10.0.0.0/8"]
+
+    def test_to_sdk_model_minimal(self):
+        """Test conversion to SDK model with minimal fields."""
+        region = Region(name="US-South", folder="Texas")
+        sdk_data = region.to_sdk_model()
+        assert sdk_data == {"name": "US-South", "folder": "Texas"}
+        assert "geo_location" not in sdk_data
+        assert "address" not in sdk_data
+
+    def test_container_validation(self):
+        """Test that exactly one container must be set."""
+        with pytest.raises(ValidationError):
+            Region(
+                name="US-South",
+                folder="Texas",
+                snippet="test-snippet",
+            )
+
+    def test_latitude_range(self):
+        """Test latitude validation range."""
+        with pytest.raises(ValidationError):
+            Region(name="test", folder="Texas", latitude=91.0)
+        with pytest.raises(ValidationError):
+            Region(name="test", folder="Texas", latitude=-91.0)
+
+    def test_longitude_range(self):
+        """Test longitude validation range."""
+        with pytest.raises(ValidationError):
+            Region(name="test", folder="Texas", longitude=181.0)
+        with pytest.raises(ValidationError):
+            Region(name="test", folder="Texas", longitude=-181.0)
 
 
 class TestSecurityRule:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@
 
 import pytest
 from pydantic import ValidationError
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, Region, Schedule, SecurityRule, Zone
+from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, QuarantinedDevice, Region, Schedule, SecurityRule, Zone
 
 
 class TestBandwidthAllocation:
@@ -356,6 +356,40 @@ class TestRegion:
             Region(name="test", folder="Texas", longitude=181.0)
         with pytest.raises(ValidationError):
             Region(name="test", folder="Texas", longitude=-181.0)
+class TestQuarantinedDevice:
+    """Test cases for the QuarantinedDevice model."""
+
+    def test_valid_quarantined_device(self):
+        """Test creating a valid quarantined device."""
+        device = QuarantinedDevice(
+            host_id="host-123",
+            serial_number="SN-456",
+        )
+        assert device.host_id == "host-123"
+        assert device.serial_number == "SN-456"
+
+    def test_missing_host_id(self):
+        """Test that host_id is required."""
+        with pytest.raises(ValidationError):
+            QuarantinedDevice()
+
+    def test_optional_serial_number(self):
+        """Test that serial_number is optional."""
+        device = QuarantinedDevice(host_id="host-123")
+        assert device.host_id == "host-123"
+        assert device.serial_number is None
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        device = QuarantinedDevice(host_id="host-123", serial_number="SN-456")
+        sdk_data = device.to_sdk_model()
+        assert sdk_data == {"host_id": "host-123", "serial_number": "SN-456"}
+
+    def test_to_sdk_model_no_serial(self):
+        """Test conversion to SDK model format without serial number."""
+        device = QuarantinedDevice(host_id="host-123")
+        sdk_data = device.to_sdk_model()
+        assert sdk_data == {"host_id": "host-123"}
 
 
 class TestSecurityRule:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@
 
 import pytest
 from pydantic import ValidationError
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, SecurityRule, Zone
+from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, Schedule, SecurityRule, Zone
 
 
 class TestBandwidthAllocation:
@@ -157,6 +157,120 @@ class TestAddressGroup:
         assert address_group.members == []
         assert address_group.description == ""
         assert address_group.tags == []
+
+
+class TestSchedule:
+    """Test cases for the Schedule model."""
+
+    def test_valid_recurring_daily(self):
+        """Test creating a valid recurring daily schedule."""
+        schedule = Schedule(
+            name="business-hours",
+            folder="Texas",
+            schedule_type="recurring-daily",
+            time_ranges=["09:00-17:00"],
+        )
+        assert schedule.name == "business-hours"
+        assert schedule.folder == "Texas"
+        assert schedule.schedule_type == "recurring-daily"
+        assert schedule.time_ranges == ["09:00-17:00"]
+
+    def test_valid_recurring_weekly(self):
+        """Test creating a valid recurring weekly schedule."""
+        schedule = Schedule(
+            name="weekday-hours",
+            folder="Texas",
+            schedule_type="recurring-weekly",
+            days={"monday": ["09:00-17:00"], "friday": ["09:00-12:00"]},
+        )
+        assert schedule.name == "weekday-hours"
+        assert schedule.schedule_type == "recurring-weekly"
+        assert schedule.days == {"monday": ["09:00-17:00"], "friday": ["09:00-12:00"]}
+
+    def test_valid_non_recurring(self):
+        """Test creating a valid non-recurring schedule."""
+        schedule = Schedule(
+            name="maintenance",
+            folder="Texas",
+            schedule_type="non-recurring",
+            time_ranges=["2026/03/15@02:00-2026/03/15@06:00"],
+        )
+        assert schedule.name == "maintenance"
+        assert schedule.schedule_type == "non-recurring"
+
+    def test_invalid_schedule_type(self):
+        """Test that invalid schedule type raises error."""
+        with pytest.raises(ValidationError):
+            Schedule(
+                name="test",
+                folder="Texas",
+                schedule_type="invalid",
+                time_ranges=["09:00-17:00"],
+            )
+
+    def test_missing_time_ranges_for_daily(self):
+        """Test that missing time_ranges for daily raises error."""
+        with pytest.raises(ValidationError):
+            Schedule(
+                name="test",
+                folder="Texas",
+                schedule_type="recurring-daily",
+            )
+
+    def test_missing_days_for_weekly(self):
+        """Test that missing days for weekly raises error."""
+        with pytest.raises(ValidationError):
+            Schedule(
+                name="test",
+                folder="Texas",
+                schedule_type="recurring-weekly",
+            )
+
+    def test_to_sdk_model_daily(self):
+        """Test SDK model conversion for daily schedule."""
+        schedule = Schedule(
+            name="daily-sched",
+            folder="Texas",
+            schedule_type="recurring-daily",
+            time_ranges=["09:00-17:00", "18:00-22:00"],
+        )
+        sdk = schedule.to_sdk_model()
+        assert sdk["name"] == "daily-sched"
+        assert sdk["folder"] == "Texas"
+        assert sdk["schedule_type"]["recurring"]["daily"] == ["09:00-17:00", "18:00-22:00"]
+
+    def test_to_sdk_model_weekly(self):
+        """Test SDK model conversion for weekly schedule."""
+        schedule = Schedule(
+            name="weekly-sched",
+            folder="Texas",
+            schedule_type="recurring-weekly",
+            days={"monday": ["09:00-17:00"]},
+        )
+        sdk = schedule.to_sdk_model()
+        assert sdk["schedule_type"]["recurring"]["weekly"] == {"monday": ["09:00-17:00"]}
+
+    def test_to_sdk_model_non_recurring(self):
+        """Test SDK model conversion for non-recurring schedule."""
+        schedule = Schedule(
+            name="maint",
+            folder="Texas",
+            schedule_type="non-recurring",
+            time_ranges=["2026/03/15@02:00-2026/03/15@06:00"],
+        )
+        sdk = schedule.to_sdk_model()
+        assert sdk["schedule_type"]["non_recurring"] == ["2026/03/15@02:00-2026/03/15@06:00"]
+
+    def test_container_validation(self):
+        """Test container field validation."""
+        with pytest.raises(ValidationError):
+            Schedule(
+                name="test",
+                folder="Texas",
+                snippet="MySnippet",
+                schedule_type="recurring-daily",
+                time_ranges=["09:00-17:00"],
+            )
 
 
 class TestSecurityRule:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@
 
 import pytest
 from pydantic import ValidationError
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, QuarantinedDevice, Region, Schedule, SecurityRule, Zone
+from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, IKECryptoProfile, QuarantinedDevice, Region, Schedule, SecurityRule, Zone
 
 
 class TestBandwidthAllocation:
@@ -55,6 +55,70 @@ class TestBandwidthAllocation:
         )
         assert allocation.description == ""
         assert allocation.tags == []
+
+
+class TestIKECryptoProfile:
+    """Test cases for the IKECryptoProfile model."""
+
+    def test_valid_ike_crypto_profile(self):
+        """Test creating a valid IKE crypto profile."""
+        profile = IKECryptoProfile(name="test-profile", folder="test-folder", hash=["sha256"], dh_group=["group14"], encryption=["aes-256-cbc"], lifetime_hours=8)
+        assert profile.name == "test-profile"
+        assert profile.folder == "test-folder"
+        assert profile.hash == ["sha256"]
+        assert profile.dh_group == ["group14"]
+        assert profile.encryption == ["aes-256-cbc"]
+        assert profile.lifetime_hours == 8
+
+    def test_missing_required_fields(self):
+        """Test that required fields are enforced."""
+        with pytest.raises(ValidationError):
+            IKECryptoProfile(name="test-profile", folder="test-folder")
+
+    def test_invalid_hash(self):
+        """Test that invalid hash algorithms are rejected."""
+        with pytest.raises(ValidationError):
+            IKECryptoProfile(name="test-profile", folder="test-folder", hash=["invalid-hash"], dh_group=["group14"], encryption=["aes-256-cbc"])
+
+    def test_invalid_dh_group(self):
+        """Test that invalid DH groups are rejected."""
+        with pytest.raises(ValidationError):
+            IKECryptoProfile(name="test-profile", folder="test-folder", hash=["sha256"], dh_group=["group99"], encryption=["aes-256-cbc"])
+
+    def test_invalid_encryption(self):
+        """Test that invalid encryption algorithms are rejected."""
+        with pytest.raises(ValidationError):
+            IKECryptoProfile(name="test-profile", folder="test-folder", hash=["sha256"], dh_group=["group14"], encryption=["invalid-enc"])
+
+    def test_multiple_lifetime_rejected(self):
+        """Test that setting multiple lifetime fields is rejected."""
+        with pytest.raises(ValidationError):
+            IKECryptoProfile(name="test-profile", folder="test-folder", hash=["sha256"], dh_group=["group14"], encryption=["aes-256-cbc"], lifetime_hours=8, lifetime_days=1)
+
+    def test_container_validation(self):
+        """Test that exactly one container is required."""
+        with pytest.raises(ValidationError):
+            IKECryptoProfile(name="test-profile", hash=["sha256"], dh_group=["group14"], encryption=["aes-256-cbc"])
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        profile = IKECryptoProfile(
+            name="test-profile", folder="test-folder", hash=["sha256", "sha384"], dh_group=["group14", "group19"], encryption=["aes-256-cbc"], lifetime_hours=8, authentication_multiple=3
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["name"] == "test-profile"
+        assert sdk_data["folder"] == "test-folder"
+        assert sdk_data["hash"] == ["sha256", "sha384"]
+        assert sdk_data["dh_group"] == ["group14", "group19"]
+        assert sdk_data["encryption"] == ["aes-256-cbc"]
+        assert sdk_data["lifetime"] == {"hours": 8}
+        assert sdk_data["authentication_multiple"] == 3
+
+    def test_to_sdk_model_no_lifetime(self):
+        """Test conversion to SDK model without lifetime."""
+        profile = IKECryptoProfile(name="test-profile", folder="test-folder", hash=["sha256"], dh_group=["group14"], encryption=["aes-256-cbc"])
+        sdk_data = profile.to_sdk_model()
+        assert "lifetime" not in sdk_data
 
 
 class TestZone:


### PR DESCRIPTION
## Summary
- Add schedule object commands (#44) - recurring daily/weekly and non-recurring schedules
- Add region object commands (#45) - geo-location and address CIDRs
- Add quarantined device commands (#46) - create/list/delete (no update)
- Add IKE crypto profile commands (#47) - encryption, hash, DH group, lifetime settings

Each resource includes: validators, SDK client methods (with smart upsert where applicable), CLI commands (set/show/delete/load/backup), mock mode support, and unit tests.

## Test plan
- [x] All new validator tests pass (32 tests across 4 resources)
- [x] Lint checks pass
- [x] Existing tests unaffected

Closes #44, Closes #45, Closes #46, Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)