### PR TITLE
feat: SDK parity batch 2 - IPsec crypto, DNS security, NAT, vuln protection, URL category

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,3 +391,4 @@ Thumbs.db
 .claude/sdk/scm/utils/__init__.py
 .claude/sdk/scm/utils/logging.py
 .claude/sdk/scm/utils/tag_colors.py
+.claude/worktrees/

--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -14,6 +14,7 @@ from pydantic import ValidationError
 from ..utils.config import load_from_yaml
 from ..utils.sdk_client import scm_client
 from ..utils.validators import IKECryptoProfile, Zone
+from ..utils.validators import IPSecCryptoProfile, Zone
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -88,6 +89,27 @@ BACKUP_FILE_OPTION = typer.Option(
     "--file",
     help="Output filename for backup (defaults to {object-type}-{location}.yaml)",
 )
+
+# IPsec crypto profile option constants (module-level to avoid B008)
+IPSEC_FOLDER_OPTION = typer.Option("Texas", "--folder", help="Folder path for the IPsec crypto profile")
+IPSEC_NAME_OPTION = typer.Option(..., "--name", help="Name of the IPsec crypto profile")
+IPSEC_ESP_ENCRYPTION_OPTION: list[str] = typer.Option(
+    ["aes-256-cbc"],
+    "--esp-encryption",
+    help="ESP encryption algorithms (des, 3des, aes-128-cbc, aes-192-cbc, aes-256-cbc, aes-128-gcm, aes-256-gcm, null)",
+)
+IPSEC_ESP_AUTHENTICATION_OPTION: list[str] = typer.Option(
+    ["sha256"],
+    "--esp-authentication",
+    help="ESP authentication algorithms (md5, sha1, sha256, sha384, sha512)",
+)
+IPSEC_DH_GROUP_OPTION = typer.Option(
+    "group14",
+    "--dh-group",
+    help="DH group for PFS (no-pfs, group1, group2, group5, group14, group19, group20)",
+)
+IPSEC_LIFETIME_SECONDS_OPTION = typer.Option(None, "--lifetime-seconds", help="Lifetime in seconds (180-65535)")
+IPSEC_LIFETIME_HOURS_OPTION = typer.Option(None, "--lifetime-hours", help="Lifetime in hours (1-65535)")
 
 # ========================================================================================================================================================================================
 # HELPER FUNCTIONS
@@ -761,4 +783,275 @@ def show_zone(
 
     except Exception as e:
         typer.echo(f"Error showing security zone: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# IPSEC CRYPTO PROFILE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("ipsec-crypto-profile")
+def backup_ipsec_crypto_profile(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: str = BACKUP_FILE_OPTION,
+):
+    """Back up all IPsec crypto profiles from a container to a YAML file.
+
+    Examples
+    --------
+        # Backup from folder
+        scm backup network ipsec-crypto-profile --folder Texas
+
+        # Backup to custom filename
+        scm backup network ipsec-crypto-profile --folder Texas --file my-profiles.yaml
+
+    """
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    if not file:
+        file = get_default_backup_filename("ipsec-crypto-profiles", location_type, location_value)
+
+    try:
+        profiles = scm_client.list_ipsec_crypto_profiles(folder=folder, snippet=snippet, device=device, exact_match=True)
+
+        if not profiles:
+            typer.echo(f"No IPsec crypto profiles found in {location_type} '{location_value}'")
+            return None
+
+        backup_data = []
+        for profile in profiles:
+            profile_dict = profile.copy()
+            profile_dict.pop("id", None)
+            backup_data.append(profile_dict)
+
+        yaml_data = {"ipsec_crypto_profiles": backup_data}
+
+        with open(file, "w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} IPsec crypto profiles to {file}")
+        return file
+
+    except NotImplementedError as e:
+        typer.echo(f"Error: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error backing up IPsec crypto profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("ipsec-crypto-profile")
+def delete_ipsec_crypto_profile(
+    folder: str = IPSEC_FOLDER_OPTION,
+    name: str = IPSEC_NAME_OPTION,
+):
+    """Delete an IPsec crypto profile.
+
+    Example: scm delete network ipsec-crypto-profile --folder Texas --name my-profile
+    """
+    try:
+        result = scm_client.delete_ipsec_crypto_profile(folder=folder, name=name)
+
+        if result:
+            typer.echo(f"Deleted IPsec crypto profile: {name} from folder {folder}")
+        else:
+            typer.echo(f"IPsec crypto profile not found: {name} in folder {folder}", err=True)
+            raise typer.Exit(code=1)
+    except Exception as e:
+        typer.echo(f"Error deleting IPsec crypto profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("ipsec-crypto-profile")
+def load_ipsec_crypto_profile(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+):
+    """Load IPsec crypto profiles from a YAML file.
+
+    Example: scm load network ipsec-crypto-profile --file ipsec-profiles.yaml
+    """
+    try:
+        config = load_from_yaml(str(file), "ipsec_crypto_profiles")
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            typer.echo(yaml.dump(config["ipsec_crypto_profiles"]))
+            return None
+
+        results = []
+        for profile_data in config["ipsec_crypto_profiles"]:
+            profile = IPSecCryptoProfile(**profile_data)
+            sdk_data = profile.to_sdk_model()
+
+            result = scm_client.create_ipsec_crypto_profile(
+                folder=profile.folder or "Texas",
+                name=sdk_data["name"],
+                esp_encryption=sdk_data["esp"]["encryption"],
+                esp_authentication=sdk_data["esp"]["authentication"],
+                dh_group=sdk_data.get("dh_group", "group14"),
+                lifetime=sdk_data.get("lifetime"),
+                lifesize=sdk_data.get("lifesize"),
+            )
+
+            results.append(result)
+            action = result.get("__action__", "applied")
+            typer.echo(f"IPsec crypto profile '{result['name']}' {action} in folder {result.get('folder', 'N/A')}")
+
+        return results
+    except ValidationError as e:
+        typer.echo(f"Validation error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error loading IPsec crypto profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("ipsec-crypto-profile")
+def set_ipsec_crypto_profile(
+    folder: str = IPSEC_FOLDER_OPTION,
+    name: str = IPSEC_NAME_OPTION,
+    esp_encryption: list[str] = IPSEC_ESP_ENCRYPTION_OPTION,
+    esp_authentication: list[str] = IPSEC_ESP_AUTHENTICATION_OPTION,
+    dh_group: str = IPSEC_DH_GROUP_OPTION,
+    lifetime_seconds: int | None = IPSEC_LIFETIME_SECONDS_OPTION,
+    lifetime_hours: int | None = IPSEC_LIFETIME_HOURS_OPTION,
+):
+    """Create or update an IPsec crypto profile.
+
+    Example:
+    -------
+        scm set network ipsec-crypto-profile --folder Texas --name my-profile \
+        --esp-encryption aes-256-cbc --esp-authentication sha256 --dh-group group14
+
+    """
+    try:
+        profile = IPSecCryptoProfile(
+            folder=folder,
+            name=name,
+            esp_encryption=esp_encryption,
+            esp_authentication=esp_authentication,
+            dh_group=dh_group,
+            lifetime_seconds=lifetime_seconds,
+            lifetime_hours=lifetime_hours,
+        )
+
+        sdk_data = profile.to_sdk_model()
+
+        result = scm_client.create_ipsec_crypto_profile(
+            folder=folder,
+            name=name,
+            esp_encryption=sdk_data["esp"]["encryption"],
+            esp_authentication=sdk_data["esp"]["authentication"],
+            dh_group=sdk_data.get("dh_group", "group14"),
+            lifetime=sdk_data.get("lifetime"),
+            lifesize=sdk_data.get("lifesize"),
+        )
+
+        action = result.get("__action__", "created")
+        typer.echo(f"IPsec crypto profile '{result['name']}' {action} in folder {result.get('folder', folder)}")
+        return result
+    except Exception as e:
+        typer.echo(f"Error creating IPsec crypto profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("ipsec-crypto-profile")
+def show_ipsec_crypto_profile(
+    folder: str = IPSEC_FOLDER_OPTION,
+    name: str | None = typer.Option(None, "--name", help="Name of the IPsec crypto profile to show"),
+):
+    """Display IPsec crypto profiles.
+
+    Example:
+    -------
+        # List all IPsec crypto profiles in a folder
+        scm show network ipsec-crypto-profile --folder Texas
+
+        # Show a specific IPsec crypto profile
+        scm show network ipsec-crypto-profile --folder Texas --name my-profile
+
+    """
+    try:
+        if name:
+            profile = scm_client.get_ipsec_crypto_profile(folder=folder, name=name)
+
+            typer.echo(f"\nIPsec Crypto Profile: {profile.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+
+            if profile.get("folder"):
+                typer.echo(f"Location: Folder '{profile['folder']}'")
+
+            # Display ESP config
+            esp = profile.get("esp", {})
+            if esp:
+                typer.echo(f"ESP Encryption: {', '.join(esp.get('encryption', []))}")
+                typer.echo(f"ESP Authentication: {', '.join(esp.get('authentication', []))}")
+
+            if profile.get("dh_group"):
+                typer.echo(f"DH Group: {profile['dh_group']}")
+
+            # Display lifetime
+            lifetime = profile.get("lifetime", {})
+            if lifetime:
+                for unit, value in lifetime.items():
+                    typer.echo(f"Lifetime: {value} {unit}")
+
+            # Display lifesize
+            lifesize = profile.get("lifesize", {})
+            if lifesize:
+                for unit, value in lifesize.items():
+                    typer.echo(f"Lifesize: {value} {unit.upper()}")
+
+            if profile.get("id"):
+                typer.echo(f"ID: {profile['id']}")
+
+            return profile
+
+        else:
+            profiles = scm_client.list_ipsec_crypto_profiles(folder=folder)
+
+            if not profiles:
+                typer.echo(f"No IPsec crypto profiles found in folder '{folder}'")
+                return None
+
+            typer.echo(f"\nIPsec Crypto Profiles in folder '{folder}':")
+            typer.echo("=" * 80)
+
+            for profile in profiles:
+                typer.echo(f"Name: {profile.get('name', 'N/A')}")
+
+                if profile.get("folder"):
+                    typer.echo(f"  Location: Folder '{profile['folder']}'")
+
+                esp = profile.get("esp", {})
+                if esp:
+                    typer.echo(f"  ESP Encryption: {', '.join(esp.get('encryption', []))}")
+                    typer.echo(f"  ESP Authentication: {', '.join(esp.get('authentication', []))}")
+
+                if profile.get("dh_group"):
+                    typer.echo(f"  DH Group: {profile['dh_group']}")
+
+                lifetime = profile.get("lifetime", {})
+                if lifetime:
+                    for unit, value in lifetime.items():
+                        typer.echo(f"  Lifetime: {value} {unit}")
+
+                lifesize = profile.get("lifesize", {})
+                if lifesize:
+                    for unit, value in lifesize.items():
+                        typer.echo(f"  Lifesize: {value} {unit.upper()}")
+
+                if profile.get("id"):
+                    typer.echo(f"  ID: {profile['id']}")
+
+                typer.echo("-" * 80)
+
+            return profiles
+
+    except Exception as e:
+        typer.echo(f"Error showing IPsec crypto profile: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -4,8 +4,10 @@ This module implements set, delete, and load commands for network-related
 configurations such as zones and interfaces.
 """
 
+import json
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import typer
 import yaml
@@ -13,8 +15,7 @@ from pydantic import ValidationError
 
 from ..utils.config import load_from_yaml
 from ..utils.sdk_client import scm_client
-from ..utils.validators import IKECryptoProfile, Zone
-from ..utils.validators import IPSecCryptoProfile, Zone
+from ..utils.validators import IKECryptoProfile, IPSecCryptoProfile, NATRule, Zone
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -88,6 +89,95 @@ BACKUP_FILE_OPTION = typer.Option(
     None,
     "--file",
     help="Output filename for backup (defaults to {object-type}-{location}.yaml)",
+)
+
+# NAT rule option constants
+NAT_FOLDER_OPTION = typer.Option(
+    ...,
+    "--folder",
+    help="Folder path for the NAT rule",
+)
+NAT_NAME_OPTION = typer.Option(
+    ...,
+    "--name",
+    help="Name of the NAT rule",
+)
+NAT_DESCRIPTION_OPTION = typer.Option(
+    None,
+    "--description",
+    help="Description of the NAT rule",
+)
+NAT_TAG_OPTION = typer.Option(
+    None,
+    "--tag",
+    help="Tags for the NAT rule",
+)
+NAT_DISABLED_OPTION = typer.Option(
+    False,
+    "--disabled",
+    help="Disable the NAT rule",
+)
+NAT_NAT_TYPE_OPTION = typer.Option(
+    "ipv4",
+    "--nat-type",
+    help="NAT type (ipv4, nat64, nptv6)",
+)
+NAT_FROM_ZONES_OPTION = typer.Option(
+    None,
+    "--from-zone",
+    help="Source zone(s)",
+)
+NAT_TO_ZONES_OPTION = typer.Option(
+    None,
+    "--to-zone",
+    help="Destination zone(s)",
+)
+NAT_TO_INTERFACE_OPTION = typer.Option(
+    None,
+    "--to-interface",
+    help="Destination interface",
+)
+NAT_SOURCE_OPTION = typer.Option(
+    None,
+    "--source",
+    help="Source address(es)",
+)
+NAT_DESTINATION_OPTION = typer.Option(
+    None,
+    "--destination",
+    help="Destination address(es)",
+)
+NAT_SERVICE_OPTION = typer.Option(
+    "any",
+    "--service",
+    help="TCP/UDP service",
+)
+NAT_SOURCE_TRANSLATION_OPTION = typer.Option(
+    None,
+    "--source-translation",
+    help="Source translation config as JSON string",
+)
+NAT_DESTINATION_TRANSLATION_OPTION = typer.Option(
+    None,
+    "--destination-translation",
+    help="Destination translation config as JSON string",
+)
+
+# Container override options for load commands
+LOAD_FOLDER_OPTION = typer.Option(
+    None,
+    "--folder",
+    help="Override folder location for all objects",
+)
+LOAD_SNIPPET_OPTION = typer.Option(
+    None,
+    "--snippet",
+    help="Override snippet location for all objects",
+)
+LOAD_DEVICE_OPTION = typer.Option(
+    None,
+    "--device",
+    help="Override device location for all objects",
 )
 
 # IPsec crypto profile option constants (module-level to avoid B008)
@@ -1054,4 +1144,374 @@ def show_ipsec_crypto_profile(
 
     except Exception as e:
         typer.echo(f"Error showing IPsec crypto profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# NAT RULE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("nat-rule")
+def backup_nat_rule(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: str = BACKUP_FILE_OPTION,
+):
+    """Back up all NAT rules from a container to a YAML file.
+
+    Examples
+    --------
+        # Backup from folder
+        scm backup network nat-rule --folder Texas
+
+        # Backup to custom filename
+        scm backup network nat-rule --folder Texas --file my-nat-rules.yaml
+
+    """
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    if not file:
+        file = get_default_backup_filename("nat-rules", location_type, location_value)
+
+    try:
+        nat_rules = scm_client.list_nat_rules(folder=folder, snippet=snippet, device=device, exact_match=True)
+
+        if not nat_rules:
+            typer.echo(f"No NAT rules found in {location_type} '{location_value}'")
+            return None
+
+        backup_data = []
+        for rule in nat_rules:
+            rule_dict = rule.copy()
+            rule_dict.pop("id", None)
+            backup_data.append(rule_dict)
+
+        yaml_data = {"nat_rules": backup_data}
+
+        with open(file, "w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} NAT rules to {file}")
+        return file
+
+    except NotImplementedError as e:
+        typer.echo(f"Error: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error backing up NAT rules: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("nat-rule")
+def delete_nat_rule(
+    folder: str = NAT_FOLDER_OPTION,
+    name: str = NAT_NAME_OPTION,
+):
+    """Delete a NAT rule.
+
+    Example: scm delete network nat-rule --folder Texas --name outbound-nat
+    """
+    try:
+        result = scm_client.delete_nat_rule(folder=folder, name=name)
+
+        if result:
+            typer.echo(f"Deleted NAT rule: {name} from folder {folder}")
+        else:
+            typer.echo(f"NAT rule not found: {name} in folder {folder}", err=True)
+            raise typer.Exit(code=1)
+    except Exception as e:
+        typer.echo(f"Error deleting NAT rule: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("nat-rule")
+def load_nat_rule(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+    snippet: str = LOAD_SNIPPET_OPTION,
+    device: str = LOAD_DEVICE_OPTION,
+):
+    """Load NAT rules from a YAML file.
+
+    Example: scm load network nat-rule --file nat-rules.yaml
+    """
+    try:
+        # Validate container override parameters
+        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+            typer.echo(
+                "Error: Only one of --folder, --snippet, or --device can be specified",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        if not file.exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+
+        with open(file) as f:
+            raw_data = yaml.safe_load(f)
+
+        if not raw_data or "nat_rules" not in raw_data:
+            typer.echo("No NAT rules found in file", err=True)
+            raise typer.Exit(code=1)
+
+        nat_rules = raw_data["nat_rules"]
+        if not isinstance(nat_rules, list):
+            nat_rules = [nat_rules]
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(nat_rules))
+            return None
+
+        results: list[dict[str, Any]] = []
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+
+        for rule_data in nat_rules:
+            try:
+                # Apply container override
+                if folder:
+                    rule_data["folder"] = folder
+                    rule_data.pop("snippet", None)
+                    rule_data.pop("device", None)
+                elif snippet:
+                    rule_data["snippet"] = snippet
+                    rule_data.pop("folder", None)
+                    rule_data.pop("device", None)
+                elif device:
+                    rule_data["device"] = device
+                    rule_data.pop("folder", None)
+                    rule_data.pop("snippet", None)
+
+                nat_rule = NATRule(**rule_data)
+                sdk_data = nat_rule.to_sdk_model()
+
+                result = scm_client.create_nat_rule(
+                    folder=nat_rule.folder,
+                    snippet=nat_rule.snippet,
+                    device=nat_rule.device,
+                    name=nat_rule.name,
+                    description=nat_rule.description,
+                    tag=nat_rule.tag,
+                    disabled=nat_rule.disabled,
+                    nat_type=nat_rule.nat_type,
+                    from_zones=sdk_data.get("from_"),
+                    to_zones=sdk_data.get("to_"),
+                    to_interface=nat_rule.to_interface,
+                    source=sdk_data.get("source"),
+                    destination=sdk_data.get("destination"),
+                    service=nat_rule.service,
+                    source_translation=nat_rule.source_translation,
+                    destination_translation=nat_rule.destination_translation,
+                    active_active_device_binding=nat_rule.active_active_device_binding,
+                )
+
+                action = result.pop("__action__", "created")
+                results.append(result)
+
+                if action == "created":
+                    created_count += 1
+                elif action == "updated":
+                    updated_count += 1
+                else:
+                    no_change_count += 1
+
+            except Exception as e:
+                typer.echo(
+                    f"Error processing NAT rule '{rule_data.get('name', 'unknown')}': {str(e)}",
+                    err=True,
+                )
+                continue
+
+        typer.echo(f"Successfully processed {len(results)} NAT rule(s):")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+
+        return results
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error loading NAT rules: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("nat-rule")
+def set_nat_rule(
+    folder: str = NAT_FOLDER_OPTION,
+    name: str = NAT_NAME_OPTION,
+    description: str | None = NAT_DESCRIPTION_OPTION,
+    tag: list[str] | None = NAT_TAG_OPTION,
+    disabled: bool = NAT_DISABLED_OPTION,
+    nat_type: str = NAT_NAT_TYPE_OPTION,
+    from_zone: list[str] | None = NAT_FROM_ZONES_OPTION,
+    to_zone: list[str] | None = NAT_TO_ZONES_OPTION,
+    to_interface: str | None = NAT_TO_INTERFACE_OPTION,
+    source: list[str] | None = NAT_SOURCE_OPTION,
+    destination: list[str] | None = NAT_DESTINATION_OPTION,
+    service: str = NAT_SERVICE_OPTION,
+    source_translation: str | None = NAT_SOURCE_TRANSLATION_OPTION,
+    destination_translation: str | None = NAT_DESTINATION_TRANSLATION_OPTION,
+):
+    r"""Create or update a NAT rule.
+
+    Example:
+    -------
+        scm set network nat-rule --folder Texas --name outbound-nat \
+        --from-zone trust --to-zone untrust --source any --destination any \
+        --source-translation '{"dynamic_ip_and_port": {"type": "dynamic_ip_and_port", "translated_address": ["10.0.0.1"]}}'
+
+    """
+    try:
+        # Parse JSON strings for translation configs
+        src_translation = json.loads(source_translation) if source_translation else None
+        dst_translation = json.loads(destination_translation) if destination_translation else None
+
+        result = scm_client.create_nat_rule(
+            folder=folder,
+            name=name,
+            description=description,
+            tag=tag,
+            disabled=disabled,
+            nat_type=nat_type,
+            from_zones=from_zone or ["any"],
+            to_zones=to_zone or ["any"],
+            to_interface=to_interface,
+            source=source or ["any"],
+            destination=destination or ["any"],
+            service=service,
+            source_translation=src_translation,
+            destination_translation=dst_translation,
+        )
+
+        action = result.pop("__action__", "created")
+
+        if action == "created":
+            typer.echo(f"Created NAT rule: {result['name']} in folder {folder}")
+        elif action == "updated":
+            typer.echo(f"Updated NAT rule: {result['name']} in folder {folder}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for NAT rule: {result['name']} in folder {folder}")
+
+        return result
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating NAT rule: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("nat-rule")
+def show_nat_rule(
+    folder: str = NAT_FOLDER_OPTION,
+    name: str | None = typer.Option(None, "--name", help="Name of the NAT rule to show"),
+):
+    """Display NAT rules.
+
+    Example:
+    -------
+        # List all NAT rules in a folder
+        scm show network nat-rule --folder Texas
+
+        # Show a specific NAT rule by name
+        scm show network nat-rule --folder Texas --name outbound-nat
+
+    """
+    try:
+        if name:
+            rule = scm_client.get_nat_rule(folder=folder, name=name)
+
+            typer.echo(f"\nNAT Rule: {rule.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+
+            if rule.get("folder"):
+                typer.echo(f"Location: Folder '{rule['folder']}'")
+            elif rule.get("snippet"):
+                typer.echo(f"Location: Snippet '{rule['snippet']}'")
+            elif rule.get("device"):
+                typer.echo(f"Location: Device '{rule['device']}'")
+
+            if rule.get("description"):
+                typer.echo(f"Description: {rule['description']}")
+            typer.echo(f"NAT Type: {rule.get('nat_type', 'ipv4')}")
+            typer.echo(f"From: {', '.join(rule.get('from_', ['any']))}")
+            typer.echo(f"To: {', '.join(rule.get('to_', ['any']))}")
+            typer.echo(f"Source: {', '.join(rule.get('source', ['any']))}")
+            typer.echo(f"Destination: {', '.join(rule.get('destination', ['any']))}")
+            typer.echo(f"Service: {rule.get('service', 'any')}")
+
+            if rule.get("source_translation"):
+                typer.echo(f"Source Translation: {json.dumps(rule['source_translation'], indent=2)}")
+            if rule.get("destination_translation"):
+                typer.echo(f"Destination Translation: {json.dumps(rule['destination_translation'], indent=2)}")
+            if rule.get("disabled"):
+                typer.echo("Status: Disabled")
+            if rule.get("tag"):
+                typer.echo(f"Tags: {', '.join(rule['tag'])}")
+            if rule.get("id"):
+                typer.echo(f"ID: {rule['id']}")
+
+            return rule
+
+        else:
+            rules = scm_client.list_nat_rules(folder=folder)
+
+            if not rules:
+                typer.echo(f"No NAT rules found in folder '{folder}'")
+                return None
+
+            typer.echo(f"\nNAT Rules in folder '{folder}':")
+            typer.echo("=" * 80)
+
+            for rule in rules:
+                typer.echo(f"Name: {rule.get('name', 'N/A')}")
+
+                if rule.get("folder"):
+                    typer.echo(f"  Location: Folder '{rule['folder']}'")
+                elif rule.get("snippet"):
+                    typer.echo(f"  Location: Snippet '{rule['snippet']}'")
+                elif rule.get("device"):
+                    typer.echo(f"  Location: Device '{rule['device']}'")
+
+                if rule.get("description"):
+                    typer.echo(f"  Description: {rule['description']}")
+                typer.echo(f"  NAT Type: {rule.get('nat_type', 'ipv4')}")
+                typer.echo(f"  From: {', '.join(rule.get('from_', ['any']))}")
+                typer.echo(f"  To: {', '.join(rule.get('to_', ['any']))}")
+                typer.echo(f"  Source: {', '.join(rule.get('source', ['any']))}")
+                typer.echo(f"  Destination: {', '.join(rule.get('destination', ['any']))}")
+                typer.echo(f"  Service: {rule.get('service', 'any')}")
+
+                if rule.get("source_translation"):
+                    typer.echo(f"  Source Translation: {json.dumps(rule['source_translation'])}")
+                if rule.get("destination_translation"):
+                    typer.echo(f"  Destination Translation: {json.dumps(rule['destination_translation'])}")
+                if rule.get("disabled"):
+                    typer.echo("  Status: Disabled")
+                if rule.get("tag"):
+                    typer.echo(f"  Tags: {', '.join(rule['tag'])}")
+                if rule.get("id"):
+                    typer.echo(f"  ID: {rule['id']}")
+
+                typer.echo("-" * 80)
+
+            return rules
+
+    except Exception as e:
+        typer.echo(f"Error showing NAT rule: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -13,7 +13,7 @@ import typer
 import yaml
 
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AntiSpywareProfile, DecryptionProfile, DNSSecurityProfile, SecurityRule, WildfireAntivirusProfile
+from ..utils.validators import AntiSpywareProfile, DecryptionProfile, DNSSecurityProfile, SecurityRule, VulnerabilityProtectionProfile, WildfireAntivirusProfile
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -2755,4 +2755,476 @@ def show_dns_security_profile(
 
     except Exception as e:
         typer.echo(f"Error showing DNS security profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# VULNERABILITY PROTECTION PROFILE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("vulnerability-protection-profile")
+def backup_vulnerability_protection_profile(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: str = BACKUP_FILE_OPTION,
+):
+    """Backup all vulnerability protection profiles from a container to a YAML file.
+
+    Examples:
+        # Backup from folder
+        scm backup security vulnerability-protection-profile --folder Austin
+
+        # Backup from snippet
+        scm backup security vulnerability-protection-profile --snippet Security-Best-Practice
+
+        # Backup from device
+        scm backup security vulnerability-protection-profile --device austin-01
+
+        # Backup to custom filename
+        scm backup security vulnerability-protection-profile --folder Austin --file my-profiles.yaml
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    # Set default filename if not provided
+    if not file:
+        file = get_default_backup_filename("vulnerability-protection-profiles", location_type, location_value)
+
+    try:
+        # List all vulnerability protection profiles with exact_match=True using kwargs pattern
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_vulnerability_protection_profiles(**kwargs, exact_match=True)
+
+        if not profiles:
+            typer.echo(f"No vulnerability protection profiles found in {location_type} '{location_value}'")
+            return
+
+        # Convert SDK models to dictionaries, excluding unset values
+        backup_data = []
+        for profile in profiles:
+            # The list method already returns dicts with exclude_unset=True
+            profile_dict = profile.copy()
+            # Remove system fields that shouldn't be in backup
+            profile_dict.pop("id", None)
+
+            backup_data.append(profile_dict)
+
+        # Create the YAML structure
+        yaml_data = {"vulnerability_protection_profiles": backup_data}
+
+        # Write to YAML file
+        with open(file, "w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} vulnerability protection profiles to {file}")
+        return file
+
+    except Exception as e:
+        typer.echo(f"Error backing up vulnerability protection profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("vulnerability-protection-profile")
+def delete_vulnerability_protection_profile(
+    folder: str = typer.Option(None, "--folder", help="Folder containing the vulnerability protection profile"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet containing the vulnerability protection profile"),
+    device: str = typer.Option(None, "--device", help="Device containing the vulnerability protection profile"),
+    name: str = NAME_OPTION,
+):
+    """Delete a vulnerability protection profile.
+
+    Examples:
+        # Delete from folder
+        scm delete security vulnerability-protection-profile --folder Texas --name strict-vuln
+
+        # Delete from snippet
+        scm delete security vulnerability-protection-profile --snippet Security-Best-Practice --name vuln-protection
+
+        # Delete from device
+        scm delete security vulnerability-protection-profile --device austin-01 --name local-profile
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        kwargs = {location_type: location_value}
+        result = scm_client.delete_vulnerability_protection_profile(**kwargs, name=name)
+        if result:
+            typer.echo(f"Deleted vulnerability protection profile: {name} from {location_type} {location_value}")
+        else:
+            typer.echo(
+                f"Vulnerability protection profile not found: {name} in {location_type} {location_value}",
+                err=True,
+            )
+            raise typer.Exit(code=1) from Exception
+    except Exception as e:
+        typer.echo(f"Error deleting vulnerability protection profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("vulnerability-protection-profile", help="Load vulnerability protection profiles from a YAML file.")
+def load_vulnerability_protection_profile(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+    snippet: str = LOAD_SNIPPET_OPTION,
+    device: str = LOAD_DEVICE_OPTION,
+):
+    """Load vulnerability protection profiles from a YAML file.
+
+    Examples:
+        # Load from file with original locations
+        scm load security vulnerability-protection-profile --file config/vuln_profiles.yml
+
+        # Load with folder override
+        scm load security vulnerability-protection-profile --file config/vuln_profiles.yml --folder Production
+
+        # Load with snippet override
+        scm load security vulnerability-protection-profile --file config/vuln_profiles.yml --snippet Security-Best-Practice
+
+        # Dry run to preview changes
+        scm load security vulnerability-protection-profile --file config/vuln_profiles.yml --dry-run
+
+    """
+    try:
+        # Validate container override parameters
+        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+            typer.echo(
+                "Error: Only one of --folder, --snippet, or --device can be specified",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        # Validate file exists
+        if not file.exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+
+        # Load YAML data using the same pattern as other commands
+        with open(file) as f:
+            raw_data = yaml.safe_load(f)
+
+        if not raw_data or "vulnerability_protection_profiles" not in raw_data:
+            typer.echo("No vulnerability protection profiles found in file", err=True)
+            raise typer.Exit(code=1)
+
+        profiles = raw_data["vulnerability_protection_profiles"]
+        if not isinstance(profiles, list):
+            profiles = [profiles]
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            # Show override information if applicable
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(profiles))
+            return []
+
+        # Apply each vulnerability protection profile
+        results = []
+        created_count = 0
+        updated_count = 0
+
+        for profile_data in profiles:
+            try:
+                # Apply container override if specified
+                if folder:
+                    profile_data["folder"] = folder
+                    profile_data.pop("snippet", None)
+                    profile_data.pop("device", None)
+                elif snippet:
+                    profile_data["snippet"] = snippet
+                    profile_data.pop("folder", None)
+                    profile_data.pop("device", None)
+                elif device:
+                    profile_data["device"] = device
+                    profile_data.pop("folder", None)
+                    profile_data.pop("snippet", None)
+
+                # Validate using the Pydantic model
+                profile = VulnerabilityProtectionProfile(**profile_data)
+
+                # Call the SDK client to create the vulnerability protection profile
+                sdk_data = profile.to_sdk_model()
+
+                # Extract container params
+                container_kwargs = {}
+                if sdk_data.get("folder"):
+                    container_kwargs["folder"] = sdk_data.pop("folder")
+                elif sdk_data.get("snippet"):
+                    container_kwargs["snippet"] = sdk_data.pop("snippet")
+                elif sdk_data.get("device"):
+                    container_kwargs["device"] = sdk_data.pop("device")
+
+                result = scm_client.create_vulnerability_protection_profile(**container_kwargs, **sdk_data)
+
+                results.append(result)
+
+                # Track if created or updated based on response
+                if "created" in str(result).lower():
+                    created_count += 1
+                else:
+                    updated_count += 1
+
+            except Exception as e:
+                typer.echo(
+                    f"Error processing vulnerability protection profile '{profile_data.get('name', 'unknown')}': {str(e)}",
+                    err=True,
+                )
+                # Continue processing other profiles
+                continue
+
+        # Display summary with counts
+        typer.echo(f"Successfully processed {len(results)} vulnerability protection profile(s):")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+
+        return results
+
+    except Exception as e:
+        typer.echo(f"Error loading vulnerability protection profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("vulnerability-protection-profile")
+def set_vulnerability_protection_profile(
+    folder: str = typer.Option(None, "--folder", help="Folder path for the vulnerability protection profile"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet path for the vulnerability protection profile"),
+    device: str = typer.Option(None, "--device", help="Device path for the vulnerability protection profile"),
+    name: str = NAME_OPTION,
+    description: str | None = DESCRIPTION_OPTION,
+    block_critical_high: bool = typer.Option(
+        False,
+        "--block-critical-high",
+        help="Add default rule to block critical and high severity vulnerabilities",
+    ),
+):
+    r"""Create or update a vulnerability protection profile.
+
+    Examples:
+        # Create basic profile in folder
+        scm set security vulnerability-protection-profile --folder Texas --name strict-vuln \
+            --description "Block critical vulnerabilities"
+
+        # Create profile with block critical/high rule
+        scm set security vulnerability-protection-profile --folder Texas --name vuln-protection \
+            --block-critical-high
+
+        # Create profile in snippet
+        scm set security vulnerability-protection-profile --snippet Security-Best-Practice \
+            --name standard-vuln
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        # Validate and create vulnerability protection profile
+        profile_data: dict[str, Any] = {
+            location_type: location_value,
+            "name": name,
+        }
+
+        if description:
+            profile_data["description"] = description
+
+        # Add a default rule if requested or if no rules specified
+        if block_critical_high:
+            profile_data["rules"] = [
+                {
+                    "name": "Block Critical and High",
+                    "severity": ["critical", "high"],
+                    "category": "any",
+                    "host": "any",
+                    "action": {"alert": {}},
+                    "packet_capture": "single-packet",
+                }
+            ]
+        else:
+            # Add a minimal default rule to satisfy SDK requirements
+            profile_data["rules"] = [
+                {
+                    "name": "simple-critical",
+                    "severity": ["critical"],
+                    "category": "any",
+                    "host": "any",
+                    "action": {"default": {}},
+                }
+            ]
+
+        # VulnerabilityProtectionProfile expects specific field types
+        typed_profile_data = profile_data.copy()
+        profile = VulnerabilityProtectionProfile(**typed_profile_data)
+
+        # Call SDK client to create the profile
+        sdk_data = profile.to_sdk_model()
+
+        # Extract container params
+        container_kwargs = {}
+        if sdk_data.get("folder"):
+            container_kwargs["folder"] = sdk_data.pop("folder")
+        elif sdk_data.get("snippet"):
+            container_kwargs["snippet"] = sdk_data.pop("snippet")
+        elif sdk_data.get("device"):
+            container_kwargs["device"] = sdk_data.pop("device")
+
+        result = scm_client.create_vulnerability_protection_profile(**container_kwargs, **sdk_data)
+
+        # Format and display output
+        typer.echo(f"Created vulnerability protection profile: {result['name']} in {location_type} {location_value}")
+
+    except Exception as e:
+        typer.echo(f"Error creating vulnerability protection profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("vulnerability-protection-profile")
+def show_vulnerability_protection_profile(
+    folder: str = typer.Option(None, "--folder", help="Folder containing the vulnerability protection profile"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet containing the vulnerability protection profile"),
+    device: str = typer.Option(None, "--device", help="Device containing the vulnerability protection profile"),
+    name: str | None = typer.Option(None, "--name", help="Name of the vulnerability protection profile to show"),
+):
+    """Display vulnerability protection profiles.
+
+    Examples:
+        # List all vulnerability protection profiles in a folder (default behavior)
+        scm show security vulnerability-protection-profile --folder Texas
+
+        # Show a specific vulnerability protection profile by name
+        scm show security vulnerability-protection-profile --folder Texas --name strict-vuln
+
+        # List profiles in snippet
+        scm show security vulnerability-protection-profile --snippet Security-Best-Practice
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        if name:
+            # Get a specific vulnerability protection profile by name
+            kwargs = {location_type: location_value}
+            profile = scm_client.get_vulnerability_protection_profile(**kwargs, name=name)
+
+            typer.echo(f"\nVulnerability Protection Profile: {profile.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+
+            # Display container location (folder, snippet, or device)
+            if profile.get("folder"):
+                typer.echo(f"Location: Folder '{profile['folder']}'")
+            elif profile.get("snippet"):
+                typer.echo(f"Location: Snippet '{profile['snippet']}'")
+            elif profile.get("device"):
+                typer.echo(f"Location: Device '{profile['device']}'")
+
+            # Display description if present
+            if profile.get("description"):
+                typer.echo(f"Description: {profile['description']}")
+
+            # Display rules in detail
+            if profile.get("rules"):
+                typer.echo(f"\nRules ({len(profile['rules'])}):")
+                for idx, rule in enumerate(profile["rules"], 1):
+                    typer.echo(f"  Rule {idx}: {rule.get('name', 'Unnamed')}")
+                    if rule.get("severity"):
+                        severity = rule["severity"] if isinstance(rule["severity"], list) else [rule["severity"]]
+                        typer.echo(f"    Severity: {', '.join(severity)}")
+                    typer.echo(f"    Action: {rule.get('action', 'N/A')}")
+                    if rule.get("category"):
+                        typer.echo(f"    Category: {rule['category']}")
+                    if rule.get("host"):
+                        typer.echo(f"    Host: {rule['host']}")
+                    if rule.get("threat_name"):
+                        typer.echo(f"    Threat Name: {rule['threat_name']}")
+                    if rule.get("packet_capture"):
+                        typer.echo(f"    Packet Capture: {rule['packet_capture']}")
+                    if rule.get("cve"):
+                        typer.echo(f"    CVE: {', '.join(rule['cve'])}")
+                    if rule.get("vendor_id") or rule.get("vendor-id"):
+                        vendor_ids = rule.get("vendor_id") or rule.get("vendor-id")
+                        typer.echo(f"    Vendor ID: {', '.join(vendor_ids)}")
+
+            # Display threat exceptions in detail
+            if profile.get("threat_exception"):
+                typer.echo(f"\nThreat Exceptions ({len(profile['threat_exception'])}):")
+                for idx, exception in enumerate(profile["threat_exception"], 1):
+                    typer.echo(f"  Exception {idx}:")
+                    if exception.get("name"):
+                        typer.echo(f"    Name: {exception['name']}")
+                    if exception.get("packet_capture"):
+                        typer.echo(f"    Packet Capture: {exception['packet_capture']}")
+                    if exception.get("action"):
+                        typer.echo(f"    Action: {exception['action']}")
+                    if exception.get("exempt_ip"):
+                        ips = [ip.get("name", str(ip)) if isinstance(ip, dict) else str(ip) for ip in exception["exempt_ip"]]
+                        typer.echo(f"    Exempt IPs: {', '.join(ips)}")
+                    if exception.get("notes"):
+                        typer.echo(f"    Notes: {exception['notes']}")
+                    if exception.get("time_attribute"):
+                        ta = exception["time_attribute"]
+                        typer.echo(f"    Time Attribute: interval={ta.get('interval')}, threshold={ta.get('threshold')}, track_by={ta.get('track_by')}")
+
+            # Display ID if present
+            if profile.get("id"):
+                typer.echo(f"\nID: {profile['id']}")
+
+            return profile
+
+        else:
+            # Default behavior: list all
+            kwargs = {location_type: location_value}
+            profiles = scm_client.list_vulnerability_protection_profiles(**kwargs, exact_match=False)
+
+            if not profiles:
+                typer.echo(f"No vulnerability protection profiles found in {location_type} '{location_value}'")
+                return
+
+            typer.echo(f"\nVulnerability Protection Profiles in {location_type} '{location_value}':")
+            typer.echo("=" * 80)
+
+            for profile in profiles:
+                # Display profile information
+                typer.echo(f"Name: {profile.get('name', 'N/A')}")
+
+                # Display container location (folder, snippet, or device)
+                if profile.get("folder"):
+                    typer.echo(f"  Location: Folder '{profile['folder']}'")
+                elif profile.get("snippet"):
+                    typer.echo(f"  Location: Snippet '{profile['snippet']}'")
+                elif profile.get("device"):
+                    typer.echo(f"  Location: Device '{profile['device']}'")
+
+                # Display description if present
+                if profile.get("description"):
+                    typer.echo(f"  Description: {profile['description']}")
+
+                # Display rules if present
+                if profile.get("rules"):
+                    typer.echo(f"  Rules: {len(profile['rules'])} configured")
+                    for rule in profile["rules"]:
+                        typer.echo(f"    - {rule.get('name', 'Unnamed')}: {rule.get('action', 'N/A')}")
+
+                # Display threat exceptions if present
+                if profile.get("threat_exception"):
+                    typer.echo(f"  Threat Exceptions: {len(profile['threat_exception'])}")
+
+                # Display ID if present
+                if profile.get("id"):
+                    typer.echo(f"  ID: {profile['id']}")
+
+                typer.echo("-" * 80)
+
+            return profiles
+
+    except Exception as e:
+        typer.echo(f"Error showing vulnerability protection profile: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -13,7 +13,7 @@ import typer
 import yaml
 
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AntiSpywareProfile, DecryptionProfile, SecurityRule, WildfireAntivirusProfile
+from ..utils.validators import AntiSpywareProfile, DecryptionProfile, DNSSecurityProfile, SecurityRule, WildfireAntivirusProfile
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -2291,4 +2291,468 @@ def show_wildfire_antivirus_profile(
 
     except Exception as e:
         typer.echo(f"Error showing WildFire antivirus profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# DNS SECURITY PROFILE COMMANDS
+# ========================================================================================================================================================================================
+
+# Module-level option constants for dns-security-profile list types (avoids B008 lint errors)
+DNS_SEC_FOLDER_OPTION = typer.Option(None, "--folder", help="Folder containing the DNS security profile")
+DNS_SEC_SNIPPET_OPTION = typer.Option(None, "--snippet", help="Snippet containing the DNS security profile")
+DNS_SEC_DEVICE_OPTION = typer.Option(None, "--device", help="Device containing the DNS security profile")
+
+
+@backup_app.command("dns-security-profile")
+def backup_dns_security_profile(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: str = BACKUP_FILE_OPTION,
+):
+    """Backup all DNS security profiles from a container to a YAML file.
+
+    Examples:
+        # Backup from folder
+        scm backup security dns-security-profile --folder Austin
+
+        # Backup from snippet
+        scm backup security dns-security-profile --snippet DNS-Best-Practice
+
+        # Backup to custom filename
+        scm backup security dns-security-profile --folder Austin --file my-dns-profiles.yaml
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    # Set default filename if not provided
+    if not file:
+        file = get_default_backup_filename("dns-security-profiles", location_type, location_value)
+
+    try:
+        # List all DNS security profiles with exact_match=True using kwargs pattern
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_dns_security_profiles(**kwargs, exact_match=True)
+
+        if not profiles:
+            typer.echo(f"No DNS security profiles found in {location_type} '{location_value}'")
+            return
+
+        # Convert SDK models to dictionaries, excluding unset values
+        backup_data = []
+        for profile in profiles:
+            # The list method already returns dicts with exclude_unset=True
+            profile_dict = profile.copy()
+            # Remove system fields that shouldn't be in backup
+            profile_dict.pop("id", None)
+
+            backup_data.append(profile_dict)
+
+        # Create the YAML structure
+        yaml_data = {"dns_security_profiles": backup_data}
+
+        # Write to YAML file
+        with open(file, "w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} DNS security profiles to {file}")
+        return file
+
+    except Exception as e:
+        typer.echo(f"Error backing up DNS security profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("dns-security-profile")
+def delete_dns_security_profile(
+    folder: str = DNS_SEC_FOLDER_OPTION,
+    snippet: str = DNS_SEC_SNIPPET_OPTION,
+    device: str = DNS_SEC_DEVICE_OPTION,
+    name: str = NAME_OPTION,
+):
+    """Delete a DNS security profile.
+
+    Examples:
+        # Delete from folder
+        scm delete security dns-security-profile --folder Texas --name dns-sec-default
+
+        # Delete from snippet
+        scm delete security dns-security-profile --snippet DNS-Best-Practice --name dns-sec-strict
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        kwargs = {location_type: location_value}
+        result = scm_client.delete_dns_security_profile(**kwargs, name=name)
+        if result:
+            typer.echo(f"Deleted DNS security profile: {name} from {location_type} {location_value}")
+        else:
+            typer.echo(
+                f"DNS security profile not found: {name} in {location_type} {location_value}",
+                err=True,
+            )
+            raise typer.Exit(code=1) from Exception
+    except Exception as e:
+        typer.echo(f"Error deleting DNS security profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("dns-security-profile", help="Load DNS security profiles from a YAML file.")
+def load_dns_security_profile(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+    snippet: str = LOAD_SNIPPET_OPTION,
+    device: str = LOAD_DEVICE_OPTION,
+):
+    """Load DNS security profiles from a YAML file.
+
+    Examples:
+        # Load from file with original locations
+        scm load security dns-security-profile --file config/dns_security_profiles.yml
+
+        # Load with folder override
+        scm load security dns-security-profile --file config/dns_security_profiles.yml --folder Production
+
+        # Dry run to preview changes
+        scm load security dns-security-profile --file config/dns_security_profiles.yml --dry-run
+
+    """
+    try:
+        # Validate container override parameters
+        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+            typer.echo(
+                "Error: Only one of --folder, --snippet, or --device can be specified",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        # Validate file exists
+        if not file.exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+
+        # Load YAML data using the same pattern as other commands
+        with open(file) as f:
+            raw_data = yaml.safe_load(f)
+
+        if not raw_data or "dns_security_profiles" not in raw_data:
+            typer.echo("No DNS security profiles found in file", err=True)
+            raise typer.Exit(code=1)
+
+        profiles = raw_data["dns_security_profiles"]
+        if not isinstance(profiles, list):
+            profiles = [profiles]
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            # Show override information if applicable
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(profiles))
+            return []
+
+        # Apply each DNS security profile
+        results = []
+        created_count = 0
+        updated_count = 0
+
+        for profile_data in profiles:
+            try:
+                # Apply container override if specified
+                if folder:
+                    profile_data["folder"] = folder
+                    profile_data.pop("snippet", None)
+                    profile_data.pop("device", None)
+                elif snippet:
+                    profile_data["snippet"] = snippet
+                    profile_data.pop("folder", None)
+                    profile_data.pop("device", None)
+                elif device:
+                    profile_data["device"] = device
+                    profile_data.pop("folder", None)
+                    profile_data.pop("snippet", None)
+
+                # Validate using the Pydantic model
+                profile = DNSSecurityProfile(**profile_data)
+
+                # Call the SDK client to create the DNS security profile
+                sdk_data = profile.to_sdk_model()
+
+                # Extract container params
+                container_kwargs = {}
+                if sdk_data.get("folder"):
+                    container_kwargs["folder"] = sdk_data.pop("folder")
+                elif sdk_data.get("snippet"):
+                    container_kwargs["snippet"] = sdk_data.pop("snippet")
+                elif sdk_data.get("device"):
+                    container_kwargs["device"] = sdk_data.pop("device")
+
+                result = scm_client.create_dns_security_profile(**container_kwargs, **sdk_data)
+
+                results.append(result)
+
+                # Track if created or updated based on __action__ field
+                action = result.get("__action__", "")
+                if action == "created":
+                    created_count += 1
+                elif action == "updated":
+                    updated_count += 1
+
+            except Exception as e:
+                typer.echo(
+                    f"Error processing DNS security profile '{profile_data.get('name', 'unknown')}': {str(e)}",
+                    err=True,
+                )
+                # Continue processing other profiles
+                continue
+
+        # Display summary with counts
+        typer.echo(f"Successfully processed {len(results)} DNS security profile(s):")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+
+        return results
+
+    except Exception as e:
+        typer.echo(f"Error loading DNS security profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("dns-security-profile")
+def set_dns_security_profile(
+    folder: str = typer.Option(None, "--folder", help="Folder path for the DNS security profile"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet path for the DNS security profile"),
+    device: str = typer.Option(None, "--device", help="Device path for the DNS security profile"),
+    name: str = NAME_OPTION,
+    description: str | None = typer.Option(
+        None,
+        "--description",
+        help="Description of the DNS security profile",
+    ),
+    botnet_domains: str | None = typer.Option(
+        None,
+        "--botnet-domains",
+        help="Botnet domains settings as JSON string",
+    ),
+):
+    r"""Create or update a DNS security profile.
+
+    Examples:
+        # Create basic DNS security profile with sinkhole
+        scm set security dns-security-profile --folder Texas --name dns-sec-default \
+            --botnet-domains '{"dns_security_categories": [{"name": "pan-dns-sec-malware", "action": "sinkhole"}]}'
+
+        # Create profile with whitelist
+        scm set security dns-security-profile --folder Texas --name dns-sec-custom \
+            --botnet-domains '{"whitelist": [{"name": "example.com"}]}'
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        # Build profile data
+        profile_data: dict[str, Any] = {
+            location_type: location_value,
+            "name": name,
+        }
+
+        # Add optional description
+        if description:
+            profile_data["description"] = description
+
+        # Parse JSON string for botnet domains
+        if botnet_domains:
+            profile_data["botnet_domains"] = json.loads(botnet_domains)
+
+        # Validate using the Pydantic model
+        profile = DNSSecurityProfile(**profile_data)
+
+        # Call SDK client to create the profile
+        sdk_data = profile.to_sdk_model()
+
+        # Extract container params
+        container_kwargs = {}
+        if sdk_data.get("folder"):
+            container_kwargs["folder"] = sdk_data.pop("folder")
+        elif sdk_data.get("snippet"):
+            container_kwargs["snippet"] = sdk_data.pop("snippet")
+        elif sdk_data.get("device"):
+            container_kwargs["device"] = sdk_data.pop("device")
+
+        result = scm_client.create_dns_security_profile(**container_kwargs, **sdk_data)
+
+        # Format and display output based on action
+        action = result.get("__action__", "created")
+        if action == "updated":
+            typer.echo(f"Updated DNS security profile: {result['name']} in {location_type} {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes to DNS security profile: {result['name']} in {location_type} {location_value}")
+        else:
+            typer.echo(f"Created DNS security profile: {result['name']} in {location_type} {location_value}")
+
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON settings: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating DNS security profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("dns-security-profile")
+def show_dns_security_profile(
+    folder: str = DNS_SEC_FOLDER_OPTION,
+    snippet: str = DNS_SEC_SNIPPET_OPTION,
+    device: str = DNS_SEC_DEVICE_OPTION,
+    name: str | None = typer.Option(None, "--name", help="Name of the DNS security profile to show"),
+):
+    """Display DNS security profiles.
+
+    Examples:
+        # List all DNS security profiles in a folder (default behavior)
+        scm show security dns-security-profile --folder Texas
+
+        # Show a specific DNS security profile by name
+        scm show security dns-security-profile --folder Texas --name dns-sec-default
+
+        # List profiles in snippet
+        scm show security dns-security-profile --snippet Security-Best-Practice
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        if name:
+            # Get a specific DNS security profile by name
+            kwargs = {location_type: location_value}
+            profile = scm_client.get_dns_security_profile(**kwargs, name=name)
+
+            typer.echo(f"\nDNS Security Profile: {profile.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+
+            # Display container location (folder, snippet, or device)
+            if profile.get("folder"):
+                typer.echo(f"Location: Folder '{profile['folder']}'")
+            elif profile.get("snippet"):
+                typer.echo(f"Location: Snippet '{profile['snippet']}'")
+            elif profile.get("device"):
+                typer.echo(f"Location: Device '{profile['device']}'")
+
+            # Display description if present
+            if profile.get("description"):
+                typer.echo(f"Description: {profile['description']}")
+
+            # Display botnet domains settings
+            botnet = profile.get("botnet_domains")
+            if botnet:
+                # Display DNS security categories
+                categories = botnet.get("dns_security_categories")
+                if categories:
+                    typer.echo("\nDNS Security Categories:")
+                    for cat in categories:
+                        typer.echo(f"  Name: {cat.get('name', 'N/A')}")
+                        typer.echo(f"    Action: {cat.get('action', 'N/A')}")
+                        if cat.get("log_level"):
+                            typer.echo(f"    Log Level: {cat['log_level']}")
+                        if cat.get("packet_capture"):
+                            typer.echo(f"    Packet Capture: {cat['packet_capture']}")
+
+                # Display lists
+                lists = botnet.get("lists")
+                if lists:
+                    typer.echo("\nDNS Lists:")
+                    for lst in lists:
+                        typer.echo(f"  Name: {lst.get('name', 'N/A')}")
+                        if lst.get("action"):
+                            typer.echo(f"    Action: {lst['action']}")
+                        if lst.get("packet_capture"):
+                            typer.echo(f"    Packet Capture: {lst['packet_capture']}")
+
+                # Display sinkhole settings
+                sinkhole = botnet.get("sinkhole")
+                if sinkhole:
+                    typer.echo("\nSinkhole Settings:")
+                    typer.echo(f"  IPv4 Address: {sinkhole.get('ipv4_address', 'N/A')}")
+                    typer.echo(f"  IPv6 Address: {sinkhole.get('ipv6_address', 'N/A')}")
+
+                # Display whitelist
+                whitelist = botnet.get("whitelist")
+                if whitelist:
+                    typer.echo("\nWhitelist:")
+                    for entry in whitelist:
+                        typer.echo(f"  Domain: {entry.get('name', 'N/A')}")
+                        if entry.get("description"):
+                            typer.echo(f"    Description: {entry['description']}")
+
+            # Display ID if present
+            if profile.get("id"):
+                typer.echo(f"\nID: {profile['id']}")
+
+            return profile
+
+        else:
+            # Default behavior: list all
+            kwargs = {location_type: location_value}
+            profiles = scm_client.list_dns_security_profiles(**kwargs, exact_match=False)
+
+            if not profiles:
+                typer.echo(f"No DNS security profiles found in {location_type} '{location_value}'")
+                return
+
+            typer.echo(f"\nDNS Security Profiles in {location_type} '{location_value}':")
+            typer.echo("=" * 80)
+
+            for profile in profiles:
+                # Display profile information
+                typer.echo(f"Name: {profile.get('name', 'N/A')}")
+
+                # Display container location (folder, snippet, or device)
+                if profile.get("folder"):
+                    typer.echo(f"  Location: Folder '{profile['folder']}'")
+                elif profile.get("snippet"):
+                    typer.echo(f"  Location: Snippet '{profile['snippet']}'")
+                elif profile.get("device"):
+                    typer.echo(f"  Location: Device '{profile['device']}'")
+
+                # Display description if present
+                if profile.get("description"):
+                    typer.echo(f"  Description: {profile['description']}")
+
+                # Display DNS security categories count
+                botnet = profile.get("botnet_domains")
+                if botnet:
+                    categories = botnet.get("dns_security_categories")
+                    if categories:
+                        typer.echo(f"  DNS Security Categories: {len(categories)}")
+
+                    # Show sinkhole config
+                    if botnet.get("sinkhole"):
+                        sinkhole = botnet["sinkhole"]
+                        typer.echo(f"  Sinkhole: IPv4={sinkhole.get('ipv4_address', 'N/A')}, IPv6={sinkhole.get('ipv6_address', 'N/A')}")
+
+                    # Show whitelist count
+                    whitelist = botnet.get("whitelist")
+                    if whitelist:
+                        typer.echo(f"  Whitelist Entries: {len(whitelist)}")
+
+                # Display ID if present
+                if profile.get("id"):
+                    typer.echo(f"  ID: {profile['id']}")
+
+                typer.echo("-" * 80)
+
+            return profiles
+
+    except Exception as e:
+        typer.echo(f"Error showing DNS security profile: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -13,7 +13,7 @@ import typer
 import yaml
 
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AntiSpywareProfile, DecryptionProfile, DNSSecurityProfile, SecurityRule, VulnerabilityProtectionProfile, WildfireAntivirusProfile
+from ..utils.validators import AntiSpywareProfile, DecryptionProfile, DNSSecurityProfile, SecurityRule, URLCategory, VulnerabilityProtectionProfile, WildfireAntivirusProfile
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -3227,4 +3227,420 @@ def show_vulnerability_protection_profile(
 
     except Exception as e:
         typer.echo(f"Error showing vulnerability protection profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# URL CATEGORY COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("url-category")
+def backup_url_category(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: str = BACKUP_FILE_OPTION,
+):
+    """Backup all URL categories from a container to a YAML file.
+
+    Examples:
+        # Backup from folder
+        scm backup security url-category --folder Austin
+
+        # Backup from snippet
+        scm backup security url-category --snippet DNS-Best-Practice
+
+        # Backup from device
+        scm backup security url-category --device austin-01
+
+        # Backup to custom filename
+        scm backup security url-category --folder Austin --file my-url-categories.yaml
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    # Set default filename if not provided
+    if not file:
+        file = get_default_backup_filename("url-categories", location_type, location_value)
+
+    try:
+        # List all URL categories with exact_match=True using kwargs pattern
+        kwargs = {location_type: location_value}
+        categories = scm_client.list_url_categories(**kwargs, exact_match=True)
+
+        if not categories:
+            typer.echo(f"No URL categories found in {location_type} '{location_value}'")
+            return
+
+        # Convert SDK models to dictionaries, excluding unset values
+        backup_data = []
+        for category in categories:
+            category_dict = category.copy()
+            # Remove system fields that shouldn't be in backup
+            category_dict.pop("id", None)
+
+            backup_data.append(category_dict)
+
+        # Create the YAML structure
+        yaml_data = {"url_categories": backup_data}
+
+        # Write to YAML file
+        with open(file, "w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} URL categories to {file}")
+        return file
+
+    except Exception as e:
+        typer.echo(f"Error backing up URL categories: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("url-category")
+def delete_url_category(
+    folder: str = typer.Option(None, "--folder", help="Folder containing the URL category"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet containing the URL category"),
+    device: str = typer.Option(None, "--device", help="Device containing the URL category"),
+    name: str = NAME_OPTION,
+):
+    """Delete a URL category.
+
+    Examples:
+        # Delete from folder
+        scm delete security url-category --folder Texas --name custom-block-list
+
+        # Delete from snippet
+        scm delete security url-category --snippet DNS-Best-Practice --name phishing-urls
+
+        # Delete from device
+        scm delete security url-category --device austin-01 --name local-blocklist
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        kwargs = {location_type: location_value}
+        result = scm_client.delete_url_category(**kwargs, name=name)
+        if result:
+            typer.echo(f"Deleted URL category: {name} from {location_type} {location_value}")
+        else:
+            typer.echo(
+                f"URL category not found: {name} in {location_type} {location_value}",
+                err=True,
+            )
+            raise typer.Exit(code=1) from Exception
+    except Exception as e:
+        typer.echo(f"Error deleting URL category: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("url-category", help="Load URL categories from a YAML file.")
+def load_url_category(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+    snippet: str = LOAD_SNIPPET_OPTION,
+    device: str = LOAD_DEVICE_OPTION,
+):
+    """Load URL categories from a YAML file.
+
+    Examples:
+        # Load from file with original locations
+        scm load security url-category --file config/url_categories.yml
+
+        # Load with folder override
+        scm load security url-category --file config/url_categories.yml --folder Production
+
+        # Load with snippet override
+        scm load security url-category --file config/url_categories.yml --snippet Security-Best-Practice
+
+        # Dry run to preview changes
+        scm load security url-category --file config/url_categories.yml --dry-run
+
+    """
+    try:
+        # Validate container override parameters
+        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+            typer.echo(
+                "Error: Only one of --folder, --snippet, or --device can be specified",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        # Validate file exists
+        if not file.exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+
+        # Load YAML data using the same pattern as other commands
+        with open(file) as f:
+            raw_data = yaml.safe_load(f)
+
+        if not raw_data or "url_categories" not in raw_data:
+            typer.echo("No URL categories found in file", err=True)
+            raise typer.Exit(code=1)
+
+        categories = raw_data["url_categories"]
+        if not isinstance(categories, list):
+            categories = [categories]
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            # Show override information if applicable
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(categories))
+            return []
+
+        # Apply each URL category
+        results = []
+        created_count = 0
+        updated_count = 0
+
+        for category_data in categories:
+            try:
+                # Apply container override if specified
+                if folder:
+                    category_data["folder"] = folder
+                    category_data.pop("snippet", None)
+                    category_data.pop("device", None)
+                elif snippet:
+                    category_data["snippet"] = snippet
+                    category_data.pop("folder", None)
+                    category_data.pop("device", None)
+                elif device:
+                    category_data["device"] = device
+                    category_data.pop("folder", None)
+                    category_data.pop("snippet", None)
+
+                # Validate using the Pydantic model
+                category = URLCategory(**category_data)
+
+                # Call the SDK client to create the URL category
+                sdk_data = category.to_sdk_model()
+
+                # Extract container params
+                container_kwargs = {}
+                if sdk_data.get("folder"):
+                    container_kwargs["folder"] = sdk_data.pop("folder")
+                elif sdk_data.get("snippet"):
+                    container_kwargs["snippet"] = sdk_data.pop("snippet")
+                elif sdk_data.get("device"):
+                    container_kwargs["device"] = sdk_data.pop("device")
+
+                result = scm_client.create_url_category(**container_kwargs, **sdk_data)
+
+                results.append(result)
+
+                # Track if created or updated based on response
+                if result.get("__action__") == "created":
+                    created_count += 1
+                else:
+                    updated_count += 1
+
+            except Exception as e:
+                typer.echo(
+                    f"Error processing URL category '{category_data.get('name', 'unknown')}': {str(e)}",
+                    err=True,
+                )
+                # Continue processing other categories
+                continue
+
+        # Display summary with counts
+        typer.echo(f"Successfully processed {len(results)} URL category(ies):")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+
+        return results
+
+    except Exception as e:
+        typer.echo(f"Error loading URL categories: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("url-category")
+def set_url_category(
+    folder: str = typer.Option(None, "--folder", help="Folder path for the URL category"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet path for the URL category"),
+    device: str = typer.Option(None, "--device", help="Device path for the URL category"),
+    name: str = NAME_OPTION,
+    description: str | None = DESCRIPTION_OPTION,
+    type: str = typer.Option("URL List", "--type", help="Type of URL category (URL List or Category Match)"),
+    urls: list[str] | None = typer.Option(None, "--url", help="URL entries for the category"),
+):
+    r"""Create or update a URL category.
+
+    Examples:
+        # Create URL list category in folder
+        scm set security url-category --folder Texas --name custom-block \
+            --url malware.example.com --url phishing.test.org
+
+        # Create category match type
+        scm set security url-category --folder Texas --name match-category \
+            --type "Category Match" --url gambling --url adult
+
+        # Create in snippet
+        scm set security url-category --snippet Security-Best-Practice \
+            --name blocked-sites --url bad-site.com
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        # Build category data
+        category_data: dict[str, Any] = {
+            location_type: location_value,
+            "name": name,
+            "type": type,
+        }
+
+        if description:
+            category_data["description"] = description
+        if urls:
+            category_data["list"] = urls
+
+        # Validate using Pydantic model
+        category = URLCategory(**category_data)
+
+        # Call SDK client
+        sdk_data = category.to_sdk_model()
+
+        # Extract container params
+        container_kwargs = {}
+        if sdk_data.get("folder"):
+            container_kwargs["folder"] = sdk_data.pop("folder")
+        elif sdk_data.get("snippet"):
+            container_kwargs["snippet"] = sdk_data.pop("snippet")
+        elif sdk_data.get("device"):
+            container_kwargs["device"] = sdk_data.pop("device")
+
+        result = scm_client.create_url_category(**container_kwargs, **sdk_data)
+
+        # Format and display output
+        action = result.get("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created URL category: {result['name']} in {location_type} {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated URL category: {result['name']} in {location_type} {location_value}")
+        else:
+            typer.echo(f"No changes to URL category: {result['name']} in {location_type} {location_value}")
+
+    except Exception as e:
+        typer.echo(f"Error creating URL category: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("url-category")
+def show_url_category(
+    folder: str = typer.Option(None, "--folder", help="Folder containing the URL category"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet containing the URL category"),
+    device: str = typer.Option(None, "--device", help="Device containing the URL category"),
+    name: str | None = typer.Option(None, "--name", help="Name of the URL category to show"),
+):
+    """Display URL categories.
+
+    Examples:
+        # List all URL categories in a folder (default behavior)
+        scm show security url-category --folder Texas
+
+        # Show a specific URL category by name
+        scm show security url-category --folder Texas --name custom-block
+
+        # List URL categories in snippet
+        scm show security url-category --snippet Security-Best-Practice
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        if name:
+            # Get a specific URL category by name
+            kwargs = {location_type: location_value}
+            category = scm_client.get_url_category(**kwargs, name=name)
+
+            typer.echo(f"\nURL Category: {category.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+
+            # Display container location
+            if category.get("folder"):
+                typer.echo(f"Location: Folder '{category['folder']}'")
+            elif category.get("snippet"):
+                typer.echo(f"Location: Snippet '{category['snippet']}'")
+            elif category.get("device"):
+                typer.echo(f"Location: Device '{category['device']}'")
+
+            # Display description if present
+            if category.get("description"):
+                typer.echo(f"Description: {category['description']}")
+
+            # Display type
+            if category.get("type"):
+                typer.echo(f"Type: {category['type']}")
+
+            # Display URL list
+            if category.get("list"):
+                typer.echo(f"\nURLs ({len(category['list'])}):")
+                for url in category["list"]:
+                    typer.echo(f"  - {url}")
+
+            # Display ID if present
+            if category.get("id"):
+                typer.echo(f"\nID: {category['id']}")
+
+            return category
+
+        else:
+            # Default behavior: list all
+            kwargs = {location_type: location_value}
+            categories = scm_client.list_url_categories(**kwargs, exact_match=False)
+
+            if not categories:
+                typer.echo(f"No URL categories found in {location_type} '{location_value}'")
+                return
+
+            typer.echo(f"\nURL Categories in {location_type} '{location_value}':")
+            typer.echo("=" * 80)
+
+            for category in categories:
+                typer.echo(f"Name: {category.get('name', 'N/A')}")
+
+                # Display container location
+                if category.get("folder"):
+                    typer.echo(f"  Location: Folder '{category['folder']}'")
+                elif category.get("snippet"):
+                    typer.echo(f"  Location: Snippet '{category['snippet']}'")
+                elif category.get("device"):
+                    typer.echo(f"  Location: Device '{category['device']}'")
+
+                # Display description if present
+                if category.get("description"):
+                    typer.echo(f"  Description: {category['description']}")
+
+                # Display type
+                if category.get("type"):
+                    typer.echo(f"  Type: {category['type']}")
+
+                # Display URL count
+                if category.get("list"):
+                    typer.echo(f"  URLs: {len(category['list'])} entries")
+
+                # Display ID if present
+                if category.get("id"):
+                    typer.echo(f"  ID: {category['id']}")
+
+                typer.echo("-" * 80)
+
+            return categories
+
+    except Exception as e:
+        typer.echo(f"Error showing URL category: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -13,7 +13,7 @@ import typer
 import yaml
 
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AntiSpywareProfile, DecryptionProfile, SecurityRule
+from ..utils.validators import AntiSpywareProfile, DecryptionProfile, SecurityRule, WildfireAntivirusProfile
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -1818,4 +1818,477 @@ def show_decryption_profile(
 
     except Exception as e:
         typer.echo(f"Error showing decryption profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# WILDFIRE ANTIVIRUS PROFILE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("wildfire-antivirus-profile")
+def backup_wildfire_antivirus_profile(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: str = BACKUP_FILE_OPTION,
+):
+    """Backup all WildFire antivirus profiles from a container to a YAML file.
+
+    Examples:
+        # Backup from folder
+        scm backup security wildfire-antivirus-profile --folder Austin
+
+        # Backup from snippet
+        scm backup security wildfire-antivirus-profile --snippet Security-Best-Practice
+
+        # Backup from device
+        scm backup security wildfire-antivirus-profile --device austin-01
+
+        # Backup to custom filename
+        scm backup security wildfire-antivirus-profile --folder Austin --file my-profiles.yaml
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    # Set default filename if not provided
+    if not file:
+        file = get_default_backup_filename("wildfire-antivirus-profiles", location_type, location_value)
+
+    try:
+        # List all WildFire antivirus profiles with exact_match=True using kwargs pattern
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_wildfire_antivirus_profiles(**kwargs, exact_match=True)
+
+        if not profiles:
+            typer.echo(f"No WildFire antivirus profiles found in {location_type} '{location_value}'")
+            return
+
+        # Convert SDK models to dictionaries, excluding unset values
+        backup_data = []
+        for profile in profiles:
+            # The list method already returns dicts with exclude_unset=True
+            profile_dict = profile.copy()
+            # Remove system fields that shouldn't be in backup
+            profile_dict.pop("id", None)
+
+            backup_data.append(profile_dict)
+
+        # Create the YAML structure
+        yaml_data = {"wildfire_antivirus_profiles": backup_data}
+
+        # Write to YAML file
+        with open(file, "w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} WildFire antivirus profiles to {file}")
+        return file
+
+    except Exception as e:
+        typer.echo(f"Error backing up WildFire antivirus profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("wildfire-antivirus-profile")
+def delete_wildfire_antivirus_profile(
+    folder: str = typer.Option(None, "--folder", help="Folder containing the WildFire antivirus profile"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet containing the WildFire antivirus profile"),
+    device: str = typer.Option(None, "--device", help="Device containing the WildFire antivirus profile"),
+    name: str = NAME_OPTION,
+):
+    """Delete a WildFire antivirus profile.
+
+    Examples:
+        # Delete from folder
+        scm delete security wildfire-antivirus-profile --folder Texas --name wf-strict
+
+        # Delete from snippet
+        scm delete security wildfire-antivirus-profile --snippet Security-Best-Practice --name wf-standard
+
+        # Delete from device
+        scm delete security wildfire-antivirus-profile --device austin-01 --name wf-local
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        kwargs = {location_type: location_value}
+        result = scm_client.delete_wildfire_antivirus_profile(**kwargs, name=name)
+        if result:
+            typer.echo(f"Deleted WildFire antivirus profile: {name} from {location_type} {location_value}")
+        else:
+            typer.echo(
+                f"WildFire antivirus profile not found: {name} in {location_type} {location_value}",
+                err=True,
+            )
+            raise typer.Exit(code=1) from Exception
+    except Exception as e:
+        typer.echo(f"Error deleting WildFire antivirus profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("wildfire-antivirus-profile", help="Load WildFire antivirus profiles from a YAML file.")
+def load_wildfire_antivirus_profile(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+    snippet: str = LOAD_SNIPPET_OPTION,
+    device: str = LOAD_DEVICE_OPTION,
+):
+    """Load WildFire antivirus profiles from a YAML file.
+
+    Examples:
+        # Load from file with original locations
+        scm load security wildfire-antivirus-profile --file config/wildfire_antivirus_profiles.yml
+
+        # Load with folder override
+        scm load security wildfire-antivirus-profile --file config/wildfire_antivirus_profiles.yml --folder Production
+
+        # Load with snippet override
+        scm load security wildfire-antivirus-profile --file config/wildfire_antivirus_profiles.yml --snippet Security-Best-Practice
+
+        # Dry run to preview changes
+        scm load security wildfire-antivirus-profile --file config/wildfire_antivirus_profiles.yml --dry-run
+
+    """
+    try:
+        # Validate container override parameters
+        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+            typer.echo(
+                "Error: Only one of --folder, --snippet, or --device can be specified",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        # Validate file exists
+        if not file.exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+
+        # Load YAML data using the same pattern as other commands
+        with open(file) as f:
+            raw_data = yaml.safe_load(f)
+
+        if not raw_data or "wildfire_antivirus_profiles" not in raw_data:
+            typer.echo("No WildFire antivirus profiles found in file", err=True)
+            raise typer.Exit(code=1)
+
+        profiles = raw_data["wildfire_antivirus_profiles"]
+        if not isinstance(profiles, list):
+            profiles = [profiles]
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            # Show override information if applicable
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(profiles))
+            return []
+
+        # Apply each WildFire antivirus profile
+        results = []
+        created_count = 0
+        updated_count = 0
+
+        for profile_data in profiles:
+            try:
+                # Apply container override if specified
+                if folder:
+                    profile_data["folder"] = folder
+                    profile_data.pop("snippet", None)
+                    profile_data.pop("device", None)
+                elif snippet:
+                    profile_data["snippet"] = snippet
+                    profile_data.pop("folder", None)
+                    profile_data.pop("device", None)
+                elif device:
+                    profile_data["device"] = device
+                    profile_data.pop("folder", None)
+                    profile_data.pop("snippet", None)
+
+                # Validate using the Pydantic model
+                profile = WildfireAntivirusProfile(**profile_data)
+
+                # Call the SDK client to create the WildFire antivirus profile
+                sdk_data = profile.to_sdk_model()
+
+                # Extract container params
+                container_kwargs = {}
+                if sdk_data.get("folder"):
+                    container_kwargs["folder"] = sdk_data.pop("folder")
+                elif sdk_data.get("snippet"):
+                    container_kwargs["snippet"] = sdk_data.pop("snippet")
+                elif sdk_data.get("device"):
+                    container_kwargs["device"] = sdk_data.pop("device")
+
+                result = scm_client.create_wildfire_antivirus_profile(**container_kwargs, **sdk_data)
+
+                results.append(result)
+
+                # Track if created or updated based on response
+                if "created" in str(result).lower():
+                    created_count += 1
+                else:
+                    updated_count += 1
+
+            except Exception as e:
+                typer.echo(
+                    f"Error processing WildFire antivirus profile '{profile_data.get('name', 'unknown')}': {str(e)}",
+                    err=True,
+                )
+                # Continue processing other profiles
+                continue
+
+        # Display summary with counts
+        typer.echo(f"Successfully processed {len(results)} WildFire antivirus profile(s):")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+
+        return results
+
+    except Exception as e:
+        typer.echo(f"Error loading WildFire antivirus profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("wildfire-antivirus-profile")
+def set_wildfire_antivirus_profile(
+    folder: str = typer.Option(None, "--folder", help="Folder path for the WildFire antivirus profile"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet path for the WildFire antivirus profile"),
+    device: str = typer.Option(None, "--device", help="Device path for the WildFire antivirus profile"),
+    name: str = NAME_OPTION,
+    description: str | None = DESCRIPTION_OPTION,
+    rules_json: str | None = typer.Option(
+        None,
+        "--rules",
+        help="JSON string of rules configuration",
+    ),
+    packet_capture: bool = typer.Option(
+        False,
+        "--packet-capture/--no-packet-capture",
+        help="Enable packet capture",
+    ),
+):
+    r"""Create or update a WildFire antivirus profile.
+
+    Examples:
+        # Create basic profile in folder with default rule
+        scm set security wildfire-antivirus-profile --folder Texas --name wf-basic \
+            --description "Basic WildFire profile"
+
+        # Create profile with custom rules (JSON)
+        scm set security wildfire-antivirus-profile --folder Texas --name wf-custom \
+            --rules '[{"name":"Forward All","direction":"both","analysis":"public-cloud","application":["any"],"file_type":["any"]}]'
+
+        # Create profile with packet capture
+        scm set security wildfire-antivirus-profile --folder Texas --name wf-capture \
+            --packet-capture
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        # Validate and create WildFire antivirus profile
+        profile_data: dict[str, Any] = {
+            location_type: location_value,
+            "name": name,
+        }
+
+        if description:
+            profile_data["description"] = description
+        if packet_capture:
+            profile_data["packet_capture"] = packet_capture
+
+        # Parse rules from JSON if provided
+        if rules_json:
+            try:
+                profile_data["rules"] = json.loads(rules_json)
+            except json.JSONDecodeError as e:
+                typer.echo(f"Error parsing rules JSON: {str(e)}", err=True)
+                raise typer.Exit(code=1) from e
+        else:
+            # Add a default rule
+            profile_data["rules"] = [
+                {
+                    "name": "default-fwd",
+                    "direction": "both",
+                    "analysis": "public-cloud",
+                    "application": ["any"],
+                    "file_type": ["any"],
+                }
+            ]
+
+        # Validate using the Pydantic model
+        profile = WildfireAntivirusProfile(**profile_data)
+
+        # Call SDK client to create the profile
+        sdk_data = profile.to_sdk_model()
+
+        # Extract container params
+        container_kwargs = {}
+        if sdk_data.get("folder"):
+            container_kwargs["folder"] = sdk_data.pop("folder")
+        elif sdk_data.get("snippet"):
+            container_kwargs["snippet"] = sdk_data.pop("snippet")
+        elif sdk_data.get("device"):
+            container_kwargs["device"] = sdk_data.pop("device")
+
+        result = scm_client.create_wildfire_antivirus_profile(**container_kwargs, **sdk_data)
+
+        # Format and display output
+        typer.echo(f"Created WildFire antivirus profile: {result['name']} in {location_type} {location_value}")
+
+    except Exception as e:
+        typer.echo(f"Error creating WildFire antivirus profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("wildfire-antivirus-profile")
+def show_wildfire_antivirus_profile(
+    folder: str = typer.Option(None, "--folder", help="Folder containing the WildFire antivirus profile"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet containing the WildFire antivirus profile"),
+    device: str = typer.Option(None, "--device", help="Device containing the WildFire antivirus profile"),
+    name: str | None = typer.Option(None, "--name", help="Name of the WildFire antivirus profile to show"),
+):
+    """Display WildFire antivirus profiles.
+
+    Examples:
+        # List all WildFire antivirus profiles in a folder (default behavior)
+        scm show security wildfire-antivirus-profile --folder Texas
+
+        # Show a specific profile by name
+        scm show security wildfire-antivirus-profile --folder Texas --name wf-basic
+
+        # List profiles in snippet
+        scm show security wildfire-antivirus-profile --snippet Security-Best-Practice
+
+    """
+    # Validate location parameters
+    location_type, location_value = validate_location_params(folder, snippet, device)
+
+    try:
+        if name:
+            # Get a specific WildFire antivirus profile by name
+            kwargs = {location_type: location_value}
+            profile = scm_client.get_wildfire_antivirus_profile(**kwargs, name=name)
+
+            typer.echo(f"\nWildFire Antivirus Profile: {profile.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+
+            # Display container location (folder, snippet, or device)
+            if profile.get("folder"):
+                typer.echo(f"Location: Folder '{profile['folder']}'")
+            elif profile.get("snippet"):
+                typer.echo(f"Location: Snippet '{profile['snippet']}'")
+            elif profile.get("device"):
+                typer.echo(f"Location: Device '{profile['device']}'")
+
+            # Display description if present
+            if profile.get("description"):
+                typer.echo(f"Description: {profile['description']}")
+
+            # Display packet capture setting
+            if "packet_capture" in profile:
+                typer.echo(f"Packet Capture: {'Enabled' if profile['packet_capture'] else 'Disabled'}")
+
+            # Display rules in detail
+            if profile.get("rules"):
+                typer.echo(f"\nRules ({len(profile['rules'])}):")
+                for idx, rule in enumerate(profile["rules"], 1):
+                    typer.echo(f"  Rule {idx}: {rule.get('name', 'Unnamed')}")
+                    typer.echo(f"    Direction: {rule.get('direction', 'N/A')}")
+                    if rule.get("analysis"):
+                        typer.echo(f"    Analysis: {rule['analysis']}")
+                    if rule.get("application"):
+                        typer.echo(f"    Applications: {', '.join(rule['application'])}")
+                    if rule.get("file_type"):
+                        typer.echo(f"    File Types: {', '.join(rule['file_type'])}")
+
+            # Display MLAV exceptions if present
+            if profile.get("mlav_exception"):
+                typer.echo(f"\nMLAV Exceptions ({len(profile['mlav_exception'])}):")
+                for idx, exc in enumerate(profile["mlav_exception"], 1):
+                    typer.echo(f"  Exception {idx}: {exc.get('name', 'Unnamed')}")
+                    if exc.get("filename"):
+                        typer.echo(f"    Filename: {exc['filename']}")
+                    if exc.get("description"):
+                        typer.echo(f"    Description: {exc['description']}")
+
+            # Display threat exceptions if present
+            if profile.get("threat_exception"):
+                typer.echo(f"\nThreat Exceptions ({len(profile['threat_exception'])}):")
+                for idx, exc in enumerate(profile["threat_exception"], 1):
+                    typer.echo(f"  Exception {idx}: {exc.get('name', 'Unnamed')}")
+                    if exc.get("notes"):
+                        typer.echo(f"    Notes: {exc['notes']}")
+
+            # Display ID if present
+            if profile.get("id"):
+                typer.echo(f"\nID: {profile['id']}")
+
+            return profile
+
+        else:
+            # Default behavior: list all
+            kwargs = {location_type: location_value}
+            profiles = scm_client.list_wildfire_antivirus_profiles(**kwargs, exact_match=False)
+
+            if not profiles:
+                typer.echo(f"No WildFire antivirus profiles found in {location_type} '{location_value}'")
+                return
+
+            typer.echo(f"\nWildFire Antivirus Profiles in {location_type} '{location_value}':")
+            typer.echo("=" * 80)
+
+            for profile in profiles:
+                # Display profile information
+                typer.echo(f"Name: {profile.get('name', 'N/A')}")
+
+                # Display container location (folder, snippet, or device)
+                if profile.get("folder"):
+                    typer.echo(f"  Location: Folder '{profile['folder']}'")
+                elif profile.get("snippet"):
+                    typer.echo(f"  Location: Snippet '{profile['snippet']}'")
+                elif profile.get("device"):
+                    typer.echo(f"  Location: Device '{profile['device']}'")
+
+                # Display description if present
+                if profile.get("description"):
+                    typer.echo(f"  Description: {profile['description']}")
+
+                # Display rules if present
+                if profile.get("rules"):
+                    typer.echo(f"  Rules: {len(profile['rules'])} configured")
+                    for rule in profile["rules"]:
+                        typer.echo(f"    - {rule.get('name', 'Unnamed')}: {rule.get('direction', 'N/A')}")
+
+                # Display packet capture setting
+                if profile.get("packet_capture"):
+                    typer.echo("  Packet Capture: Enabled")
+
+                # Display threat exceptions if present
+                if profile.get("threat_exception"):
+                    typer.echo(f"  Threat Exceptions: {len(profile['threat_exception'])}")
+
+                # Display MLAV exceptions if present
+                if profile.get("mlav_exception"):
+                    typer.echo(f"  MLAV Exceptions: {len(profile['mlav_exception'])}")
+
+                # Display ID if present
+                if profile.get("id"):
+                    typer.echo(f"  ID: {profile['id']}")
+
+                typer.echo("-" * 80)
+
+            return profiles
+
+    except Exception as e:
+        typer.echo(f"Error showing WildFire antivirus profile: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -5471,6 +5471,382 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("listing", folder or snippet or device or "", "IKE crypto profiles", e)
 
+    # --------------------------------------------------------------------------------------- NAT Rules ------------------------------------------------------------------------------------
+
+    def create_nat_rule(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = "",
+        description: str | None = None,
+        tag: list[str] | None = None,
+        disabled: bool = False,
+        nat_type: str = "ipv4",
+        from_zones: list[str] | None = None,
+        to_zones: list[str] | None = None,
+        to_interface: str | None = None,
+        source: list[str] | None = None,
+        destination: list[str] | None = None,
+        service: str = "any",
+        source_translation: dict[str, Any] | None = None,
+        destination_translation: dict[str, Any] | None = None,
+        active_active_device_binding: str | None = None,
+    ) -> dict[str, Any]:
+        """Create or update a NAT rule (smart upsert).
+
+        Args:
+            folder: Folder to create the NAT rule in
+            snippet: Snippet to create the NAT rule in
+            device: Device to create the NAT rule in
+            name: Name of the NAT rule
+            description: Description of the NAT rule
+            tag: Tags associated with the NAT rule
+            disabled: Whether the NAT rule is disabled
+            nat_type: NAT type (ipv4, nat64, nptv6)
+            from_zones: Source zone(s)
+            to_zones: Destination zone(s)
+            to_interface: Destination interface
+            source: Source address(es)
+            destination: Destination address(es)
+            service: TCP/UDP service
+            source_translation: Source translation configuration
+            destination_translation: Destination translation configuration
+            active_active_device_binding: Active/Active device binding
+
+        Returns:
+            dict[str, Any]: The created/updated NAT rule object, with '__action__' key.
+
+        """
+        container = folder or snippet or device or "Texas"
+        self.logger.info(f"Upsert NAT rule: {name} in {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"nat-{name}",
+                "folder": folder or "Texas",
+                "name": name,
+                "description": description or "",
+                "nat_type": nat_type,
+                "from_": from_zones or ["any"],
+                "to_": to_zones or ["any"],
+                "source": source or ["any"],
+                "destination": destination or ["any"],
+                "service": service,
+                "source_translation": source_translation,
+                "destination_translation": destination_translation,
+                "__action__": "created",
+            }
+
+        try:
+            # Build NAT rule data
+            nat_data: dict[str, Any] = {"name": name}
+            if folder:
+                nat_data["folder"] = folder
+            elif snippet:
+                nat_data["snippet"] = snippet
+            elif device:
+                nat_data["device"] = device
+
+            if description:
+                nat_data["description"] = description
+            if tag:
+                nat_data["tag"] = tag
+            if disabled:
+                nat_data["disabled"] = disabled
+            if nat_type != "ipv4":
+                nat_data["nat_type"] = nat_type
+            nat_data["from_"] = from_zones or ["any"]
+            nat_data["to_"] = to_zones or ["any"]
+            nat_data["source"] = source or ["any"]
+            nat_data["destination"] = destination or ["any"]
+            nat_data["service"] = service
+            if to_interface:
+                nat_data["to_interface"] = to_interface
+            if source_translation:
+                nat_data["source_translation"] = source_translation
+            if destination_translation:
+                nat_data["destination_translation"] = destination_translation
+            if active_active_device_binding:
+                nat_data["active_active_device_binding"] = active_active_device_binding
+
+            # Step 1: Try to fetch existing NAT rule
+            existing = None
+            try:
+                fetch_kwargs = {"name": name}
+                if folder:
+                    fetch_kwargs["folder"] = folder
+                elif snippet:
+                    fetch_kwargs["snippet"] = snippet
+                elif device:
+                    fetch_kwargs["device"] = device
+                existing = self.client.nat_rule.fetch(**fetch_kwargs)
+                self.logger.info(f"Found existing NAT rule '{name}'")
+            except NotFoundError:
+                self.logger.info(f"NAT rule '{name}' not found, will create new")
+            except Exception as e:
+                self.logger.warning(f"Error fetching NAT rule '{name}': {str(e)}")
+
+            if existing:
+                # Step 2: Compare and update if needed
+                needs_update = False
+                update_fields = []
+
+                # Compare description
+                if description is not None and getattr(existing, "description", None) != description:
+                    existing.description = description
+                    update_fields.append("description")
+                    needs_update = True
+
+                # Compare source zones
+                current_from = list(getattr(existing, "from_", []) or [])
+                new_from = from_zones or ["any"]
+                if set(current_from) != set(new_from):
+                    existing.from_ = new_from
+                    update_fields.append("from")
+                    needs_update = True
+
+                # Compare destination zones
+                current_to = list(getattr(existing, "to_", []) or [])
+                new_to = to_zones or ["any"]
+                if set(current_to) != set(new_to):
+                    existing.to_ = new_to
+                    update_fields.append("to")
+                    needs_update = True
+
+                # Compare source addresses
+                current_source = list(getattr(existing, "source", []) or [])
+                new_source = source or ["any"]
+                if set(current_source) != set(new_source):
+                    existing.source = new_source
+                    update_fields.append("source")
+                    needs_update = True
+
+                # Compare destination addresses
+                current_dest = list(getattr(existing, "destination", []) or [])
+                new_dest = destination or ["any"]
+                if set(current_dest) != set(new_dest):
+                    existing.destination = new_dest
+                    update_fields.append("destination")
+                    needs_update = True
+
+                # Compare service
+                if getattr(existing, "service", "any") != service:
+                    existing.service = service
+                    update_fields.append("service")
+                    needs_update = True
+
+                # Compare source_translation
+                if source_translation is not None:
+                    existing.source_translation = source_translation
+                    update_fields.append("source_translation")
+                    needs_update = True
+
+                # Compare destination_translation
+                if destination_translation is not None:
+                    existing.destination_translation = destination_translation
+                    update_fields.append("destination_translation")
+                    needs_update = True
+
+                # Compare tags
+                if tag is not None:
+                    current_tags = set(getattr(existing, "tag", []) or [])
+                    new_tags = set(tag or [])
+                    if current_tags != new_tags:
+                        existing.tag = tag
+                        update_fields.append("tag")
+                        needs_update = True
+
+                if needs_update:
+                    self.logger.info(f"Updating NAT rule fields: {', '.join(update_fields)}")
+                    updated = self.client.nat_rule.update(existing)
+                    self.logger.info(f"Successfully updated NAT rule '{name}'")
+                    result = json.loads(updated.model_dump_json(exclude_unset=True))
+                    result["__action__"] = "updated"
+                    return result
+                else:
+                    self.logger.info(f"No changes detected for NAT rule '{name}', skipping update")
+                    result = json.loads(existing.model_dump_json(exclude_unset=True))
+                    result["__action__"] = "no_change"
+                    return result
+            else:
+                # Step 3: Create new NAT rule
+                created = self.client.nat_rule.create(nat_data)
+                self.logger.info(f"Successfully created NAT rule '{name}'")
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+        except Exception as e:
+            self._handle_api_exception("creation/update", container, name, e)
+
+    def delete_nat_rule(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = "",
+    ) -> bool:
+        """Delete a NAT rule.
+
+        Args:
+            folder: Folder containing the NAT rule
+            snippet: Snippet containing the NAT rule
+            device: Device containing the NAT rule
+            name: Name of the NAT rule to delete
+
+        Returns:
+            bool: True if deletion was successful
+
+        """
+        container = folder or snippet or device or "Texas"
+        self.logger.info(f"Deleting NAT rule: {name} from {container}")
+
+        if not self.client:
+            return True
+
+        try:
+            fetch_kwargs: dict[str, str] = {"name": name}
+            if folder:
+                fetch_kwargs["folder"] = folder
+            elif snippet:
+                fetch_kwargs["snippet"] = snippet
+            elif device:
+                fetch_kwargs["device"] = device
+            nat_rule = self.client.nat_rule.fetch(**fetch_kwargs)
+            self.client.nat_rule.delete(str(nat_rule.id))
+            self.logger.info(f"Successfully deleted NAT rule '{name}'")
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", container, name, e)
+
+    def get_nat_rule(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = "",
+    ) -> dict[str, Any]:
+        """Get a NAT rule by name.
+
+        Args:
+            folder: Folder containing the NAT rule
+            snippet: Snippet containing the NAT rule
+            device: Device containing the NAT rule
+            name: Name of the NAT rule to get
+
+        Returns:
+            dict[str, Any]: The NAT rule object
+
+        """
+        container = folder or snippet or device or "Texas"
+        self.logger.info(f"Getting NAT rule: {name} from {container}")
+
+        if not self.client:
+            return {
+                "id": f"nat-{name}",
+                "folder": folder or "Texas",
+                "name": name,
+                "description": "Mock NAT rule",
+                "nat_type": "ipv4",
+                "from_": ["trust"],
+                "to_": ["untrust"],
+                "source": ["any"],
+                "destination": ["any"],
+                "service": "any",
+                "source_translation": {
+                    "dynamic_ip_and_port": {
+                        "type": "dynamic_ip_and_port",
+                        "translated_address": ["192.168.1.1"],
+                    }
+                },
+            }
+
+        try:
+            fetch_kwargs: dict[str, str] = {"name": name}
+            if folder:
+                fetch_kwargs["folder"] = folder
+            elif snippet:
+                fetch_kwargs["snippet"] = snippet
+            elif device:
+                fetch_kwargs["device"] = device
+            result = self.client.nat_rule.fetch(**fetch_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("retrieval", container, name, e)
+
+    def list_nat_rules(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List NAT rules in a container.
+
+        Args:
+            folder: Folder location
+            snippet: Snippet location
+            device: Device location
+            exact_match: If True, only return objects defined exactly in the specified container
+
+        Returns:
+            list[dict[str, Any]]: List of NAT rule objects
+
+        """
+        container = folder or snippet or device or "Texas"
+        self.logger.info(f"Listing NAT rules in {folder=}, {snippet=}, {device=} (exact_match={exact_match})")
+
+        if not self.client:
+            return [
+                {
+                    "id": "nat-mock1",
+                    "folder": folder or "Texas",
+                    "name": "outbound-nat",
+                    "nat_type": "ipv4",
+                    "from_": ["trust"],
+                    "to_": ["untrust"],
+                    "source": ["any"],
+                    "destination": ["any"],
+                    "service": "any",
+                    "source_translation": {
+                        "dynamic_ip_and_port": {
+                            "type": "dynamic_ip_and_port",
+                            "translated_address": ["10.0.0.1"],
+                        }
+                    },
+                },
+                {
+                    "id": "nat-mock2",
+                    "folder": folder or "Texas",
+                    "name": "inbound-web",
+                    "nat_type": "ipv4",
+                    "from_": ["untrust"],
+                    "to_": ["trust"],
+                    "source": ["any"],
+                    "destination": ["203.0.113.10"],
+                    "service": "service-http",
+                    "destination_translation": {
+                        "translated_address": "192.168.1.100",
+                        "translated_port": 8080,
+                    },
+                },
+            ]
+
+        container_kwargs: dict[str, Any] = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+
+        try:
+            results = self.client.nat_rule.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", container, "NAT rules", e)
+
     # ------------------------------------------------------------------------------------ Security Zones ----------------------------------------------------------------------------------
 
     def create_zone(

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -4011,6 +4011,7 @@ class SCMClient:
             return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
         except Exception as e:
             self._handle_api_exception("listing", folder or snippet or device or "", "regions", e)
+
     # Quarantined Devices ------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     def create_quarantined_device(
@@ -6607,6 +6608,287 @@ class SCMClient:
             return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
         except Exception as e:
             self._handle_api_exception("listing", container or "", "decryption profiles", e)
+
+    # --------------------------------------------------------------------------- WildFire Antivirus Profile ---------------------------------------------------------------------------
+
+    def create_wildfire_antivirus_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+        description: str | None = None,
+        packet_capture: bool | None = None,
+        rules: list[dict[str, Any]] | None = None,
+        mlav_exception: list[dict[str, Any]] | None = None,
+        threat_exception: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Create a WildFire antivirus profile.
+
+        Args:
+            folder: Folder to create the profile in
+            snippet: Snippet to create the profile in
+            device: Device to create the profile in
+            name: Name of the profile
+            description: Optional description
+            packet_capture: Enable packet capture
+            rules: List of WildFire antivirus rules
+            mlav_exception: List of MLAV exceptions
+            threat_exception: List of threat exceptions
+
+        Returns:
+            dict[str, Any]: The created WildFire antivirus profile object
+
+        Note:
+            If a WildFire antivirus profile with the same name already exists in the container,
+            it will be updated with the new configuration.
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Creating or updating WildFire antivirus profile: {name} in {container_type} {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"wfav-{name}",
+                "folder": folder,
+                "snippet": snippet,
+                "device": device,
+                "name": name,
+                "description": description,
+                "packet_capture": packet_capture,
+                "rules": rules or [],
+                "mlav_exception": mlav_exception,
+                "threat_exception": threat_exception,
+            }
+
+        try:
+            # First, try to fetch the existing profile
+            existing_profile = None
+            try:
+                existing_profile = self.client.wildfire_antivirus_profile.fetch(name=name, folder=folder, snippet=snippet, device=device)
+                self.logger.info(f"Found existing WildFire antivirus profile '{name}' in {container_type} '{container}', updating...")
+            except NotFoundError:
+                self.logger.info(f"WildFire antivirus profile '{name}' not found in {container_type} '{container}', creating new...")
+            except Exception as fetch_error:
+                # Log but continue - we'll try to create if fetch failed for other reasons
+                self.logger.warning(f"Error fetching WildFire antivirus profile '{name}': {str(fetch_error)}")
+
+            # Prepare profile data
+            profile_data = {
+                "name": name,
+            }
+
+            # Add container field only if not None
+            if folder is not None:
+                profile_data["folder"] = folder
+            if snippet is not None:
+                profile_data["snippet"] = snippet
+            if device is not None:
+                profile_data["device"] = device
+
+            # Add optional fields if provided
+            if description is not None:
+                profile_data["description"] = description
+            if packet_capture is not None:
+                profile_data["packet_capture"] = packet_capture
+            if rules is not None:
+                profile_data["rules"] = rules
+            if mlav_exception is not None:
+                profile_data["mlav_exception"] = mlav_exception
+            if threat_exception is not None:
+                profile_data["threat_exception"] = threat_exception
+
+            # Create or update the profile
+            if existing_profile:
+                # Update existing profile
+                profile_data["id"] = existing_profile.id
+                from scm.models.security import WildfireAvProfileUpdateModel
+
+                update_model = WildfireAvProfileUpdateModel(**profile_data)
+                result = self.client.wildfire_antivirus_profile.update(update_model)
+            else:
+                # Create a new profile
+                result = self.client.wildfire_antivirus_profile.create(profile_data)
+
+            # Convert response to dict
+            return json.loads(result.model_dump_json(exclude_unset=True))
+
+        except Exception as e:
+            self._handle_api_exception("creating", container or "", "WildFire antivirus profile", e)
+
+    def delete_wildfire_antivirus_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+    ) -> bool:
+        """Delete a WildFire antivirus profile.
+
+        Args:
+            folder: Folder containing the profile
+            snippet: Snippet containing the profile
+            device: Device containing the profile
+            name: Name of the profile to delete
+
+        Returns:
+            bool: True if deleted successfully
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Deleting WildFire antivirus profile: {name} from {container_type} {container}")
+
+        if not self.client:
+            # Return mock success if no client is available
+            return True
+
+        try:
+            # Fetch the profile to get its ID
+            profile = self.client.wildfire_antivirus_profile.fetch(name=name, folder=folder, snippet=snippet, device=device)
+
+            # Delete using the ID
+            self.client.wildfire_antivirus_profile.delete(profile.id)
+            self.logger.info(f"Successfully deleted WildFire antivirus profile '{name}' from {container_type} '{container}'")
+            return True
+        except NotFoundError:
+            self.logger.warning(f"WildFire antivirus profile '{name}' not found in {container_type} '{container}'")
+            return False
+        except Exception as e:
+            self._handle_api_exception("deleting", container or "", "WildFire antivirus profile", e)
+
+    def get_wildfire_antivirus_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+    ) -> dict[str, Any]:
+        """Get a WildFire antivirus profile by name.
+
+        Args:
+            folder: Folder containing the profile
+            snippet: Snippet containing the profile
+            device: Device containing the profile
+            name: Name of the profile
+
+        Returns:
+            dict[str, Any]: The WildFire antivirus profile object
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Getting WildFire antivirus profile: {name} from {container_type} {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"wfav-{name}",
+                "folder": folder,
+                "snippet": snippet,
+                "device": device,
+                "name": name,
+                "description": "Mock WildFire antivirus profile",
+                "rules": [
+                    {
+                        "name": "Default Rule",
+                        "direction": "both",
+                        "analysis": "public-cloud",
+                        "application": ["any"],
+                        "file_type": ["any"],
+                    }
+                ],
+                "packet_capture": False,
+            }
+
+        try:
+            # Fetch the profile using the SDK
+            result = self.client.wildfire_antivirus_profile.fetch(name=name, folder=folder, snippet=snippet, device=device)
+
+            # Convert SDK response to dict
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", container or "", "WildFire antivirus profile", e)
+
+    def list_wildfire_antivirus_profiles(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List WildFire antivirus profiles.
+
+        Args:
+            folder: Folder to list out
+            snippet: Snippet to list out
+            device: Device to list out
+            exact_match: If True, only return exact container matches
+
+        Returns:
+            list[dict[str, Any]]: List of WildFire antivirus profile objects
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+
+        # Build container kwargs
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+
+        self.logger.info(f"Listing WildFire antivirus profiles in {container_type}: {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return [
+                {
+                    "id": "wfav-mock1",
+                    "folder": folder or "Texas",
+                    "name": "WildFire Best Practice",
+                    "description": "Best practice WildFire antivirus profile",
+                    "rules": [
+                        {
+                            "name": "Forward All",
+                            "direction": "both",
+                            "analysis": "public-cloud",
+                            "application": ["any"],
+                            "file_type": ["any"],
+                        }
+                    ],
+                    "packet_capture": False,
+                },
+                {
+                    "id": "wfav-mock2",
+                    "folder": folder or "Texas",
+                    "name": "WildFire Upload Only",
+                    "description": "Upload-only WildFire profile",
+                    "rules": [
+                        {
+                            "name": "Upload Rule",
+                            "direction": "upload",
+                            "analysis": "public-cloud",
+                            "application": ["any"],
+                            "file_type": ["any"],
+                        }
+                    ],
+                },
+            ]
+
+        try:
+            # List profiles using the SDK
+            results = self.client.wildfire_antivirus_profile.list(**container_kwargs, exact_match=exact_match)
+
+            # Convert SDK response to a list of dicts for compatibility
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", container or "", "WildFire antivirus profiles", e)
 
     # ======================================================================================================================================================================================
     # INSIGHTS AND MONITORING METHODS

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -8096,6 +8096,244 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("listing", container or "", "vulnerability protection profiles", e)
 
+    # -------------------------------------------------------------------------------------- URL Category ------------------------------------------------------------------------------------
+
+    def create_url_category(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+        description: str | None = None,
+        type: str | None = None,
+        list: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Create or update a URL category.
+
+        Args:
+            folder: Folder to create the URL category in
+            snippet: Snippet to create the URL category in
+            device: Device to create the URL category in
+            name: Name of the URL category
+            description: Optional description
+            type: Type of URL category (URL List or Category Match)
+            list: List of URLs or category matches
+
+        Returns:
+            dict[str, Any]: The created URL category object
+
+        Note:
+            If a URL category with the same name already exists in the container,
+            it will be updated with the new configuration.
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Creating or updating URL category: {name} in {container_type} {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"urlcat-{name}",
+                "folder": folder,
+                "snippet": snippet,
+                "device": device,
+                "name": name,
+                "description": description,
+                "type": type or "URL List",
+                "list": list or [],
+                "__action__": "created",
+            }
+
+        try:
+            # First, try to fetch the existing URL category
+            existing = None
+            try:
+                existing = self.client.url_category.fetch(name=name, folder=folder, snippet=snippet, device=device)
+                self.logger.info(f"Found existing URL category '{name}' in {container_type} '{container}', updating...")
+            except NotFoundError:
+                self.logger.info(f"URL category '{name}' not found in {container_type} '{container}', creating new...")
+            except Exception as fetch_error:
+                self.logger.warning(f"Error fetching URL category '{name}': {str(fetch_error)}")
+
+            # Prepare data
+            data = {
+                "name": name,
+            }
+
+            # Add container field only if not None
+            if folder is not None:
+                data["folder"] = folder
+            if snippet is not None:
+                data["snippet"] = snippet
+            if device is not None:
+                data["device"] = device
+
+            # Add optional fields if provided
+            if description is not None:
+                data["description"] = description
+            if type is not None:
+                data["type"] = type
+            if list is not None:
+                data["list"] = list
+
+            # Create or update
+            if existing:
+                # Update existing
+                data["id"] = existing.id
+                from scm.models.security.url_categories import URLCategoriesUpdateModel
+
+                update_model = URLCategoriesUpdateModel(**data)
+                result = self.client.url_category.update(update_model)
+                result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                result_dict["__action__"] = "updated"
+            else:
+                # Create new
+                result = self.client.url_category.create(data)
+                result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                result_dict["__action__"] = "created"
+
+            return result_dict
+
+        except Exception as e:
+            self._handle_api_exception("creating", container or "", "URL category", e)
+
+    def delete_url_category(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+    ) -> bool:
+        """Delete a URL category.
+
+        Args:
+            folder: Folder containing the URL category
+            snippet: Snippet containing the URL category
+            device: Device containing the URL category
+            name: Name of the URL category to delete
+
+        Returns:
+            bool: True if deleted successfully
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Deleting URL category: {name} from {container_type} {container}")
+
+        if not self.client:
+            return True
+
+        try:
+            profile = self.client.url_category.fetch(name=name, folder=folder, snippet=snippet, device=device)
+            self.client.url_category.delete(profile.id)
+            self.logger.info(f"Successfully deleted URL category '{name}' from {container_type} '{container}'")
+            return True
+        except NotFoundError:
+            self.logger.warning(f"URL category '{name}' not found in {container_type} '{container}'")
+            return False
+        except Exception as e:
+            self._handle_api_exception("deleting", container or "", "URL category", e)
+
+    def get_url_category(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+    ) -> dict[str, Any]:
+        """Get a URL category by name.
+
+        Args:
+            folder: Folder containing the URL category
+            snippet: Snippet containing the URL category
+            device: Device containing the URL category
+            name: Name of the URL category
+
+        Returns:
+            dict[str, Any]: The URL category object
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Getting URL category: {name} from {container_type} {container}")
+
+        if not self.client:
+            return {
+                "id": f"urlcat-{name}",
+                "folder": folder,
+                "snippet": snippet,
+                "device": device,
+                "name": name,
+                "description": "Mock URL category",
+                "type": "URL List",
+                "list": ["example.com", "test.org"],
+            }
+
+        try:
+            result = self.client.url_category.fetch(name=name, folder=folder, snippet=snippet, device=device)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", container or "", "URL category", e)
+
+    def list_url_categories(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List URL categories.
+
+        Args:
+            folder: Folder to list out
+            snippet: Snippet to list out
+            device: Device to list out
+            exact_match: If True, only return exact container matches
+
+        Returns:
+            list[dict[str, Any]]: List of URL category objects
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+
+        self.logger.info(f"Listing URL categories in {container_type}: {container}")
+
+        if not self.client:
+            return [
+                {
+                    "id": "urlcat-mock1",
+                    "folder": folder or "Texas",
+                    "name": "Custom-Block-List",
+                    "description": "Custom blocked URLs",
+                    "type": "URL List",
+                    "list": ["malware.example.com", "phishing.test.org"],
+                },
+                {
+                    "id": "urlcat-mock2",
+                    "folder": folder or "Texas",
+                    "name": "Internal-Sites",
+                    "description": "Internal company sites",
+                    "type": "URL List",
+                    "list": ["intranet.company.com", "wiki.company.com"],
+                },
+            ]
+
+        try:
+            results = self.client.url_category.list(**container_kwargs, exact_match=exact_match)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", container or "", "URL categories", e)
+
     # ======================================================================================================================================================================================
     # INSIGHTS AND MONITORING METHODS
     # ======================================================================================================================================================================================

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -5745,6 +5745,267 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("listing", container, "security zones", e)
 
+    # -------------------------------------------------------------------------------- IPsec Crypto Profiles -------------------------------------------------------------------------------
+
+    def create_ipsec_crypto_profile(
+        self,
+        folder: str,
+        name: str,
+        esp_encryption: list[str] | None = None,
+        esp_authentication: list[str] | None = None,
+        dh_group: str = "group14",
+        lifetime: dict[str, int] | None = None,
+        lifesize: dict[str, int] | None = None,
+    ) -> dict[str, Any]:
+        """Create or update an IPsec crypto profile using smart upsert logic.
+
+        Args:
+            folder: Folder to create the profile in
+            name: Name of the IPsec crypto profile
+            esp_encryption: List of ESP encryption algorithms
+            esp_authentication: List of ESP authentication algorithms
+            dh_group: DH group for PFS
+            lifetime: Lifetime configuration dict (e.g. {"hours": 1})
+            lifesize: Lifesize configuration dict (e.g. {"mb": 100})
+
+        Returns:
+            dict[str, Any]: The created/updated IPsec crypto profile
+
+        """
+        esp_encryption = esp_encryption or ["aes-256-cbc"]
+        esp_authentication = esp_authentication or ["sha256"]
+        lifetime = lifetime or {"hours": 1}
+
+        self.logger.info(f"Creating or updating IPsec crypto profile: {name} in folder {folder}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            result = {
+                "id": f"ipsec-crypto-{name}",
+                "folder": folder,
+                "name": name,
+                "esp": {
+                    "encryption": esp_encryption,
+                    "authentication": esp_authentication,
+                },
+                "dh_group": dh_group,
+                "lifetime": lifetime,
+                "__action__": "created",
+            }
+            if lifesize:
+                result["lifesize"] = lifesize
+            return result
+
+        try:
+            # Prepare the profile data
+            profile_data: dict[str, Any] = {
+                "folder": folder,
+                "name": name,
+                "esp": {
+                    "encryption": esp_encryption,
+                    "authentication": esp_authentication,
+                },
+                "dh_group": dh_group,
+                "lifetime": lifetime,
+            }
+            if lifesize:
+                profile_data["lifesize"] = lifesize
+
+            # Try to fetch existing profile for smart upsert
+            existing_profile = None
+            try:
+                existing_profile = self.client.ipsec_crypto_profile.fetch(name=name, folder=folder)
+                self.logger.info(f"Found existing IPsec crypto profile '{name}' in folder '{folder}'")
+            except NotFoundError:
+                self.logger.info(f"IPsec crypto profile '{name}' not found in folder '{folder}', will create new")
+            except Exception as fetch_error:
+                self.logger.warning(f"Error fetching IPsec crypto profile '{name}': {str(fetch_error)}")
+
+            if existing_profile:
+                # Compare fields to detect changes
+                needs_update = False
+                update_fields = []
+
+                # Compare ESP encryption
+                existing_esp = existing_profile.esp
+                if existing_esp:
+                    existing_enc = [str(e.value) if hasattr(e, "value") else str(e) for e in existing_esp.encryption]
+                    if set(existing_enc) != set(esp_encryption):
+                        needs_update = True
+                        update_fields.append("esp_encryption")
+                    existing_auth = [str(a) for a in existing_esp.authentication]
+                    if set(existing_auth) != set(esp_authentication):
+                        needs_update = True
+                        update_fields.append("esp_authentication")
+
+                # Compare DH group
+                existing_dh = str(existing_profile.dh_group.value) if hasattr(existing_profile.dh_group, "value") else str(existing_profile.dh_group)
+                if existing_dh != dh_group:
+                    needs_update = True
+                    update_fields.append("dh_group")
+
+                if needs_update:
+                    self.logger.info(f"Updating IPsec crypto profile fields: {', '.join(update_fields)}")
+                    profile_data["id"] = str(existing_profile.id)
+                    result = self.client.ipsec_crypto_profile.update(profile_data)
+                    self.logger.info(f"Successfully updated IPsec crypto profile '{name}'")
+                    response = json.loads(result.model_dump_json(exclude_unset=True))
+                    response["__action__"] = "updated"
+                    return response
+                else:
+                    self.logger.info(f"No changes detected for IPsec crypto profile '{name}', skipping update")
+                    response = json.loads(existing_profile.model_dump_json(exclude_unset=True))
+                    response["__action__"] = "no_change"
+                    return response
+            else:
+                # Create new profile
+                result = self.client.ipsec_crypto_profile.create(profile_data)
+                self.logger.info(f"Successfully created IPsec crypto profile '{name}'")
+                response = json.loads(result.model_dump_json(exclude_unset=True))
+                response["__action__"] = "created"
+                return response
+
+        except Exception as e:
+            self._handle_api_exception("create/update", folder, name, e)
+
+    def delete_ipsec_crypto_profile(
+        self,
+        folder: str,
+        name: str,
+    ) -> bool:
+        """Delete an IPsec crypto profile.
+
+        Args:
+            folder: Folder containing the profile
+            name: Name of the profile to delete
+
+        Returns:
+            bool: True if deletion was successful
+
+        """
+        self.logger.info(f"Deleting IPsec crypto profile: {name} from folder {folder}")
+
+        if not self.client:
+            return True
+
+        try:
+            profile = self.client.ipsec_crypto_profile.fetch(name=name, folder=folder)
+            self.client.ipsec_crypto_profile.delete(str(profile.id))
+            self.logger.info(f"Successfully deleted IPsec crypto profile '{name}'")
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", folder, name, e)
+
+    def get_ipsec_crypto_profile(
+        self,
+        folder: str,
+        name: str,
+    ) -> dict[str, Any]:
+        """Get an IPsec crypto profile by name and folder.
+
+        Args:
+            folder: Folder containing the profile
+            name: Name of the profile to get
+
+        Returns:
+            dict[str, Any]: The IPsec crypto profile
+
+        """
+        self.logger.info(f"Getting IPsec crypto profile: {name} from folder {folder}")
+
+        if not self.client:
+            return {
+                "id": f"ipsec-crypto-{name}",
+                "folder": folder,
+                "name": name,
+                "esp": {
+                    "encryption": ["aes-256-cbc"],
+                    "authentication": ["sha256"],
+                },
+                "dh_group": "group14",
+                "lifetime": {"hours": 1},
+            }
+
+        try:
+            result = self.client.ipsec_crypto_profile.fetch(name=name, folder=folder)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("retrieval", folder, name, e)
+
+    def list_ipsec_crypto_profiles(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List IPsec crypto profiles in a container.
+
+        Args:
+            folder: Folder location
+            snippet: Snippet location
+            device: Device location
+            exact_match: If True, only return objects defined exactly in the specified container
+
+        Returns:
+            list[dict[str, Any]]: List of IPsec crypto profile objects
+
+        """
+        container = folder or snippet or device or "Texas"
+        self.logger.info(f"Listing IPsec crypto profiles in {folder=}, {snippet=}, {device=} (exact_match={exact_match})")
+
+        if not self.client:
+            return [
+                {
+                    "id": "ipsec-crypto-mock1",
+                    "folder": folder or "Texas",
+                    "name": "ipsec-esp-aes256-sha256",
+                    "esp": {
+                        "encryption": ["aes-256-cbc"],
+                        "authentication": ["sha256"],
+                    },
+                    "dh_group": "group14",
+                    "lifetime": {"hours": 1},
+                },
+                {
+                    "id": "ipsec-crypto-mock2",
+                    "folder": folder or "Texas",
+                    "name": "ipsec-esp-aes128-sha1",
+                    "esp": {
+                        "encryption": ["aes-128-cbc"],
+                        "authentication": ["sha1"],
+                    },
+                    "dh_group": "group2",
+                    "lifetime": {"seconds": 3600},
+                },
+                {
+                    "id": "ipsec-crypto-mock3",
+                    "folder": folder or "Texas",
+                    "name": "ipsec-esp-aes256gcm",
+                    "esp": {
+                        "encryption": ["aes-256-gcm"],
+                        "authentication": ["sha512"],
+                    },
+                    "dh_group": "group20",
+                    "lifetime": {"hours": 8},
+                    "lifesize": {"gb": 1},
+                },
+            ]
+
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+
+        try:
+            results = self.client.ipsec_crypto_profile.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", container, "IPsec crypto profiles", e)
+
     # ======================================================================================================================================================================================
     # SECURITY CONFIGURATION METHODS
     # ======================================================================================================================================================================================

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -7826,6 +7826,276 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("listing", container or "", "DNS security profiles", e)
 
+    # --------------------------------------------------------------------------- Vulnerability Protection Profile ---------------------------------------------------------------------------
+
+    def create_vulnerability_protection_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+        description: str | None = None,
+        threat_exception: list[dict[str, Any]] | None = None,
+        rules: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Create a vulnerability protection profile.
+
+        Args:
+            folder: Folder to create the profile in
+            snippet: Snippet to create the profile in
+            device: Device to create the profile in
+            name: Name of the profile
+            description: Optional description
+            threat_exception: List of threat exceptions
+            rules: List of vulnerability protection rules
+
+        Returns:
+            dict[str, Any]: The created vulnerability protection profile object
+
+        Note:
+            If a vulnerability protection profile with the same name already exists in the container,
+            it will be updated with the new configuration.
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Creating or updating vulnerability protection profile: {name} in {container_type} {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"vpp-{name}",
+                "folder": folder,
+                "snippet": snippet,
+                "device": device,
+                "name": name,
+                "description": description,
+                "threat_exception": threat_exception or [],
+                "rules": rules or [],
+            }
+
+        try:
+            # First, try to fetch the existing vulnerability protection profile
+            existing_profile = None
+            try:
+                existing_profile = self.client.vulnerability_protection_profile.fetch(name=name, folder=folder, snippet=snippet, device=device)
+                self.logger.info(f"Found existing vulnerability protection profile '{name}' in {container_type} '{container}', updating...")
+            except NotFoundError:
+                self.logger.info(f"Vulnerability protection profile '{name}' not found in {container_type} '{container}', creating new...")
+            except Exception as fetch_error:
+                # Log but continue - we'll try to create if fetch failed for other reasons
+                self.logger.warning(f"Error fetching vulnerability protection profile '{name}': {str(fetch_error)}")
+
+            # Prepare profile data
+            profile_data = {
+                "name": name,
+            }
+
+            # Add container field only if not None
+            if folder is not None:
+                profile_data["folder"] = folder
+            if snippet is not None:
+                profile_data["snippet"] = snippet
+            if device is not None:
+                profile_data["device"] = device
+
+            # Add optional fields if provided
+            if description is not None:
+                profile_data["description"] = description
+            if threat_exception is not None:
+                profile_data["threat_exception"] = threat_exception
+            if rules is not None:
+                profile_data["rules"] = rules
+
+            # Create or update the profile
+            if existing_profile:
+                # Update existing profile
+                profile_data["id"] = existing_profile.id
+                from scm.models.security import VulnerabilityProfileUpdateModel
+
+                update_model = VulnerabilityProfileUpdateModel(**profile_data)
+                result = self.client.vulnerability_protection_profile.update(update_model)
+            else:
+                # Create a new profile
+                result = self.client.vulnerability_protection_profile.create(profile_data)
+
+            # Convert response to dict
+            return json.loads(result.model_dump_json(exclude_unset=True))
+
+        except Exception as e:
+            self._handle_api_exception("creating", container or "", "vulnerability protection profile", e)
+
+    def delete_vulnerability_protection_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+    ) -> bool:
+        """Delete a vulnerability protection profile.
+
+        Args:
+            folder: Folder containing the profile
+            snippet: Snippet containing the profile
+            device: Device containing the profile
+            name: Name of the profile to delete
+
+        Returns:
+            bool: True if deleted successfully
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Deleting vulnerability protection profile: {name} from {container_type} {container}")
+
+        if not self.client:
+            # Return mock success if no client is available
+            return True
+
+        try:
+            # Fetch the profile to get its ID
+            profile = self.client.vulnerability_protection_profile.fetch(name=name, folder=folder, snippet=snippet, device=device)
+
+            # Delete using the ID
+            self.client.vulnerability_protection_profile.delete(profile.id)
+            self.logger.info(f"Successfully deleted vulnerability protection profile '{name}' from {container_type} '{container}'")
+            return True
+        except NotFoundError:
+            self.logger.warning(f"Vulnerability protection profile '{name}' not found in {container_type} '{container}'")
+            return False
+        except Exception as e:
+            self._handle_api_exception("deleting", container or "", "vulnerability protection profile", e)
+
+    def get_vulnerability_protection_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+    ) -> dict[str, Any]:
+        """Get a vulnerability protection profile by name.
+
+        Args:
+            folder: Folder containing the profile
+            snippet: Snippet containing the profile
+            device: Device containing the profile
+            name: Name of the profile
+
+        Returns:
+            dict[str, Any]: The vulnerability protection profile object
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+        self.logger.info(f"Getting vulnerability protection profile: {name} from {container_type} {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"vpp-{name}",
+                "folder": folder,
+                "snippet": snippet,
+                "device": device,
+                "name": name,
+                "description": "Mock vulnerability protection profile",
+                "rules": [
+                    {
+                        "name": "Block Critical Vulnerabilities",
+                        "severity": ["critical", "high"],
+                        "category": "any",
+                        "host": "any",
+                        "action": {"alert": {}},
+                        "packet_capture": "single-packet",
+                    }
+                ],
+            }
+
+        try:
+            # Fetch the profile using the SDK
+            result = self.client.vulnerability_protection_profile.fetch(name=name, folder=folder, snippet=snippet, device=device)
+
+            # Convert SDK response to dict
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", container or "", "vulnerability protection profile", e)
+
+    def list_vulnerability_protection_profiles(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List vulnerability protection profiles.
+
+        Args:
+            folder: Folder to list out
+            snippet: Snippet to list out
+            device: Device to list out
+            exact_match: If True, only return exact container matches
+
+        Returns:
+            list[dict[str, Any]]: List of vulnerability protection profile objects
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+
+        # Build container kwargs
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+
+        self.logger.info(f"Listing vulnerability protection profiles in {container_type}: {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return [
+                {
+                    "id": "vpp-mock1",
+                    "folder": folder or "Texas",
+                    "name": "Strict Vulnerability Protection",
+                    "description": "Block all critical and high severity vulnerabilities",
+                    "rules": [
+                        {
+                            "name": "Block Critical",
+                            "severity": ["critical", "high"],
+                            "category": "any",
+                            "host": "any",
+                            "action": {"alert": {}},
+                        }
+                    ],
+                },
+                {
+                    "id": "vpp-mock2",
+                    "folder": folder or "Texas",
+                    "name": "Standard Vulnerability Protection",
+                    "description": "Standard vulnerability protection",
+                    "rules": [
+                        {
+                            "name": "Alert Medium",
+                            "severity": ["medium"],
+                            "category": "any",
+                            "host": "any",
+                            "action": {"default": {}},
+                        }
+                    ],
+                },
+            ]
+
+        try:
+            # List profiles using the SDK
+            results = self.client.vulnerability_protection_profile.list(**container_kwargs, exact_match=exact_match)
+
+            # Convert SDK response to a list of dicts for compatibility
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", container or "", "vulnerability protection profiles", e)
+
     # ======================================================================================================================================================================================
     # INSIGHTS AND MONITORING METHODS
     # ======================================================================================================================================================================================

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -7151,6 +7151,305 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("listing", container or "", "WildFire antivirus profiles", e)
 
+    # ------------------------------------------------------------------------------- DNS Security Profile ---------------------------------------------------------------------------
+
+    def create_dns_security_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        **profile_data,
+    ) -> dict[str, Any]:
+        """Create or update a DNS security profile.
+
+        Args:
+            folder: Folder to create the profile in
+            snippet: Snippet to create the profile in
+            device: Device to create the profile in
+            **profile_data: Additional profile configuration data
+
+        Returns:
+            dict[str, Any]: Created/updated DNS security profile object
+
+        """
+        name = profile_data.get("name")
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+
+        self.logger.info(f"Creating/updating DNS security profile: {name} in {container_type} {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"dns-sec-{name}",
+                "name": name,
+                container_type: container,
+                "description": profile_data.get("description", ""),
+                "botnet_domains": profile_data.get("botnet_domains", {}),
+                "__action__": "created",
+            }
+
+        try:
+            # Check if the profile already exists
+            existing_profile = None
+            try:
+                if folder:
+                    existing_profile = self.client.dns_security_profile.fetch(name=name, folder=folder)
+                elif snippet:
+                    existing_profile = self.client.dns_security_profile.fetch(name=name, snippet=snippet)
+                elif device:
+                    existing_profile = self.client.dns_security_profile.fetch(name=name, device=device)
+            except NotFoundError:
+                self.logger.info(f"DNS security profile '{name}' not found. Creating new profile.")
+
+            if existing_profile:
+                # Update existing profile
+                self.logger.info(f"DNS security profile '{name}' exists. Updating.")
+
+                # Update with new data
+                for key, value in profile_data.items():
+                    if value is not None and hasattr(existing_profile, key):
+                        setattr(existing_profile, key, value)
+
+                # Update the profile
+                result = self.client.dns_security_profile.update(existing_profile)
+                self.logger.info(f"Successfully updated DNS security profile '{name}'")
+                result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                result_dict["__action__"] = "updated"
+                return result_dict
+            else:
+                # Create a new profile
+                profile_dict = {container_type: container}
+                profile_dict.update(profile_data)
+
+                result = self.client.dns_security_profile.create(profile_dict)
+                self.logger.info(f"Successfully created DNS security profile '{name}'")
+                result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                result_dict["__action__"] = "created"
+                return result_dict
+        except Exception as e:
+            self._handle_api_exception("creation/update", container or "", name or "", e)
+
+    def delete_dns_security_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+    ) -> bool:
+        """Delete a DNS security profile.
+
+        Args:
+            folder: Folder containing the profile
+            snippet: Snippet containing the profile
+            device: Device containing the profile
+            name: Name of the profile to delete
+
+        Returns:
+            bool: True if deletion was successful
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+
+        self.logger.info(f"Deleting DNS security profile: {name} from {container_type} {container}")
+
+        if not self.client:
+            # Return a mock result if no client is available
+            return True
+
+        try:
+            # Get the profile first to get its ID
+            profile = None
+            if folder:
+                profile = self.client.dns_security_profile.fetch(name=name, folder=folder)
+            elif snippet:
+                profile = self.client.dns_security_profile.fetch(name=name, snippet=snippet)
+            elif device:
+                profile = self.client.dns_security_profile.fetch(name=name, device=device)
+
+            # Delete using the ID
+            if profile is None:
+                raise ValueError(f"DNS security profile '{name}' not found")
+            self.client.dns_security_profile.delete(str(profile.id))
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", container or "", name or "", e)
+
+    def get_dns_security_profile(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        name: str = None,
+    ) -> dict[str, Any]:
+        """Get a DNS security profile by name.
+
+        Args:
+            folder: Folder containing the profile
+            snippet: Snippet containing the profile
+            device: Device containing the profile
+            name: Name of the profile to get
+
+        Returns:
+            dict[str, Any]: The DNS security profile object
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+
+        self.logger.info(f"Getting DNS security profile: {name} from {container_type} {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"dns-sec-{name}",
+                container_type: container,
+                "name": name,
+                "description": "Mock DNS security profile",
+                "botnet_domains": {
+                    "dns_security_categories": [
+                        {
+                            "name": "pan-dns-sec-grayware",
+                            "action": "default",
+                            "log_level": "default",
+                            "packet_capture": "disable",
+                        },
+                        {
+                            "name": "pan-dns-sec-malware",
+                            "action": "sinkhole",
+                            "log_level": "default",
+                            "packet_capture": "single-packet",
+                        },
+                    ],
+                    "sinkhole": {
+                        "ipv4_address": "pan-sinkhole-default-ip",
+                        "ipv6_address": "::1",
+                    },
+                    "whitelist": [
+                        {
+                            "name": "example.com",
+                            "description": "Whitelisted domain",
+                        },
+                    ],
+                },
+            }
+
+        try:
+            # Fetch the profile using the SDK
+            result = None
+            if folder:
+                result = self.client.dns_security_profile.fetch(name=name, folder=folder)
+            elif snippet:
+                result = self.client.dns_security_profile.fetch(name=name, snippet=snippet)
+            elif device:
+                result = self.client.dns_security_profile.fetch(name=name, device=device)
+
+            # Convert SDK response to dict for compatibility
+            if result is not None:
+                return json.loads(result.model_dump_json(exclude_unset=True))
+            else:
+                raise ValueError(f"DNS security profile '{name}' not found")
+        except Exception as e:
+            self._handle_api_exception("getting", container or "", "DNS security profile", e)
+
+    def list_dns_security_profiles(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List DNS security profiles.
+
+        Args:
+            folder: Folder to list from
+            snippet: Snippet to list from
+            device: Device to list from
+            exact_match: If True, only return exact container matches
+
+        Returns:
+            list[dict[str, Any]]: List of DNS security profile objects
+
+        """
+        container = folder or snippet or device
+        container_type = "folder" if folder else ("snippet" if snippet else "device")
+
+        # Build container kwargs
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+
+        self.logger.info(f"Listing DNS security profiles in {container_type}: {container}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return [
+                {
+                    "id": "dns-sec-mock1",
+                    "folder": folder or "Texas",
+                    "name": "DNS-Security-Default",
+                    "description": "Default DNS security profile",
+                    "botnet_domains": {
+                        "dns_security_categories": [
+                            {
+                                "name": "pan-dns-sec-grayware",
+                                "action": "default",
+                                "log_level": "default",
+                            },
+                            {
+                                "name": "pan-dns-sec-malware",
+                                "action": "sinkhole",
+                                "log_level": "default",
+                                "packet_capture": "single-packet",
+                            },
+                        ],
+                        "sinkhole": {
+                            "ipv4_address": "pan-sinkhole-default-ip",
+                            "ipv6_address": "::1",
+                        },
+                    },
+                },
+                {
+                    "id": "dns-sec-mock2",
+                    "folder": folder or "Texas",
+                    "name": "DNS-Security-Strict",
+                    "description": "Strict DNS security profile",
+                    "botnet_domains": {
+                        "dns_security_categories": [
+                            {
+                                "name": "pan-dns-sec-grayware",
+                                "action": "block",
+                                "log_level": "high",
+                            },
+                            {
+                                "name": "pan-dns-sec-malware",
+                                "action": "sinkhole",
+                                "log_level": "critical",
+                                "packet_capture": "extended-capture",
+                            },
+                        ],
+                        "sinkhole": {
+                            "ipv4_address": "pan-sinkhole-default-ip",
+                            "ipv6_address": "::1",
+                        },
+                    },
+                },
+            ]
+
+        try:
+            # List profiles using the SDK
+            results = self.client.dns_security_profile.list(**container_kwargs, exact_match=exact_match)
+
+            # Convert SDK response to a list of dicts for compatibility
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", container or "", "DNS security profiles", e)
+
     # ======================================================================================================================================================================================
     # INSIGHTS AND MONITORING METHODS
     # ======================================================================================================================================================================================

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -2110,6 +2110,85 @@ class DecryptionProfile(BaseModel):
         return model_data
 
 
+class WildfireAntivirusProfile(BaseModel):
+    """Model for WildFire antivirus profile configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the WildFire antivirus profile")
+    snippet: str | None = Field(None, description="Snippet path for the WildFire antivirus profile")
+    device: str | None = Field(None, description="Device path for the WildFire antivirus profile")
+    name: str = Field(..., description="Name of the WildFire antivirus profile")
+    description: str | None = Field(None, description="Description of the WildFire antivirus profile")
+
+    # Packet capture
+    packet_capture: bool | None = Field(None, description="Enable packet capture")
+
+    # Rules configuration
+    rules: list[dict[str, Any]] | None = Field(None, description="List of WildFire antivirus rules")
+
+    # MLAV exceptions
+    mlav_exception: list[dict[str, Any]] | None = Field(None, description="List of MLAV exceptions")
+
+    # Threat exceptions
+    threat_exception: list[dict[str, Any]] | None = Field(None, description="List of threat exceptions")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "WildfireAntivirusProfile":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @field_validator("rules")
+    def validate_rules(cls, v: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:  # noqa: N805
+        """Validate rules configuration."""
+        if v is None:
+            return v
+
+        valid_directions = ["download", "upload", "both"]
+        valid_analyses = ["public-cloud", "private-cloud"]
+
+        for idx, rule in enumerate(v):
+            if "name" not in rule:
+                raise ValueError(f"Rule {idx}: 'name' is required")
+            if "direction" not in rule:
+                raise ValueError(f"Rule {idx}: 'direction' is required")
+            if rule["direction"] not in valid_directions:
+                raise ValueError(f"Rule {idx}: Invalid direction '{rule['direction']}'")
+            if "analysis" in rule and rule["analysis"] is not None and rule["analysis"] not in valid_analyses:
+                raise ValueError(f"Rule {idx}: Invalid analysis '{rule['analysis']}'")
+
+        return v
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data = {
+            "name": self.name,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Add optional fields
+        if self.description:
+            model_data["description"] = self.description
+        if self.packet_capture is not None:
+            model_data["packet_capture"] = self.packet_capture
+        if self.rules:
+            model_data["rules"] = self.rules
+        if self.mlav_exception:
+            model_data["mlav_exception"] = self.mlav_exception
+        if self.threat_exception:
+            model_data["threat_exception"] = self.threat_exception
+
+        return model_data
+
+
 # ========================================================================================================================================================================================
 # UTILITY FUNCTIONS
 # ========================================================================================================================================================================================

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -1856,6 +1856,103 @@ class Zone(BaseModel):
         return model_data
 
 
+class IPSecCryptoProfile(BaseModel):
+    """Model for IPsec crypto profile configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the IPsec crypto profile")
+    snippet: str | None = Field(None, description="Snippet path for the IPsec crypto profile")
+    device: str | None = Field(None, description="Device path for the IPsec crypto profile")
+    name: str = Field(..., description="Name of the IPsec crypto profile")
+    esp_encryption: list[str] = Field(default_factory=lambda: ["aes-256-cbc"], description="ESP encryption algorithms")
+    esp_authentication: list[str] = Field(default_factory=lambda: ["sha256"], description="ESP authentication algorithms")
+    dh_group: str = Field("group14", description="DH group for PFS")
+    lifetime_seconds: int | None = Field(None, description="Lifetime in seconds (180-65535)")
+    lifetime_minutes: int | None = Field(None, description="Lifetime in minutes (3-65535)")
+    lifetime_hours: int | None = Field(None, description="Lifetime in hours (1-65535)")
+    lifetime_days: int | None = Field(None, description="Lifetime in days (1-365)")
+    lifesize_kb: int | None = Field(None, description="Lifesize in KB (1-65535)")
+    lifesize_mb: int | None = Field(None, description="Lifesize in MB (1-65535)")
+    lifesize_gb: int | None = Field(None, description="Lifesize in GB (1-65535)")
+    lifesize_tb: int | None = Field(None, description="Lifesize in TB (1-65535)")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "IPSecCryptoProfile":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @field_validator("esp_encryption")
+    def validate_esp_encryption(cls, v: list[str]) -> list[str]:  # noqa: N805
+        """Validate ESP encryption algorithms."""
+        valid = ["des", "3des", "aes-128-cbc", "aes-192-cbc", "aes-256-cbc", "aes-128-gcm", "aes-256-gcm", "null"]
+        for alg in v:
+            if alg not in valid:
+                raise ValueError(f"Invalid ESP encryption algorithm '{alg}'. Valid: {', '.join(valid)}")
+        return v
+
+    @field_validator("esp_authentication")
+    def validate_esp_authentication(cls, v: list[str]) -> list[str]:  # noqa: N805
+        """Validate ESP authentication algorithms."""
+        valid = ["md5", "sha1", "sha256", "sha384", "sha512"]
+        for alg in v:
+            if alg not in valid:
+                raise ValueError(f"Invalid ESP authentication algorithm '{alg}'. Valid: {', '.join(valid)}")
+        return v
+
+    @field_validator("dh_group")
+    def validate_dh_group(cls, v: str) -> str:  # noqa: N805
+        """Validate DH group."""
+        valid = ["no-pfs", "group1", "group2", "group5", "group14", "group19", "group20"]
+        if v not in valid:
+            raise ValueError(f"Invalid DH group '{v}'. Valid: {', '.join(valid)}")
+        return v
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "name": self.name,
+            "dh_group": self.dh_group,
+            "esp": {
+                "encryption": self.esp_encryption,
+                "authentication": self.esp_authentication,
+            },
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Build lifetime - default to 1 hour if none specified
+        if self.lifetime_seconds:
+            model_data["lifetime"] = {"seconds": self.lifetime_seconds}
+        elif self.lifetime_minutes:
+            model_data["lifetime"] = {"minutes": self.lifetime_minutes}
+        elif self.lifetime_hours:
+            model_data["lifetime"] = {"hours": self.lifetime_hours}
+        elif self.lifetime_days:
+            model_data["lifetime"] = {"days": self.lifetime_days}
+        else:
+            model_data["lifetime"] = {"hours": 1}
+
+        # Build lifesize if specified
+        if self.lifesize_kb:
+            model_data["lifesize"] = {"kb": self.lifesize_kb}
+        elif self.lifesize_mb:
+            model_data["lifesize"] = {"mb": self.lifesize_mb}
+        elif self.lifesize_gb:
+            model_data["lifesize"] = {"gb": self.lifesize_gb}
+        elif self.lifesize_tb:
+            model_data["lifesize"] = {"tb": self.lifesize_tb}
+
+        return model_data
+
+
 # ========================================================================================================================================================================================
 # SECURITY CONFIGURATION MODELS
 # ========================================================================================================================================================================================

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -2403,6 +2403,66 @@ class DNSSecurityProfile(BaseModel):
         return model_data
 
 
+class URLCategory(BaseModel):
+    """Model for URL category configurations."""
+
+    model_config = {"populate_by_name": True}
+
+    folder: str | None = Field(None, description="Folder path for the URL category")
+    snippet: str | None = Field(None, description="Snippet path for the URL category")
+    device: str | None = Field(None, description="Device path for the URL category")
+    name: str = Field(..., description="Name of the URL category")
+    description: str | None = Field(None, description="Description of the URL category")
+
+    # URL category type
+    type: str | None = Field("URL List", description="Type of the URL category (URL List or Category Match)")
+
+    # List of URLs or categories - use alias to match SDK field name "list"
+    url_list: list[str] = Field(default_factory=list, alias="list", description="List of URLs or category matches")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "URLCategory":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @field_validator("type")
+    def validate_type(cls, v: str | None) -> str | None:  # noqa: N805
+        """Validate URL category type."""
+        if v is None:
+            return v
+        valid_types = ["URL List", "Category Match"]
+        if v not in valid_types:
+            raise ValueError(f"Invalid type '{v}'. Must be one of: {', '.join(valid_types)}")
+        return v
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data = {
+            "name": self.name,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Add optional fields
+        if self.description:
+            model_data["description"] = self.description
+        if self.type:
+            model_data["type"] = self.type
+        if self.url_list:
+            model_data["list"] = self.url_list
+
+        return model_data
+
+
 # ========================================================================================================================================================================================
 # UTILITY FUNCTIONS
 # ========================================================================================================================================================================================

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -2448,6 +2448,138 @@ def validate_yaml_file(data: dict[str, Any], model_class: type[ModelT], key: str
     return validated_items
 
 
+class VulnerabilityProtectionProfile(BaseModel):
+    """Model for vulnerability protection profile configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the vulnerability protection profile")
+    snippet: str | None = Field(None, description="Snippet path for the vulnerability protection profile")
+    device: str | None = Field(None, description="Device path for the vulnerability protection profile")
+    name: str = Field(..., description="Name of the vulnerability protection profile")
+    description: str | None = Field(None, description="Description of the vulnerability protection profile")
+
+    # Threat exceptions
+    threat_exceptions: list[dict[str, Any]] | None = Field(None, description="List of threat exceptions")
+
+    # Rules configuration
+    rules: list[dict[str, Any]] | None = Field(None, description="List of vulnerability protection rules")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "VulnerabilityProtectionProfile":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @field_validator("rules")
+    def validate_rules(cls, v: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:  # noqa: N805
+        """Validate rules configuration."""
+        if v is None:
+            return v
+
+        for idx, rule in enumerate(v):
+            # Required fields
+            if "name" not in rule:
+                raise ValueError(f"Rule {idx}: 'name' is required")
+            if "severity" not in rule:
+                raise ValueError(f"Rule {idx}: 'severity' is required")
+            if "host" not in rule:
+                raise ValueError(f"Rule {idx}: 'host' is required")
+
+            # Validate severity
+            valid_severities = [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "informational",
+                "any",
+            ]
+            if isinstance(rule["severity"], list):
+                for sev in rule["severity"]:
+                    if sev not in valid_severities:
+                        raise ValueError(f"Rule {idx}: Invalid severity '{sev}'")
+            elif rule["severity"] not in valid_severities:
+                raise ValueError(f"Rule {idx}: Invalid severity '{rule['severity']}'")
+
+            # Validate host if present
+            valid_hosts = ["any", "client", "server"]
+            if rule["host"] not in valid_hosts:
+                raise ValueError(f"Rule {idx}: Invalid host '{rule['host']}'")
+
+            # Validate action if present
+            if "action" in rule:
+                valid_actions = [
+                    "allow",
+                    "alert",
+                    "drop",
+                    "reset-client",
+                    "reset-server",
+                    "reset-both",
+                    "block-ip",
+                    "default",
+                ]
+                action = rule["action"]
+                if isinstance(action, dict):
+                    # Action is a dict like {"block_ip": {"track_by": "source", "duration": 300}}
+                    pass
+                elif action not in valid_actions:
+                    raise ValueError(f"Rule {idx}: Invalid action '{action}'")
+
+            # Validate packet_capture if present
+            if "packet_capture" in rule:
+                valid_captures = ["disable", "single-packet", "extended-capture"]
+                if rule["packet_capture"] not in valid_captures:
+                    raise ValueError(f"Rule {idx}: Invalid packet_capture '{rule['packet_capture']}'")
+
+            # Validate category if present
+            if "category" in rule:
+                valid_categories = [
+                    "any",
+                    "brute-force",
+                    "code-execution",
+                    "code-obfuscation",
+                    "command-execution",
+                    "dos",
+                    "exploit-kit",
+                    "info-leak",
+                    "insecure-credentials",
+                    "overflow",
+                    "phishing",
+                    "protocol-anomaly",
+                    "scan",
+                    "sql-injection",
+                ]
+                if rule["category"] not in valid_categories:
+                    raise ValueError(f"Rule {idx}: Invalid category '{rule['category']}'")
+
+        return v
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data = {
+            "name": self.name,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Add optional fields
+        if self.description:
+            model_data["description"] = self.description
+        if self.threat_exceptions:
+            model_data["threat_exception"] = self.threat_exceptions
+        if self.rules:
+            model_data["rules"] = self.rules
+
+        return model_data
+
+
 # ========================================================================================================================================================================================
 # INSIGHTS AND MONITORING MODELS
 # ========================================================================================================================================================================================

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -1702,6 +1702,80 @@ class Tag(BaseModel):
 # ========================================================================================================================================================================================
 
 
+class NATRule(BaseModel):
+    """Model for NAT rule configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the NAT rule")
+    snippet: str | None = Field(None, description="Snippet path for the NAT rule")
+    device: str | None = Field(None, description="Device path for the NAT rule")
+    name: str = Field(..., description="Name of the NAT rule")
+    description: str | None = Field(None, description="Description of the NAT rule")
+    tag: list[str] | None = Field(None, description="Tags associated with the NAT rule")
+    disabled: bool = Field(False, description="Whether the NAT rule is disabled")
+    nat_type: str = Field("ipv4", description="NAT type (ipv4, nat64, nptv6)")
+    from_zone: list[str] = Field(default_factory=lambda: ["any"], alias="from", description="Source zone(s)")
+    to_zone: list[str] = Field(default_factory=lambda: ["any"], alias="to", description="Destination zone(s)")
+    to_interface: str | None = Field(None, description="Destination interface")
+    source: list[str] = Field(default_factory=lambda: ["any"], description="Source address(es)")
+    destination: list[str] = Field(default_factory=lambda: ["any"], description="Destination address(es)")
+    service: str = Field("any", description="TCP/UDP service")
+    source_translation: dict[str, Any] | None = Field(None, description="Source translation configuration")
+    destination_translation: dict[str, Any] | None = Field(None, description="Destination translation configuration")
+    active_active_device_binding: str | None = Field(None, description="Active/Active device binding")
+
+    model_config = {"populate_by_name": True}
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "NATRule":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "name": self.name,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Add optional fields
+        if self.description:
+            model_data["description"] = self.description
+        if self.tag:
+            model_data["tag"] = self.tag
+        if self.disabled:
+            model_data["disabled"] = self.disabled
+        if self.nat_type != "ipv4":
+            model_data["nat_type"] = self.nat_type
+
+        # Zone fields use 'from' and 'to' aliases in the SDK
+        model_data["from_"] = self.from_zone
+        model_data["to_"] = self.to_zone
+        model_data["source"] = self.source
+        model_data["destination"] = self.destination
+        model_data["service"] = self.service
+
+        if self.to_interface:
+            model_data["to_interface"] = self.to_interface
+        if self.source_translation:
+            model_data["source_translation"] = self.source_translation
+        if self.destination_translation:
+            model_data["destination_translation"] = self.destination_translation
+        if self.active_active_device_binding:
+            model_data["active_active_device_binding"] = self.active_active_device_binding
+
+        return model_data
+
+
 class IKECryptoProfile(BaseModel):
     """Model for IKE crypto profile configurations."""
 

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -2286,6 +2286,49 @@ class WildfireAntivirusProfile(BaseModel):
         return model_data
 
 
+class DNSSecurityProfile(BaseModel):
+    """Model for DNS security profile configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the DNS security profile")
+    snippet: str | None = Field(None, description="Snippet path for the DNS security profile")
+    device: str | None = Field(None, description="Device path for the DNS security profile")
+    name: str = Field(..., description="Name of the DNS security profile")
+    description: str | None = Field(None, description="Description of the DNS security profile")
+
+    # Botnet domains configuration (passed as JSON)
+    botnet_domains: dict[str, Any] | None = Field(None, description="Botnet domains settings as dict")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "DNSSecurityProfile":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data = {
+            "name": self.name,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Add optional fields
+        if self.description:
+            model_data["description"] = self.description
+        if self.botnet_domains:
+            model_data["botnet_domains"] = self.botnet_domains
+
+        return model_data
+
+
 # ========================================================================================================================================================================================
 # UTILITY FUNCTIONS
 # ========================================================================================================================================================================================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,34 @@ def mock_ipsec_crypto_profiles_yaml_file(test_config_path, tmp_path):
 
 
 @pytest.fixture
+def mock_nat_rules_yaml_file(test_config_path, tmp_path):
+    """Create a mock YAML file for NAT rules testing."""
+    yaml_content = """
+    nat_rules:
+      - name: outbound-nat
+        folder: Texas
+        nat_type: ipv4
+        from:
+          - trust
+        to:
+          - untrust
+        source:
+          - any
+        destination:
+          - any
+        service: any
+        source_translation:
+          dynamic_ip_and_port:
+            type: dynamic_ip_and_port
+            translated_address:
+              - 10.0.0.1
+    """
+    test_file = tmp_path / "test_nat_rules.yml"
+    test_file.write_text(yaml_content)
+    return test_file
+
+
+@pytest.fixture
 def mock_security_rules_yaml_file(test_config_path, tmp_path):
     """Create a mock YAML file for security rules testing."""
     yaml_content = """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,25 @@ def mock_address_groups_yaml_file(test_config_path, tmp_path):
 
 
 @pytest.fixture
+def mock_ipsec_crypto_profiles_yaml_file(test_config_path, tmp_path):
+    """Create a mock YAML file for IPsec crypto profiles testing."""
+    yaml_content = """
+    ipsec_crypto_profiles:
+      - name: test-ipsec-profile
+        folder: Texas
+        esp_encryption:
+          - aes-256-cbc
+        esp_authentication:
+          - sha256
+        dh_group: group14
+        lifetime_hours: 1
+    """
+    test_file = tmp_path / "test_ipsec_crypto_profiles.yml"
+    test_file.write_text(yaml_content)
+    return test_file
+
+
+@pytest.fixture
 def mock_security_rules_yaml_file(test_config_path, tmp_path):
     """Create a mock YAML file for security rules testing."""
     yaml_content = """

--- a/tests/test_network_commands.py
+++ b/tests/test_network_commands.py
@@ -4,14 +4,18 @@ import typer  # noqa: I001
 from scm_cli.commands.network import (
     delete_app,
     delete_ike_crypto_profile,
+    delete_ipsec_crypto_profile,
     delete_zone,
     load_app,
     load_ike_crypto_profile,
+    load_ipsec_crypto_profile,
     load_security_zone as load_zone,
     set_app,
     set_ike_crypto_profile,
+    set_ipsec_crypto_profile,
     set_zone,
     show_ike_crypto_profile,
+    show_ipsec_crypto_profile,
 )
 
 
@@ -363,3 +367,239 @@ class TestIKECryptoProfileCommands:
         assert result.exit_code == 0
         assert "Created IKE crypto profile" in result.stdout
         assert "test-profile" in result.stdout
+class TestIPsecCryptoProfileCommands:
+    """Test the IPsec crypto profile commands."""
+
+    def test_set_ipsec_crypto_profile_command(self, runner, monkeypatch):
+        """Test the set ipsec-crypto-profile command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "ipsec-crypto-12345",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "esp": {
+                    "encryption": kwargs.get("esp_encryption", ["aes-256-cbc"]),
+                    "authentication": kwargs.get("esp_authentication", ["sha256"]),
+                },
+                "dh_group": kwargs.get("dh_group", "group14"),
+                "lifetime": kwargs.get("lifetime", {"hours": 1}),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_ipsec_crypto_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_ipsec_crypto_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-profile",
+                "--esp-encryption",
+                "aes-256-cbc",
+                "--esp-authentication",
+                "sha256",
+                "--dh-group",
+                "group14",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "test-profile" in result.stdout
+        assert "created" in result.stdout
+
+    def test_set_ipsec_crypto_profile_error(self, runner, monkeypatch):
+        """Test the set ipsec-crypto-profile command with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create_error(*args, **kwargs):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "create_ipsec_crypto_profile", mock_create_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_ipsec_crypto_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-profile",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error creating IPsec crypto profile" in result.stdout
+
+    def test_delete_ipsec_crypto_profile_command(self, runner, monkeypatch):
+        """Test the delete ipsec-crypto-profile command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "delete_ipsec_crypto_profile", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_ipsec_crypto_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-profile",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted IPsec crypto profile" in result.stdout
+        assert "test-profile" in result.stdout
+
+    def test_show_ipsec_crypto_profile_single(self, runner, monkeypatch):
+        """Test the show ipsec-crypto-profile command for a single profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "ipsec-crypto-12345",
+                "name": "test-profile",
+                "folder": "Texas",
+                "esp": {
+                    "encryption": ["aes-256-cbc"],
+                    "authentication": ["sha256"],
+                },
+                "dh_group": "group14",
+                "lifetime": {"hours": 1},
+            }
+
+        monkeypatch.setattr(scm_client, "get_ipsec_crypto_profile", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_ipsec_crypto_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-profile",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "test-profile" in result.stdout
+        assert "aes-256-cbc" in result.stdout
+        assert "group14" in result.stdout
+
+    def test_show_ipsec_crypto_profile_list(self, runner, monkeypatch):
+        """Test the show ipsec-crypto-profile command for listing."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "ipsec-crypto-1",
+                    "name": "profile-1",
+                    "folder": "Texas",
+                    "esp": {
+                        "encryption": ["aes-256-cbc"],
+                        "authentication": ["sha256"],
+                    },
+                    "dh_group": "group14",
+                    "lifetime": {"hours": 1},
+                },
+                {
+                    "id": "ipsec-crypto-2",
+                    "name": "profile-2",
+                    "folder": "Texas",
+                    "esp": {
+                        "encryption": ["aes-128-cbc"],
+                        "authentication": ["sha1"],
+                    },
+                    "dh_group": "group2",
+                    "lifetime": {"seconds": 3600},
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_ipsec_crypto_profiles", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_ipsec_crypto_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "profile-1" in result.stdout
+        assert "profile-2" in result.stdout
+
+    def test_load_ipsec_crypto_profile_command(self, runner, monkeypatch, mock_ipsec_crypto_profiles_yaml_file):
+        """Test the load ipsec-crypto-profile command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        created_profiles = []
+
+        def mock_create(*args, **kwargs):
+            result = {
+                "id": f"ipsec-crypto-{len(created_profiles) + 1}",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "esp": {
+                    "encryption": kwargs.get("esp_encryption", ["aes-256-cbc"]),
+                    "authentication": kwargs.get("esp_authentication", ["sha256"]),
+                },
+                "dh_group": kwargs.get("dh_group", "group14"),
+                "lifetime": kwargs.get("lifetime", {"hours": 1}),
+                "__action__": "created",
+            }
+            created_profiles.append(result)
+            return result
+
+        monkeypatch.setattr(scm_client, "create_ipsec_crypto_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_ipsec_crypto_profile)
+
+        result = runner.invoke(test_app, ["--file", str(mock_ipsec_crypto_profiles_yaml_file)])
+
+        assert result.exit_code == 0
+        assert "test-ipsec-profile" in result.stdout
+        assert "created" in result.stdout
+        assert len(created_profiles) == 1
+
+    def test_load_ipsec_crypto_profile_dry_run(self, runner, monkeypatch, mock_ipsec_crypto_profiles_yaml_file):
+        """Test the load ipsec-crypto-profile command with dry-run."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        mock_called = False
+
+        def mock_create(*args, **kwargs):
+            nonlocal mock_called
+            mock_called = True
+            return {}
+
+        monkeypatch.setattr(scm_client, "create_ipsec_crypto_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_ipsec_crypto_profile)
+
+        result = runner.invoke(test_app, ["--file", str(mock_ipsec_crypto_profiles_yaml_file), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+        assert not mock_called

--- a/tests/test_network_commands.py
+++ b/tests/test_network_commands.py
@@ -5,17 +5,21 @@ from scm_cli.commands.network import (
     delete_app,
     delete_ike_crypto_profile,
     delete_ipsec_crypto_profile,
+    delete_nat_rule,
     delete_zone,
     load_app,
     load_ike_crypto_profile,
     load_ipsec_crypto_profile,
+    load_nat_rule,
     load_security_zone as load_zone,
     set_app,
     set_ike_crypto_profile,
     set_ipsec_crypto_profile,
+    set_nat_rule,
     set_zone,
     show_ike_crypto_profile,
     show_ipsec_crypto_profile,
+    show_nat_rule,
 )
 
 
@@ -599,6 +603,289 @@ class TestIPsecCryptoProfileCommands:
         test_app.command()(load_ipsec_crypto_profile)
 
         result = runner.invoke(test_app, ["--file", str(mock_ipsec_crypto_profiles_yaml_file), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+        assert not mock_called
+
+
+class TestNATRuleCommands:
+    """Test the NAT rule commands."""
+
+    def test_set_nat_rule_command(self, runner, monkeypatch):
+        """Test the set nat-rule command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "nat-12345",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "from_": kwargs.get("from_zones", ["any"]),
+                "to_": kwargs.get("to_zones", ["any"]),
+                "source": kwargs.get("source", ["any"]),
+                "destination": kwargs.get("destination", ["any"]),
+                "service": kwargs.get("service", "any"),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_nat_rule", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_nat_rule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "outbound-nat",
+                "--from-zone",
+                "trust",
+                "--to-zone",
+                "untrust",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created NAT rule" in result.stdout
+        assert "outbound-nat" in result.stdout
+
+    def test_set_nat_rule_with_translation(self, runner, monkeypatch):
+        """Test the set nat-rule command with source translation."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "nat-12345",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "source_translation": kwargs.get("source_translation"),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_nat_rule", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_nat_rule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "outbound-nat",
+                "--source-translation",
+                '{"dynamic_ip_and_port": {"type": "dynamic_ip_and_port", "translated_address": ["10.0.0.1"]}}',
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created NAT rule" in result.stdout
+
+    def test_set_nat_rule_error(self, runner, monkeypatch):
+        """Test the set nat-rule command with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create_error(*args, **kwargs):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "create_nat_rule", mock_create_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_nat_rule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "outbound-nat",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error creating NAT rule" in result.stdout
+
+    def test_delete_nat_rule_command(self, runner, monkeypatch):
+        """Test the delete nat-rule command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "delete_nat_rule", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_nat_rule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "outbound-nat",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted NAT rule" in result.stdout
+        assert "outbound-nat" in result.stdout
+
+    def test_delete_nat_rule_error(self, runner, monkeypatch):
+        """Test the delete nat-rule command with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete_error(*args, **kwargs):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "delete_nat_rule", mock_delete_error)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_nat_rule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "outbound-nat",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error deleting NAT rule" in result.stdout
+
+    def test_show_nat_rule_single(self, runner, monkeypatch):
+        """Test showing a single NAT rule."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "nat-12345",
+                "folder": "Texas",
+                "name": "outbound-nat",
+                "nat_type": "ipv4",
+                "from_": ["trust"],
+                "to_": ["untrust"],
+                "source": ["any"],
+                "destination": ["any"],
+                "service": "any",
+            }
+
+        monkeypatch.setattr(scm_client, "get_nat_rule", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_nat_rule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "outbound-nat",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "outbound-nat" in result.stdout
+        assert "trust" in result.stdout
+
+    def test_show_nat_rule_list(self, runner, monkeypatch):
+        """Test listing NAT rules."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "nat-1",
+                    "folder": "Texas",
+                    "name": "outbound-nat",
+                    "from_": ["trust"],
+                    "to_": ["untrust"],
+                    "source": ["any"],
+                    "destination": ["any"],
+                    "service": "any",
+                },
+                {
+                    "id": "nat-2",
+                    "folder": "Texas",
+                    "name": "inbound-web",
+                    "from_": ["untrust"],
+                    "to_": ["trust"],
+                    "source": ["any"],
+                    "destination": ["203.0.113.10"],
+                    "service": "service-http",
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_nat_rules", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_nat_rule)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "outbound-nat" in result.stdout
+        assert "inbound-web" in result.stdout
+
+    def test_load_nat_rule_command(self, runner, monkeypatch, mock_nat_rules_yaml_file):
+        """Test the load nat-rule command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        created_rules = []
+
+        def mock_create(*args, **kwargs):
+            result = {
+                "id": f"nat-{len(created_rules) + 1}",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "__action__": "created",
+            }
+            created_rules.append(result)
+            return result
+
+        monkeypatch.setattr(scm_client, "create_nat_rule", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_nat_rule)
+
+        result = runner.invoke(test_app, ["--file", str(mock_nat_rules_yaml_file)])
+
+        assert result.exit_code == 0
+        assert "Successfully processed" in result.stdout
+        assert len(created_rules) == 1
+
+    def test_load_nat_rule_dry_run(self, runner, monkeypatch, mock_nat_rules_yaml_file):
+        """Test the load nat-rule command with dry-run option."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        mock_called = False
+
+        def mock_create(*args, **kwargs):
+            nonlocal mock_called
+            mock_called = True
+            return {}
+
+        monkeypatch.setattr(scm_client, "create_nat_rule", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_nat_rule)
+
+        result = runner.invoke(test_app, ["--file", str(mock_nat_rules_yaml_file), "--dry-run"])
 
         assert result.exit_code == 0
         assert "Dry run mode" in result.stdout

--- a/tests/test_security_commands.py
+++ b/tests/test_security_commands.py
@@ -1,13 +1,18 @@
 """Tests for the security commands module."""
 
 import typer
+
 from scm_cli.commands.security import (
     delete_app,
     delete_security_rule,
+    delete_wildfire_antivirus_profile,
     load_app,
     load_security_rule,
+    load_wildfire_antivirus_profile,
     set_app,
     set_security_rule,
+    set_wildfire_antivirus_profile,
+    show_wildfire_antivirus_profile,
 )
 
 
@@ -252,3 +257,246 @@ class TestSecurityRuleCommands:
         assert result.exit_code == 0
         assert "Dry run mode" in result.stdout
         assert not mock_called  # Ensure the create method was not called
+
+
+class TestWildfireAntivirusProfileCommands:
+    """Test the WildFire antivirus profile commands."""
+
+    def _mock_scm_client(self, monkeypatch):
+        """Set up a mock SCM client to avoid real API calls."""
+        from unittest.mock import MagicMock
+
+        import scm_cli.commands.security as sec_module
+
+        mock_client = MagicMock()
+        monkeypatch.setattr(sec_module, "scm_client", mock_client)
+        return mock_client
+
+    def test_set_wildfire_antivirus_profile_command(self, runner, monkeypatch):
+        """Test the set wildfire-antivirus-profile command."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.create_wildfire_antivirus_profile.return_value = {
+            "id": "wfav-12345",
+            "name": "wf-test",
+            "folder": "Texas",
+            "rules": [],
+        }
+
+        test_app = typer.Typer()
+        test_app.command()(set_wildfire_antivirus_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "wf-test",
+                "--description",
+                "Test WildFire profile",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created WildFire antivirus profile" in result.stdout
+        assert "wf-test" in result.stdout
+
+    def test_set_wildfire_antivirus_profile_with_rules_json(self, runner, monkeypatch):
+        """Test set wildfire-antivirus-profile with custom rules JSON."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.create_wildfire_antivirus_profile.return_value = {
+            "id": "wfav-12345",
+            "name": "wf-custom",
+            "folder": "Texas",
+            "rules": [],
+        }
+
+        test_app = typer.Typer()
+        test_app.command()(set_wildfire_antivirus_profile)
+
+        rules = '[{"name":"Forward All","direction":"both","analysis":"public-cloud","application":["any"],"file_type":["any"]}]'
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "wf-custom",
+                "--rules",
+                rules,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created WildFire antivirus profile" in result.stdout
+
+    def test_set_wildfire_antivirus_profile_error(self, runner, monkeypatch):
+        """Test the set wildfire-antivirus-profile command with an error."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.create_wildfire_antivirus_profile.side_effect = ValueError("Test error")
+
+        test_app = typer.Typer()
+        test_app.command()(set_wildfire_antivirus_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "wf-test",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error creating WildFire antivirus profile" in result.stdout
+
+    def test_delete_wildfire_antivirus_profile_command(self, runner, monkeypatch):
+        """Test the delete wildfire-antivirus-profile command."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.delete_wildfire_antivirus_profile.return_value = True
+
+        test_app = typer.Typer()
+        test_app.command()(delete_wildfire_antivirus_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "wf-test",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted WildFire antivirus profile" in result.stdout
+        assert "wf-test" in result.stdout
+
+    def test_show_wildfire_antivirus_profile_list(self, runner, monkeypatch):
+        """Test the show wildfire-antivirus-profile command (list mode)."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.list_wildfire_antivirus_profiles.return_value = [
+            {
+                "id": "wfav-1",
+                "folder": "Texas",
+                "name": "WF Profile 1",
+                "description": "First profile",
+                "rules": [{"name": "rule1", "direction": "both"}],
+            },
+            {
+                "id": "wfav-2",
+                "folder": "Texas",
+                "name": "WF Profile 2",
+                "rules": [{"name": "rule2", "direction": "upload"}],
+            },
+        ]
+
+        test_app = typer.Typer()
+        test_app.command()(show_wildfire_antivirus_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Texas"])
+
+        assert result.exit_code == 0
+        assert "WF Profile 1" in result.stdout
+        assert "WF Profile 2" in result.stdout
+
+    def test_show_wildfire_antivirus_profile_single(self, runner, monkeypatch):
+        """Test the show wildfire-antivirus-profile command (single profile)."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.get_wildfire_antivirus_profile.return_value = {
+            "id": "wfav-1",
+            "folder": "Texas",
+            "name": "WF Test",
+            "description": "Test profile",
+            "packet_capture": True,
+            "rules": [
+                {
+                    "name": "Forward All",
+                    "direction": "both",
+                    "analysis": "public-cloud",
+                    "application": ["any"],
+                    "file_type": ["any"],
+                }
+            ],
+        }
+
+        test_app = typer.Typer()
+        test_app.command()(show_wildfire_antivirus_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Texas", "--name", "WF Test"])
+
+        assert result.exit_code == 0
+        assert "WF Test" in result.stdout
+        assert "Packet Capture: Enabled" in result.stdout
+        assert "Forward All" in result.stdout
+
+    def test_load_wildfire_antivirus_profile_command(self, runner, monkeypatch, tmp_path):
+        """Test the load wildfire-antivirus-profile command."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        call_count = {"n": 0}
+
+        def mock_create(*args, **kwargs):
+            call_count["n"] += 1
+            return {
+                "id": f"wfav-{call_count['n']}",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "rules": kwargs.get("rules", []),
+            }
+
+        mock_client.create_wildfire_antivirus_profile.side_effect = mock_create
+
+        # Create a test YAML file
+        yaml_content = """
+wildfire_antivirus_profiles:
+  - name: wf-test
+    folder: Texas
+    rules:
+      - name: Forward All
+        direction: both
+        analysis: public-cloud
+        application:
+          - any
+        file_type:
+          - any
+"""
+        test_file = tmp_path / "wf_profiles.yml"
+        test_file.write_text(yaml_content)
+
+        test_app = typer.Typer()
+        test_app.command()(load_wildfire_antivirus_profile)
+
+        result = runner.invoke(test_app, ["--file", str(test_file)])
+
+        assert result.exit_code == 0
+        assert "Successfully processed" in result.stdout
+        assert call_count["n"] == 1
+
+    def test_load_wildfire_antivirus_profile_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test the load wildfire-antivirus-profile command with dry-run."""
+        mock_client = self._mock_scm_client(monkeypatch)
+
+        yaml_content = """
+wildfire_antivirus_profiles:
+  - name: wf-test
+    folder: Texas
+    rules:
+      - name: Forward All
+        direction: both
+        application:
+          - any
+        file_type:
+          - any
+"""
+        test_file = tmp_path / "wf_profiles.yml"
+        test_file.write_text(yaml_content)
+
+        test_app = typer.Typer()
+        test_app.command()(load_wildfire_antivirus_profile)
+
+        result = runner.invoke(test_app, ["--file", str(test_file), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+        mock_client.create_wildfire_antivirus_profile.assert_not_called()

--- a/tests/test_security_commands.py
+++ b/tests/test_security_commands.py
@@ -6,15 +6,19 @@ from scm_cli.commands.security import (
     delete_app,
     delete_dns_security_profile,
     delete_security_rule,
+    delete_vulnerability_protection_profile,
     delete_wildfire_antivirus_profile,
     load_app,
     load_security_rule,
+    load_vulnerability_protection_profile,
     load_wildfire_antivirus_profile,
     set_app,
     set_dns_security_profile,
     set_security_rule,
+    set_vulnerability_protection_profile,
     set_wildfire_antivirus_profile,
     show_dns_security_profile,
+    show_vulnerability_protection_profile,
     show_wildfire_antivirus_profile,
 )
 
@@ -624,3 +628,311 @@ class TestDNSSecurityProfileCommands:
 
         assert result.exit_code == 0
         assert "DNS-Security-Default" in result.stdout
+
+
+class TestVulnerabilityProtectionProfileCommands:
+    """Test the vulnerability protection profile commands."""
+
+    def test_set_vulnerability_protection_profile_command(self, runner, monkeypatch):
+        """Test the set vulnerability protection profile command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "vpp-12345",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "rules": kwargs.get("rules", []),
+                "description": kwargs.get("description", ""),
+            }
+
+        monkeypatch.setattr(scm_client, "create_vulnerability_protection_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_vulnerability_protection_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-vuln-profile",
+                "--description",
+                "Test vulnerability protection",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created vulnerability protection profile" in result.stdout
+        assert "test-vuln-profile" in result.stdout
+
+    def test_set_vulnerability_protection_profile_block_critical_high(self, runner, monkeypatch):
+        """Test the set command with --block-critical-high flag."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured_kwargs = {}
+
+        def mock_create(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return {
+                "id": "vpp-12345",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "rules": kwargs.get("rules", []),
+            }
+
+        monkeypatch.setattr(scm_client, "create_vulnerability_protection_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_vulnerability_protection_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "strict-vuln",
+                "--block-critical-high",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured_kwargs.get("rules") is not None
+        assert len(captured_kwargs["rules"]) == 1
+        assert "critical" in captured_kwargs["rules"][0]["severity"]
+        assert "high" in captured_kwargs["rules"][0]["severity"]
+
+    def test_set_vulnerability_protection_profile_error(self, runner, monkeypatch):
+        """Test the set command with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create_error(*args, **kwargs):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "create_vulnerability_protection_profile", mock_create_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_vulnerability_protection_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-vuln",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error creating vulnerability protection profile" in result.stdout
+
+    def test_delete_vulnerability_protection_profile_command(self, runner, monkeypatch):
+        """Test the delete vulnerability protection profile command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "delete_vulnerability_protection_profile", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_vulnerability_protection_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-vuln",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted vulnerability protection profile" in result.stdout
+        assert "test-vuln" in result.stdout
+
+    def test_delete_vulnerability_protection_profile_error(self, runner, monkeypatch):
+        """Test the delete command with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete_error(*args, **kwargs):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "delete_vulnerability_protection_profile", mock_delete_error)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_vulnerability_protection_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-vuln",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error deleting vulnerability protection profile" in result.stdout
+
+    def test_show_vulnerability_protection_profile_single(self, runner, monkeypatch):
+        """Test the show command for a single profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "vpp-12345",
+                "name": "test-vuln",
+                "folder": "Texas",
+                "description": "Test profile",
+                "rules": [
+                    {
+                        "name": "Block Critical",
+                        "severity": ["critical", "high"],
+                        "category": "any",
+                        "host": "any",
+                        "action": {"alert": {}},
+                        "packet_capture": "single-packet",
+                    }
+                ],
+            }
+
+        monkeypatch.setattr(scm_client, "get_vulnerability_protection_profile", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_vulnerability_protection_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-vuln",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Vulnerability Protection Profile: test-vuln" in result.stdout
+        assert "Block Critical" in result.stdout
+
+    def test_show_vulnerability_protection_profile_list(self, runner, monkeypatch):
+        """Test the show command listing all profiles."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "vpp-1",
+                    "name": "strict-vuln",
+                    "folder": "Texas",
+                    "rules": [{"name": "r1", "action": {"alert": {}}}],
+                },
+                {
+                    "id": "vpp-2",
+                    "name": "standard-vuln",
+                    "folder": "Texas",
+                    "rules": [{"name": "r2", "action": {"default": {}}}],
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_vulnerability_protection_profiles", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_vulnerability_protection_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "strict-vuln" in result.stdout
+        assert "standard-vuln" in result.stdout
+
+    def test_load_vulnerability_protection_profile_command(self, runner, monkeypatch, tmp_path):
+        """Test the load vulnerability protection profile command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        created_profiles = []
+
+        def mock_create(*args, **kwargs):
+            result = {
+                "id": f"vpp-{len(created_profiles) + 1}",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "rules": kwargs.get("rules", []),
+            }
+            created_profiles.append(result)
+            return result
+
+        monkeypatch.setattr(scm_client, "create_vulnerability_protection_profile", mock_create)
+
+        # Create YAML file
+        yaml_file = tmp_path / "vuln_profiles.yml"
+        yaml_file.write_text("""
+vulnerability_protection_profiles:
+  - name: test-vuln
+    folder: Texas
+    rules:
+      - name: Block Critical
+        severity:
+          - critical
+          - high
+        category: any
+        host: any
+        action:
+          alert: {}
+""")
+
+        test_app = typer.Typer()
+        test_app.command()(load_vulnerability_protection_profile)
+
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+
+        assert result.exit_code == 0
+        assert "Successfully processed 1 vulnerability protection profile(s)" in result.stdout
+        assert len(created_profiles) == 1
+
+    def test_load_vulnerability_protection_profile_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test the load command with dry-run option."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        mock_called = False
+
+        def mock_create(*args, **kwargs):
+            nonlocal mock_called
+            mock_called = True
+            return {}
+
+        monkeypatch.setattr(scm_client, "create_vulnerability_protection_profile", mock_create)
+
+        yaml_file = tmp_path / "vuln_profiles.yml"
+        yaml_file.write_text("""
+vulnerability_protection_profiles:
+  - name: test-vuln
+    folder: Texas
+    rules:
+      - name: Block Critical
+        severity:
+          - critical
+        category: any
+        host: any
+""")
+
+        test_app = typer.Typer()
+        test_app.command()(load_vulnerability_protection_profile)
+
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+        assert not mock_called

--- a/tests/test_security_commands.py
+++ b/tests/test_security_commands.py
@@ -4,14 +4,17 @@ import typer
 
 from scm_cli.commands.security import (
     delete_app,
+    delete_dns_security_profile,
     delete_security_rule,
     delete_wildfire_antivirus_profile,
     load_app,
     load_security_rule,
     load_wildfire_antivirus_profile,
     set_app,
+    set_dns_security_profile,
     set_security_rule,
     set_wildfire_antivirus_profile,
+    show_dns_security_profile,
     show_wildfire_antivirus_profile,
 )
 
@@ -500,3 +503,124 @@ wildfire_antivirus_profiles:
         assert result.exit_code == 0
         assert "Dry run mode" in result.stdout
         mock_client.create_wildfire_antivirus_profile.assert_not_called()
+
+
+class TestDNSSecurityProfileCommands:
+    """Test the DNS security profile commands."""
+
+    def _mock_scm_client(self, monkeypatch):
+        """Set up a mock SCM client to avoid real API calls."""
+        from unittest.mock import MagicMock
+
+        import scm_cli.commands.security as sec_module
+
+        mock_client = MagicMock()
+        monkeypatch.setattr(sec_module, "scm_client", mock_client)
+        return mock_client
+
+    def test_set_dns_security_profile_command(self, runner, monkeypatch):
+        """Test the set DNS security profile command."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.create_dns_security_profile.return_value = {
+            "id": "dns-sec-12345",
+            "name": "dns-sec-test",
+            "folder": "Texas",
+            "botnet_domains": {},
+            "__action__": "created",
+        }
+
+        test_app = typer.Typer()
+        test_app.command()(set_dns_security_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "dns-sec-test",
+                "--description",
+                "Test DNS security profile",
+                "--botnet-domains",
+                '{"dns_security_categories": [{"name": "pan-dns-sec-malware", "action": "sinkhole"}]}',
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created DNS security profile" in result.stdout
+        assert "dns-sec-test" in result.stdout
+
+    def test_set_dns_security_profile_error(self, runner, monkeypatch):
+        """Test the set DNS security profile command with an error."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.create_dns_security_profile.side_effect = ValueError("Test error")
+
+        test_app = typer.Typer()
+        test_app.command()(set_dns_security_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "dns-sec-test",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error creating DNS security profile" in result.stdout
+
+    def test_delete_dns_security_profile_command(self, runner, monkeypatch):
+        """Test the delete DNS security profile command."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.delete_dns_security_profile.return_value = True
+
+        test_app = typer.Typer()
+        test_app.command()(delete_dns_security_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "dns-sec-test",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted DNS security profile" in result.stdout
+        assert "dns-sec-test" in result.stdout
+
+    def test_show_dns_security_profile_list(self, runner, monkeypatch):
+        """Test the show DNS security profile command listing all profiles."""
+        mock_client = self._mock_scm_client(monkeypatch)
+        mock_client.list_dns_security_profiles.return_value = [
+            {
+                "id": "dns-sec-mock1",
+                "name": "DNS-Security-Default",
+                "folder": "Texas",
+                "description": "Default DNS security profile",
+                "botnet_domains": {
+                    "dns_security_categories": [
+                        {"name": "pan-dns-sec-malware", "action": "sinkhole"},
+                    ],
+                    "sinkhole": {"ipv4_address": "pan-sinkhole-default-ip", "ipv6_address": "::1"},
+                },
+            },
+        ]
+
+        test_app = typer.Typer()
+        test_app.command()(show_dns_security_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "DNS-Security-Default" in result.stdout

--- a/tests/test_security_commands.py
+++ b/tests/test_security_commands.py
@@ -6,6 +6,7 @@ from scm_cli.commands.security import (
     delete_app,
     delete_dns_security_profile,
     delete_security_rule,
+    delete_url_category,
     delete_vulnerability_protection_profile,
     delete_wildfire_antivirus_profile,
     load_app,
@@ -15,9 +16,11 @@ from scm_cli.commands.security import (
     set_app,
     set_dns_security_profile,
     set_security_rule,
+    set_url_category,
     set_vulnerability_protection_profile,
     set_wildfire_antivirus_profile,
     show_dns_security_profile,
+    show_url_category,
     show_vulnerability_protection_profile,
     show_wildfire_antivirus_profile,
 )
@@ -936,3 +939,160 @@ vulnerability_protection_profiles:
         assert result.exit_code == 0
         assert "Dry run mode" in result.stdout
         assert not mock_called
+
+
+class TestURLCategoryCommands:
+    """Test the URL category commands."""
+
+    def test_set_url_category_command(self, runner, monkeypatch):
+        """Test the set URL category command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "urlcat-12345",
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "type": kwargs.get("type", "URL List"),
+                "list": kwargs.get("list", []),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_url_category", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_url_category)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "custom-block",
+                "--url",
+                "malware.example.com",
+                "--url",
+                "phishing.test.org",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created URL category" in result.stdout
+        assert "custom-block" in result.stdout
+
+    def test_set_url_category_error(self, runner, monkeypatch):
+        """Test the set URL category command with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create_error(*args, **kwargs):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "create_url_category", mock_create_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_url_category)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "test-category",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "Error creating URL category" in result.stdout
+
+    def test_delete_url_category_command(self, runner, monkeypatch):
+        """Test the delete URL category command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "delete_url_category", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_url_category)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "custom-block",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted URL category" in result.stdout
+        assert "custom-block" in result.stdout
+
+    def test_show_url_category_list(self, runner, monkeypatch):
+        """Test the show URL category command for listing."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "urlcat-1",
+                    "name": "Custom-Block-List",
+                    "folder": "Texas",
+                    "type": "URL List",
+                    "list": ["malware.example.com"],
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_url_categories", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_url_category)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Custom-Block-List" in result.stdout
+
+    def test_show_url_category_by_name(self, runner, monkeypatch):
+        """Test the show URL category command for a specific category."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "urlcat-1",
+                "name": "Custom-Block-List",
+                "folder": "Texas",
+                "description": "Custom blocked URLs",
+                "type": "URL List",
+                "list": ["malware.example.com", "phishing.test.org"],
+            }
+
+        monkeypatch.setattr(scm_client, "get_url_category", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_url_category)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder",
+                "Texas",
+                "--name",
+                "Custom-Block-List",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Custom-Block-List" in result.stdout
+        assert "malware.example.com" in result.stdout
+        assert "phishing.test.org" in result.stdout

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,8 @@
 
 import pytest
 from pydantic import ValidationError
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, IKECryptoProfile, QuarantinedDevice, Region, Schedule, SecurityRule, Zone
+
+from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, IKECryptoProfile, QuarantinedDevice, Region, Schedule, SecurityRule, WildfireAntivirusProfile, Zone
 
 
 class TestBandwidthAllocation:
@@ -336,6 +337,7 @@ class TestSchedule:
                 time_ranges=["09:00-17:00"],
             )
 
+
 class TestRegion:
     """Test cases for the Region model."""
 
@@ -420,6 +422,8 @@ class TestRegion:
             Region(name="test", folder="Texas", longitude=181.0)
         with pytest.raises(ValidationError):
             Region(name="test", folder="Texas", longitude=-181.0)
+
+
 class TestQuarantinedDevice:
     """Test cases for the QuarantinedDevice model."""
 
@@ -530,3 +534,133 @@ class TestSecurityRule:
         assert rule.description == ""
         assert rule.tags == []
         assert rule.enabled is True
+
+
+class TestWildfireAntivirusProfile:
+    """Test cases for the WildfireAntivirusProfile model."""
+
+    def test_valid_profile(self):
+        """Test creating a valid WildFire antivirus profile."""
+        profile = WildfireAntivirusProfile(
+            name="wf-test",
+            folder="Texas",
+            description="Test profile",
+            rules=[
+                {
+                    "name": "Forward All",
+                    "direction": "both",
+                    "analysis": "public-cloud",
+                    "application": ["any"],
+                    "file_type": ["any"],
+                }
+            ],
+        )
+        assert profile.name == "wf-test"
+        assert profile.folder == "Texas"
+        assert len(profile.rules) == 1
+
+    def test_container_validation(self):
+        """Test that exactly one container must be specified."""
+        with pytest.raises(ValidationError):
+            WildfireAntivirusProfile(
+                name="wf-test",
+                # No container
+                rules=[{"name": "r1", "direction": "both"}],
+            )
+
+        with pytest.raises(ValidationError):
+            WildfireAntivirusProfile(
+                name="wf-test",
+                folder="Texas",
+                snippet="test-snippet",
+                rules=[{"name": "r1", "direction": "both"}],
+            )
+
+    def test_rule_direction_validation(self):
+        """Test rule direction validation."""
+        with pytest.raises(ValidationError):
+            WildfireAntivirusProfile(
+                name="wf-test",
+                folder="Texas",
+                rules=[{"name": "bad-rule", "direction": "invalid"}],
+            )
+
+    def test_rule_analysis_validation(self):
+        """Test rule analysis validation."""
+        with pytest.raises(ValidationError):
+            WildfireAntivirusProfile(
+                name="wf-test",
+                folder="Texas",
+                rules=[{"name": "bad-rule", "direction": "both", "analysis": "invalid"}],
+            )
+
+    def test_rule_missing_name(self):
+        """Test rule missing name validation."""
+        with pytest.raises(ValidationError):
+            WildfireAntivirusProfile(
+                name="wf-test",
+                folder="Texas",
+                rules=[{"direction": "both"}],
+            )
+
+    def test_rule_missing_direction(self):
+        """Test rule missing direction validation."""
+        with pytest.raises(ValidationError):
+            WildfireAntivirusProfile(
+                name="wf-test",
+                folder="Texas",
+                rules=[{"name": "bad-rule"}],
+            )
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        profile = WildfireAntivirusProfile(
+            name="wf-test",
+            folder="Texas",
+            description="Test profile",
+            packet_capture=True,
+            rules=[
+                {
+                    "name": "Forward All",
+                    "direction": "both",
+                    "analysis": "public-cloud",
+                }
+            ],
+            threat_exception=[{"name": "exc1", "notes": "test"}],
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["name"] == "wf-test"
+        assert sdk_data["folder"] == "Texas"
+        assert sdk_data["description"] == "Test profile"
+        assert sdk_data["packet_capture"] is True
+        assert len(sdk_data["rules"]) == 1
+        assert sdk_data["threat_exception"] == [{"name": "exc1", "notes": "test"}]
+
+    def test_to_sdk_model_minimal(self):
+        """Test conversion with minimal fields."""
+        profile = WildfireAntivirusProfile(
+            name="wf-minimal",
+            folder="Texas",
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data == {"name": "wf-minimal", "folder": "Texas"}
+
+    def test_valid_directions(self):
+        """Test all valid direction values."""
+        for direction in ["download", "upload", "both"]:
+            profile = WildfireAntivirusProfile(
+                name="wf-test",
+                folder="Texas",
+                rules=[{"name": "rule1", "direction": direction}],
+            )
+            assert profile.rules[0]["direction"] == direction
+
+    def test_valid_analyses(self):
+        """Test all valid analysis values."""
+        for analysis in ["public-cloud", "private-cloud"]:
+            profile = WildfireAntivirusProfile(
+                name="wf-test",
+                folder="Texas",
+                rules=[{"name": "rule1", "direction": "both", "analysis": analysis}],
+            )
+            assert profile.rules[0]["analysis"] == analysis

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, IKECryptoProfile, QuarantinedDevice, Region, Schedule, SecurityRule, WildfireAntivirusProfile, Zone
+from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, IPSecCryptoProfile, SecurityRule, Zone
 
 
 class TestBandwidthAllocation:
@@ -664,3 +665,111 @@ class TestWildfireAntivirusProfile:
                 rules=[{"name": "rule1", "direction": "both", "analysis": analysis}],
             )
             assert profile.rules[0]["analysis"] == analysis
+class TestIPSecCryptoProfile:
+    """Test cases for the IPSecCryptoProfile model."""
+
+    def test_valid_profile(self):
+        """Test creating a valid IPsec crypto profile."""
+        profile = IPSecCryptoProfile(
+            name="test-profile",
+            folder="Texas",
+            esp_encryption=["aes-256-cbc"],
+            esp_authentication=["sha256"],
+            dh_group="group14",
+            lifetime_hours=1,
+        )
+        assert profile.name == "test-profile"
+        assert profile.folder == "Texas"
+        assert profile.esp_encryption == ["aes-256-cbc"]
+        assert profile.esp_authentication == ["sha256"]
+        assert profile.dh_group == "group14"
+        assert profile.lifetime_hours == 1
+
+    def test_missing_container(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            IPSecCryptoProfile(
+                name="test-profile",
+                esp_encryption=["aes-256-cbc"],
+                esp_authentication=["sha256"],
+            )
+
+    def test_invalid_esp_encryption(self):
+        """Test that invalid ESP encryption raises error."""
+        with pytest.raises(ValidationError):
+            IPSecCryptoProfile(
+                name="test-profile",
+                folder="Texas",
+                esp_encryption=["invalid-algo"],
+            )
+
+    def test_invalid_esp_authentication(self):
+        """Test that invalid ESP authentication raises error."""
+        with pytest.raises(ValidationError):
+            IPSecCryptoProfile(
+                name="test-profile",
+                folder="Texas",
+                esp_authentication=["invalid-algo"],
+            )
+
+    def test_invalid_dh_group(self):
+        """Test that invalid DH group raises error."""
+        with pytest.raises(ValidationError):
+            IPSecCryptoProfile(
+                name="test-profile",
+                folder="Texas",
+                dh_group="invalid-group",
+            )
+
+    def test_default_values(self):
+        """Test default values are applied correctly."""
+        profile = IPSecCryptoProfile(name="test-profile", folder="Texas")
+        assert profile.esp_encryption == ["aes-256-cbc"]
+        assert profile.esp_authentication == ["sha256"]
+        assert profile.dh_group == "group14"
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        profile = IPSecCryptoProfile(
+            name="test-profile",
+            folder="Texas",
+            esp_encryption=["aes-256-cbc", "aes-128-cbc"],
+            esp_authentication=["sha256", "sha512"],
+            dh_group="group20",
+            lifetime_hours=8,
+        )
+        sdk_data = profile.to_sdk_model()
+
+        assert sdk_data["name"] == "test-profile"
+        assert sdk_data["folder"] == "Texas"
+        assert sdk_data["esp"]["encryption"] == ["aes-256-cbc", "aes-128-cbc"]
+        assert sdk_data["esp"]["authentication"] == ["sha256", "sha512"]
+        assert sdk_data["dh_group"] == "group20"
+        assert sdk_data["lifetime"] == {"hours": 8}
+
+    def test_to_sdk_model_default_lifetime(self):
+        """Test that default lifetime is applied in SDK model."""
+        profile = IPSecCryptoProfile(name="test-profile", folder="Texas")
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["lifetime"] == {"hours": 1}
+
+    def test_to_sdk_model_with_lifesize(self):
+        """Test SDK model with lifesize."""
+        profile = IPSecCryptoProfile(
+            name="test-profile",
+            folder="Texas",
+            lifetime_seconds=3600,
+            lifesize_mb=100,
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["lifetime"] == {"seconds": 3600}
+        assert sdk_data["lifesize"] == {"mb": 100}
+
+    def test_multiple_containers_error(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            IPSecCryptoProfile(
+                name="test-profile",
+                folder="Texas",
+                snippet="my-snippet",
+            )

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, IKECryptoProfile, QuarantinedDevice, Region, Schedule, SecurityRule, WildfireAntivirusProfile, Zone
+from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, DNSSecurityProfile, IKECryptoProfile, QuarantinedDevice, Region, Schedule, SecurityRule, WildfireAntivirusProfile, Zone
 from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, IPSecCryptoProfile, SecurityRule, Zone
 
 
@@ -773,3 +773,83 @@ class TestIPSecCryptoProfile:
                 folder="Texas",
                 snippet="my-snippet",
             )
+
+
+class TestDNSSecurityProfile:
+    """Test cases for the DNSSecurityProfile model."""
+
+    def test_valid_dns_security_profile(self):
+        """Test creating a valid DNS security profile."""
+        profile = DNSSecurityProfile(
+            name="dns-sec-default",
+            folder="Texas",
+            description="Default DNS security profile",
+            botnet_domains={
+                "dns_security_categories": [
+                    {"name": "pan-dns-sec-malware", "action": "sinkhole", "log_level": "default"},
+                ],
+                "sinkhole": {"ipv4_address": "pan-sinkhole-default-ip", "ipv6_address": "::1"},
+            },
+        )
+        assert profile.name == "dns-sec-default"
+        assert profile.folder == "Texas"
+        assert profile.description == "Default DNS security profile"
+        assert profile.botnet_domains is not None
+        assert len(profile.botnet_domains["dns_security_categories"]) == 1
+
+    def test_missing_name(self):
+        """Test that name is required."""
+        with pytest.raises(ValidationError):
+            DNSSecurityProfile(folder="Texas")
+
+    def test_no_container(self):
+        """Test that at least one container is required."""
+        with pytest.raises(ValidationError):
+            DNSSecurityProfile(name="test-profile")
+
+    def test_multiple_containers(self):
+        """Test that only one container is allowed."""
+        with pytest.raises(ValidationError):
+            DNSSecurityProfile(name="test-profile", folder="Texas", snippet="MySnippet")
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        profile = DNSSecurityProfile(
+            name="dns-sec-test",
+            folder="Texas",
+            description="Test profile",
+            botnet_domains={
+                "dns_security_categories": [
+                    {"name": "pan-dns-sec-malware", "action": "sinkhole"},
+                ],
+            },
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["name"] == "dns-sec-test"
+        assert sdk_data["folder"] == "Texas"
+        assert sdk_data["description"] == "Test profile"
+        assert "botnet_domains" in sdk_data
+        assert len(sdk_data["botnet_domains"]["dns_security_categories"]) == 1
+
+    def test_to_sdk_model_minimal(self):
+        """Test conversion with minimal fields."""
+        profile = DNSSecurityProfile(name="dns-sec-minimal", folder="Texas")
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["name"] == "dns-sec-minimal"
+        assert sdk_data["folder"] == "Texas"
+        assert "description" not in sdk_data
+        assert "botnet_domains" not in sdk_data
+
+    def test_snippet_container(self):
+        """Test using snippet as container."""
+        profile = DNSSecurityProfile(name="dns-sec-snippet", snippet="MySnippet")
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["snippet"] == "MySnippet"
+        assert "folder" not in sdk_data
+
+    def test_device_container(self):
+        """Test using device as container."""
+        profile = DNSSecurityProfile(name="dns-sec-device", device="fw-01")
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["device"] == "fw-01"
+        assert "folder" not in sdk_data

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,8 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, DNSSecurityProfile, IKECryptoProfile, QuarantinedDevice, Region, Schedule, SecurityRule, WildfireAntivirusProfile, Zone
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, IPSecCryptoProfile, SecurityRule, Zone
+from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, DNSSecurityProfile, IKECryptoProfile, IPSecCryptoProfile, NATRule, QuarantinedDevice, Region, Schedule, SecurityRule, WildfireAntivirusProfile, Zone
 
 
 class TestBandwidthAllocation:
@@ -459,6 +458,116 @@ class TestQuarantinedDevice:
         device = QuarantinedDevice(host_id="host-123")
         sdk_data = device.to_sdk_model()
         assert sdk_data == {"host_id": "host-123"}
+
+
+class TestNATRule:
+    """Test cases for the NATRule model."""
+
+    def test_valid_nat_rule(self):
+        """Test creating a valid NAT rule."""
+        rule = NATRule(
+            name="outbound-nat",
+            folder="Texas",
+            nat_type="ipv4",
+            source=["any"],
+            destination=["any"],
+            service="any",
+            source_translation={
+                "dynamic_ip_and_port": {
+                    "type": "dynamic_ip_and_port",
+                    "translated_address": ["10.0.0.1"],
+                }
+            },
+        )
+        assert rule.name == "outbound-nat"
+        assert rule.folder == "Texas"
+        assert rule.nat_type == "ipv4"
+        assert rule.source == ["any"]
+        assert rule.destination == ["any"]
+        assert rule.service == "any"
+        assert rule.source_translation is not None
+
+    def test_missing_required_fields(self):
+        """Test that required fields are enforced."""
+        with pytest.raises(ValidationError):
+            NATRule(
+                # Missing name
+                folder="Texas",
+            )
+
+    def test_container_validation(self):
+        """Test that exactly one container must be specified."""
+        with pytest.raises(ValidationError):
+            NATRule(
+                name="test-nat",
+                # Missing container
+            )
+
+        with pytest.raises(ValidationError):
+            NATRule(
+                name="test-nat",
+                folder="Texas",
+                snippet="test-snippet",
+            )
+
+    def test_default_values(self):
+        """Test that default values are applied correctly."""
+        rule = NATRule(name="test-nat", folder="Texas")
+        assert rule.nat_type == "ipv4"
+        assert rule.from_zone == ["any"]
+        assert rule.to_zone == ["any"]
+        assert rule.source == ["any"]
+        assert rule.destination == ["any"]
+        assert rule.service == "any"
+        assert rule.disabled is False
+        assert rule.source_translation is None
+        assert rule.destination_translation is None
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        rule = NATRule(
+            name="outbound-nat",
+            folder="Texas",
+            description="Outbound NAT rule",
+            source=["192.168.1.0/24"],
+            destination=["any"],
+            service="any",
+            source_translation={
+                "dynamic_ip_and_port": {
+                    "type": "dynamic_ip_and_port",
+                    "translated_address": ["10.0.0.1"],
+                }
+            },
+        )
+        sdk_model = rule.to_sdk_model()
+        assert sdk_model["name"] == "outbound-nat"
+        assert sdk_model["folder"] == "Texas"
+        assert sdk_model["description"] == "Outbound NAT rule"
+        assert sdk_model["source"] == ["192.168.1.0/24"]
+        assert sdk_model["destination"] == ["any"]
+        assert sdk_model["service"] == "any"
+        assert "source_translation" in sdk_model
+
+    def test_to_sdk_model_minimal(self):
+        """Test minimal conversion to SDK model."""
+        rule = NATRule(name="simple-nat", folder="Texas")
+        sdk_model = rule.to_sdk_model()
+        assert sdk_model["name"] == "simple-nat"
+        assert sdk_model["folder"] == "Texas"
+        assert sdk_model["from_"] == ["any"]
+        assert sdk_model["to_"] == ["any"]
+        assert "source_translation" not in sdk_model
+        assert "destination_translation" not in sdk_model
+
+    def test_with_from_to_alias(self):
+        """Test creating NAT rule with 'from' and 'to' aliases."""
+        rule = NATRule(
+            name="test-nat",
+            folder="Texas",
+            **{"from": ["trust"], "to": ["untrust"]},
+        )
+        assert rule.from_zone == ["trust"]
+        assert rule.to_zone == ["untrust"]
 
 
 class TestSecurityRule:

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -3,7 +3,21 @@
 import pytest
 from pydantic import ValidationError
 
-from scm_cli.utils.validators import AddressGroup, BandwidthAllocation, DNSSecurityProfile, IKECryptoProfile, IPSecCryptoProfile, NATRule, QuarantinedDevice, Region, Schedule, SecurityRule, WildfireAntivirusProfile, Zone
+from scm_cli.utils.validators import (
+    AddressGroup,
+    BandwidthAllocation,
+    DNSSecurityProfile,
+    IKECryptoProfile,
+    IPSecCryptoProfile,
+    NATRule,
+    QuarantinedDevice,
+    Region,
+    Schedule,
+    SecurityRule,
+    VulnerabilityProtectionProfile,
+    WildfireAntivirusProfile,
+    Zone,
+)
 
 
 class TestBandwidthAllocation:
@@ -962,3 +976,188 @@ class TestDNSSecurityProfile:
         sdk_data = profile.to_sdk_model()
         assert sdk_data["device"] == "fw-01"
         assert "folder" not in sdk_data
+
+
+class TestVulnerabilityProtectionProfile:
+    """Test cases for the VulnerabilityProtectionProfile model."""
+
+    def test_valid_profile(self):
+        """Test creating a valid vulnerability protection profile."""
+        profile = VulnerabilityProtectionProfile(
+            name="test-vuln-profile",
+            folder="Texas",
+            description="Test vulnerability protection",
+            rules=[
+                {
+                    "name": "Block Critical",
+                    "severity": ["critical", "high"],
+                    "category": "any",
+                    "host": "any",
+                    "action": {"alert": {}},
+                }
+            ],
+        )
+        assert profile.name == "test-vuln-profile"
+        assert profile.folder == "Texas"
+        assert profile.description == "Test vulnerability protection"
+        assert len(profile.rules) == 1
+
+    def test_missing_container(self):
+        """Test that missing container raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                rules=[{"name": "r1", "severity": ["critical"], "host": "any"}],
+            )
+
+    def test_multiple_containers(self):
+        """Test that multiple containers raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                snippet="test-snippet",
+                rules=[{"name": "r1", "severity": ["critical"], "host": "any"}],
+            )
+
+    def test_rule_missing_name(self):
+        """Test that rule without name raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                rules=[{"severity": ["critical"], "host": "any"}],
+            )
+
+    def test_rule_missing_severity(self):
+        """Test that rule without severity raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                rules=[{"name": "r1", "host": "any"}],
+            )
+
+    def test_rule_missing_host(self):
+        """Test that rule without host raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                rules=[{"name": "r1", "severity": ["critical"]}],
+            )
+
+    def test_rule_invalid_severity(self):
+        """Test that invalid severity raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                rules=[{"name": "r1", "severity": ["invalid"], "host": "any"}],
+            )
+
+    def test_rule_invalid_host(self):
+        """Test that invalid host raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                rules=[{"name": "r1", "severity": ["critical"], "host": "invalid"}],
+            )
+
+    def test_rule_invalid_category(self):
+        """Test that invalid category raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                rules=[{"name": "r1", "severity": ["critical"], "host": "any", "category": "invalid"}],
+            )
+
+    def test_rule_invalid_action(self):
+        """Test that invalid action raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                rules=[{"name": "r1", "severity": ["critical"], "host": "any", "action": "invalid"}],
+            )
+
+    def test_rule_invalid_packet_capture(self):
+        """Test that invalid packet_capture raises validation error."""
+        with pytest.raises(ValidationError):
+            VulnerabilityProtectionProfile(
+                name="test-vuln-profile",
+                folder="Texas",
+                rules=[{"name": "r1", "severity": ["critical"], "host": "any", "packet_capture": "invalid"}],
+            )
+
+    def test_to_sdk_model(self):
+        """Test converting profile to SDK model format."""
+        profile = VulnerabilityProtectionProfile(
+            name="test-vuln-profile",
+            folder="Texas",
+            description="Test profile",
+            rules=[
+                {
+                    "name": "Block Critical",
+                    "severity": ["critical"],
+                    "host": "any",
+                    "action": {"default": {}},
+                }
+            ],
+            threat_exceptions=[{"name": "exception-1", "notes": "Test exception"}],
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["name"] == "test-vuln-profile"
+        assert sdk_data["folder"] == "Texas"
+        assert sdk_data["description"] == "Test profile"
+        assert len(sdk_data["rules"]) == 1
+        assert sdk_data["threat_exception"][0]["name"] == "exception-1"
+
+    def test_to_sdk_model_minimal(self):
+        """Test converting minimal profile to SDK model."""
+        profile = VulnerabilityProtectionProfile(
+            name="minimal",
+            folder="Texas",
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["name"] == "minimal"
+        assert sdk_data["folder"] == "Texas"
+        assert "description" not in sdk_data
+        assert "rules" not in sdk_data
+        assert "threat_exception" not in sdk_data
+
+    def test_valid_all_severities(self):
+        """Test profile with all valid severity values."""
+        profile = VulnerabilityProtectionProfile(
+            name="all-sev",
+            folder="Texas",
+            rules=[
+                {
+                    "name": "all-severities",
+                    "severity": ["critical", "high", "medium", "low", "informational"],
+                    "host": "client",
+                    "category": "sql-injection",
+                    "action": "drop",
+                    "packet_capture": "extended-capture",
+                }
+            ],
+        )
+        assert len(profile.rules[0]["severity"]) == 5
+
+    def test_dict_action_allowed(self):
+        """Test that dict-style action (block_ip) is allowed."""
+        profile = VulnerabilityProtectionProfile(
+            name="block-ip-test",
+            folder="Texas",
+            rules=[
+                {
+                    "name": "block-rule",
+                    "severity": ["critical"],
+                    "host": "any",
+                    "action": {"block_ip": {"track_by": "source", "duration": 300}},
+                }
+            ],
+        )
+        assert profile.rules[0]["action"]["block_ip"]["duration"] == 300

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -14,6 +14,7 @@ from scm_cli.utils.validators import (
     Region,
     Schedule,
     SecurityRule,
+    URLCategory,
     VulnerabilityProtectionProfile,
     WildfireAntivirusProfile,
     Zone,
@@ -1161,3 +1162,83 @@ class TestVulnerabilityProtectionProfile:
             ],
         )
         assert profile.rules[0]["action"]["block_ip"]["duration"] == 300
+
+
+class TestURLCategory:
+    """Test cases for the URLCategory model."""
+
+    def test_valid_url_category(self):
+        """Test creating a valid URL category."""
+        category = URLCategory(
+            name="custom-block",
+            folder="Texas",
+            description="Custom blocked URLs",
+            type="URL List",
+            url_list=["malware.example.com", "phishing.test.org"],
+        )
+        assert category.name == "custom-block"
+        assert category.folder == "Texas"
+        assert category.description == "Custom blocked URLs"
+        assert category.type == "URL List"
+        assert category.url_list == ["malware.example.com", "phishing.test.org"]
+
+    def test_missing_name(self):
+        """Test that name is required."""
+        with pytest.raises(ValidationError):
+            URLCategory(folder="Texas")
+
+    def test_no_container(self):
+        """Test that exactly one container must be set."""
+        with pytest.raises(ValidationError):
+            URLCategory(name="test")
+
+    def test_multiple_containers(self):
+        """Test that multiple containers are rejected."""
+        with pytest.raises(ValidationError):
+            URLCategory(name="test", folder="Texas", snippet="My-Snippet")
+
+    def test_invalid_type(self):
+        """Test that invalid type is rejected."""
+        with pytest.raises(ValidationError):
+            URLCategory(name="test", folder="Texas", type="Invalid Type")
+
+    def test_valid_category_match_type(self):
+        """Test Category Match type is accepted."""
+        category = URLCategory(name="test", folder="Texas", type="Category Match", url_list=["gambling"])
+        assert category.type == "Category Match"
+
+    def test_default_values(self):
+        """Test default values."""
+        category = URLCategory(name="test", folder="Texas")
+        assert category.type == "URL List"
+        assert category.url_list == []
+        assert category.description is None
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        category = URLCategory(
+            name="custom-block",
+            folder="Texas",
+            description="Custom blocked URLs",
+            type="URL List",
+            url_list=["malware.example.com"],
+        )
+        sdk_data = category.to_sdk_model()
+        assert sdk_data["name"] == "custom-block"
+        assert sdk_data["folder"] == "Texas"
+        assert sdk_data["description"] == "Custom blocked URLs"
+        assert sdk_data["type"] == "URL List"
+        assert sdk_data["list"] == ["malware.example.com"]
+
+    def test_to_sdk_model_snippet(self):
+        """Test conversion with snippet container."""
+        category = URLCategory(name="test", snippet="My-Snippet")
+        sdk_data = category.to_sdk_model()
+        assert sdk_data["snippet"] == "My-Snippet"
+        assert "folder" not in sdk_data
+
+    def test_to_sdk_model_minimal(self):
+        """Test conversion with minimal fields."""
+        category = URLCategory(name="test", folder="Texas")
+        sdk_data = category.to_sdk_model()
+        assert sdk_data == {"name": "test", "folder": "Texas", "type": "URL List"}


### PR DESCRIPTION
## Summary
- IPsec crypto profile commands (set/show/delete/load/backup) (#48)
- NAT rule commands (set/show/delete/load/backup) (#50)
- DNS security profile commands (set/show/delete/load/backup) (#51)
- URL category commands (set/show/delete/load/backup) (#52)
- Vulnerability protection profile commands (set/show/delete/load/backup) (#53)

## Changes
- Added 5 new resource types with full CRUD + load/backup support
- Added Pydantic validators with container validation and `to_sdk_model()` for each
- Added SDK client methods with smart upsert and mock mode support
- Added 97 new passing tests (validators + commands)

## Testing
- 97 new tests, all passing
- 7 pre-existing failures (BandwidthAllocation, Zone, SecurityRule) unrelated to changes

## Checklist
- [x] Tests written and passing
- [x] Follows existing code patterns and style guides
- [x] Mock mode support included

Closes #48, closes #50, closes #51, closes #52, closes #53