### PR TITLE
feat: add aggregate interface commands (#70)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "0.5.2"
+version = "0.5.3"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -15,7 +15,7 @@ from pydantic import ValidationError
 
 from ..utils.config import load_from_yaml
 from ..utils.sdk_client import scm_client
-from ..utils.validators import IKECryptoProfile, IKEGateway, IPSecCryptoProfile, NATRule, Zone
+from ..utils.validators import AggregateInterface, IKECryptoProfile, IKEGateway, IPSecCryptoProfile, NATRule, Zone
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -463,6 +463,259 @@ def show_ike_crypto_profile(
             return profiles
     except Exception as e:
         typer.echo(f"Error showing IKE crypto profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# AGGREGATE INTERFACE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("aggregate-interface", help="Export aggregate interfaces to a YAML file.")
+def backup_aggregate_interface(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export aggregate interfaces from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving aggregate interfaces from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        interfaces = scm_client.list_aggregate_interfaces(**kwargs)
+        if not interfaces:
+            typer.echo(f"No aggregate interfaces found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"aggregate_interfaces": interfaces}
+        filename = Path(file or get_default_backup_filename("aggregate-interface", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(interfaces)} aggregate interfaces to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up aggregate interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("aggregate-interface", help="Delete an aggregate interface.")
+def delete_aggregate_interface(
+    name: str = typer.Argument(..., help="Name of the aggregate interface to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete an aggregate interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface = scm_client.get_aggregate_interface(name=name, folder=folder, snippet=snippet, device=device)
+        if not iface:
+            typer.echo(f"Aggregate interface '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete aggregate interface '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_aggregate_interface(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted aggregate interface: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting aggregate interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("aggregate-interface", help="Load aggregate interfaces from a YAML file.")
+def load_aggregate_interface(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+    dry_run: bool = DRY_RUN_OPTION,
+) -> None:
+    """Load aggregate interfaces from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "aggregate_interfaces" not in data:
+            typer.echo("No aggregate interfaces found in file", err=True)
+            raise typer.Exit(code=1)
+        interfaces = data["aggregate_interfaces"]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(interfaces))
+            return None
+
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+        for iface_data in interfaces:
+            try:
+                if folder:
+                    iface_data["folder"] = folder
+                    iface_data.pop("snippet", None)
+                    iface_data.pop("device", None)
+                elif snippet:
+                    iface_data["snippet"] = snippet
+                    iface_data.pop("folder", None)
+                    iface_data.pop("device", None)
+                elif device:
+                    iface_data["device"] = device
+                    iface_data.pop("folder", None)
+                    iface_data.pop("snippet", None)
+                validated_iface = AggregateInterface(**iface_data)
+                sdk_data = validated_iface.to_sdk_model()
+                result = scm_client.create_aggregate_interface(sdk_data)
+                action = result.pop("__action__", "created")
+                container = validated_iface.folder or validated_iface.snippet or validated_iface.device
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created aggregate interface: {validated_iface.name} in {container}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated aggregate interface: {validated_iface.name} in {container}")
+                else:
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for aggregate interface: {validated_iface.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing aggregate interface: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count + updated_count + no_change_count} aggregate interfaces")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+    except Exception as e:
+        typer.echo(f"Error loading aggregate interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("aggregate-interface", help="Create or update an aggregate interface.")
+def set_aggregate_interface(
+    name: str = typer.Argument(..., help="Name of the aggregate interface"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    comment: str = typer.Option(None, "--comment", help="Interface description/comment"),
+    layer2_json: str = typer.Option(None, "--layer2-json", help='Layer2 config as JSON (e.g. \'{"vlan_tag": "100"}\')'),
+    layer3_json: str = typer.Option(None, "--layer3-json", help='Layer3 config as JSON (e.g. \'{"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]}\')'),
+) -> None:
+    """Create or update an aggregate interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+
+        iface_data: dict[str, Any] = {
+            "name": name,
+            location_type: location_value,
+        }
+
+        if comment:
+            iface_data["comment"] = comment
+
+        if layer2_json:
+            iface_data["layer2"] = json.loads(layer2_json)
+        if layer3_json:
+            iface_data["layer3"] = json.loads(layer3_json)
+
+        validated_iface = AggregateInterface(**iface_data)
+        sdk_data = validated_iface.to_sdk_model()
+        result = scm_client.create_aggregate_interface(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created aggregate interface: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated aggregate interface: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for aggregate interface: {name} in {location_value}")
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating aggregate interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("aggregate-interface", help="Show aggregate interface details.")
+def show_aggregate_interface(
+    name: str = typer.Option(None, "--name", help="Name of specific aggregate interface to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show aggregate interface details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            iface = scm_client.get_aggregate_interface(name=name, folder=folder, snippet=snippet, device=device)
+            if not iface:
+                typer.echo(f"Aggregate interface '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nAggregate Interface: {iface['name']}")
+            typer.echo("=" * 60)
+            location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if iface.get("comment"):
+                typer.echo(f"Comment: {iface['comment']}")
+            # Interface mode
+            if iface.get("layer3"):
+                typer.echo("Mode: Layer3")
+                l3 = iface["layer3"]
+                if l3.get("mtu"):
+                    typer.echo(f"  MTU: {l3['mtu']}")
+                if l3.get("ip"):
+                    for ip_entry in l3["ip"]:
+                        typer.echo(f"  IP: {ip_entry.get('name', 'N/A')}")
+                if l3.get("interface_management_profile"):
+                    typer.echo(f"  Management Profile: {l3['interface_management_profile']}")
+                if l3.get("dhcp_client"):
+                    typer.echo("  DHCP Client: Enabled")
+            elif iface.get("layer2"):
+                typer.echo("Mode: Layer2")
+                l2 = iface["layer2"]
+                if l2.get("vlan_tag"):
+                    typer.echo(f"  VLAN Tag: {l2['vlan_tag']}")
+            if iface.get("id"):
+                typer.echo(f"\nID: {iface['id']}")
+            return iface
+        else:
+            interfaces = scm_client.list_aggregate_interfaces(folder=folder, snippet=snippet, device=device)
+            if not interfaces:
+                typer.echo("No aggregate interfaces found")
+                return
+            typer.echo("\nAggregate Interfaces:")
+            typer.echo("-" * 80)
+            for iface in interfaces:
+                location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+                typer.echo(f"Name: {iface.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                if iface.get("comment"):
+                    typer.echo(f"  Comment: {iface['comment']}")
+                if iface.get("layer3"):
+                    typer.echo("  Mode: Layer3")
+                    if iface["layer3"].get("mtu"):
+                        typer.echo(f"  MTU: {iface['layer3']['mtu']}")
+                elif iface.get("layer2"):
+                    typer.echo("  Mode: Layer2")
+                    if iface["layer2"].get("vlan_tag"):
+                        typer.echo(f"  VLAN Tag: {iface['layer2']['vlan_tag']}")
+                if iface.get("id"):
+                    typer.echo(f"  ID: {iface['id']}")
+                typer.echo("-" * 80)
+            return interfaces
+    except Exception as e:
+        typer.echo(f"Error showing aggregate interface: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -5471,6 +5471,171 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("listing", folder or snippet or device or "", "IKE crypto profiles", e)
 
+    # ---------------------------------------------------------------------------------- Aggregate Interfaces ---------------------------------------------------------------------------------
+
+    def create_aggregate_interface(self, iface_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update an aggregate interface using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in iface_data and iface_data[field] is not None:
+                container_field = field
+                container_value = iface_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            result = iface_data.copy()
+            result["id"] = f"ae-{iface_data['name']}"
+            result["__action__"] = "created"
+            return result
+        existing_iface = None
+        try:
+            existing_iface = self.client.aggregate_interface.fetch(name=iface_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing aggregate interface '{iface_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"Aggregate interface '{iface_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching aggregate interface '{iface_data['name']}': {str(e)}")
+        if existing_iface:
+            needs_update = False
+            update_fields = []
+            # Compare comment
+            if "comment" in iface_data:
+                existing_comment = getattr(existing_iface, "comment", None)
+                if iface_data["comment"] != existing_comment:
+                    needs_update = True
+                    update_fields.append("comment")
+            # Compare layer2
+            if "layer2" in iface_data:
+                existing_layer2 = json.loads(existing_iface.layer2.model_dump_json(exclude_unset=True)) if existing_iface.layer2 else None
+                if iface_data["layer2"] != existing_layer2:
+                    needs_update = True
+                    update_fields.append("layer2")
+            # Compare layer3
+            if "layer3" in iface_data:
+                existing_layer3 = json.loads(existing_iface.layer3.model_dump_json(exclude_unset=True)) if existing_iface.layer3 else None
+                if iface_data["layer3"] != existing_layer3:
+                    needs_update = True
+                    update_fields.append("layer3")
+            if needs_update:
+                self.logger.info(f"Updating aggregate interface fields: {', '.join(update_fields)}")
+                try:
+                    update_data = iface_data.copy()
+                    update_data["id"] = str(existing_iface.id)
+                    result = self.client.aggregate_interface.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"aggregate interface '{iface_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_iface.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.aggregate_interface.create(iface_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"aggregate interface '{iface_data['name']}'", create_error)
+
+    def delete_aggregate_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete an aggregate interface."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete aggregate interface: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            iface = self.client.aggregate_interface.fetch(name=name, **container_kwargs)
+            self.client.aggregate_interface.delete(str(iface.id))
+            self.logger.info(f"Deleted aggregate interface: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"aggregate interface '{name}'", e)
+
+    def get_aggregate_interface(
+        self,
+        name: str,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+    ) -> dict[str, Any] | None:
+        """Get a specific aggregate interface."""
+        if not self.client:
+            return {
+                "id": "ae-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "comment": "Mock aggregate interface",
+                "layer3": {"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]},
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.aggregate_interface.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"Aggregate interface '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"aggregate interface '{name}'", e)
+
+    def list_aggregate_interfaces(
+        self,
+        folder: str | None = None,
+        snippet: str | None = None,
+        device: str | None = None,
+        exact_match: bool = False,
+    ) -> list[dict[str, Any]]:
+        """List aggregate interfaces in a container."""
+        if not self.client:
+            return [
+                {
+                    "id": "ae-mock1",
+                    "folder": folder or "ngfw-shared",
+                    "name": "ae1",
+                    "comment": "Mock aggregate interface 1",
+                    "layer3": {"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]},
+                },
+                {
+                    "id": "ae-mock2",
+                    "folder": folder or "ngfw-shared",
+                    "name": "ae2",
+                    "comment": "Mock aggregate interface 2",
+                    "layer2": {"vlan_tag": "100"},
+                },
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.aggregate_interface.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "aggregate interfaces", e)
+
     # --------------------------------------------------------------------------------------- IKE Gateways -----------------------------------------------------------------------------------
 
     def create_ike_gateway(self, gateway_data: dict[str, Any]) -> dict[str, Any]:
@@ -8582,10 +8747,7 @@ class SCMClient:
                         jobs.append({"id": str(job)})
                 return jobs
             elif isinstance(result, list):
-                return [
-                    json.loads(j.model_dump_json(exclude_unset=True)) if hasattr(j, "model_dump_json") else {"id": str(j)}
-                    for j in result[:max_results]
-                ]
+                return [json.loads(j.model_dump_json(exclude_unset=True)) if hasattr(j, "model_dump_json") else {"id": str(j)} for j in result[:max_results]]
             return []
         except Exception as e:
             self._handle_api_exception("listing", "", "jobs", e)
@@ -8889,6 +9051,7 @@ class SCMClient:
                 if needs_update:
                     self.logger.info(f"Updating internal DNS server fields: {', '.join(update_fields)}")
                     from scm.models.deployment import InternalDnsServersUpdateModel
+
                     update_data = {
                         "id": str(existing.id),
                         "name": name,

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -1702,6 +1702,65 @@ class Tag(BaseModel):
 # ========================================================================================================================================================================================
 
 
+class AggregateInterface(BaseModel):
+    """Model for aggregate interface configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the aggregate interface")
+    snippet: str | None = Field(None, description="Snippet path for the aggregate interface")
+    device: str | None = Field(None, description="Device path for the aggregate interface")
+    name: str = Field(
+        ...,
+        description="Aggregate interface name (e.g. ae1)",
+    )
+    comment: str | None = Field(None, description="Interface description/comment")
+    default_value: str | None = Field(None, description="Default interface assignment")
+    layer2: dict[str, Any] | None = Field(None, description="Layer2 configuration (vlan_tag, lacp)")
+    layer3: dict[str, Any] | None = Field(None, description="Layer3 configuration (ip, dhcp_client, mtu, arp, lacp)")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "AggregateInterface":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @model_validator(mode="after")
+    def validate_interface_mode(self) -> "AggregateInterface":
+        """Validate that at most one interface mode is specified."""
+        modes = [self.layer2, self.layer3]
+        configured = [m for m in modes if m is not None]
+        if len(configured) > 1:
+            raise ValueError("Only one interface mode allowed: layer2 or layer3")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "name": self.name,
+        }
+
+        # Add container field
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+
+        # Add optional fields
+        if self.comment:
+            model_data["comment"] = self.comment
+        if self.default_value:
+            model_data["default_value"] = self.default_value
+        if self.layer2 is not None:
+            model_data["layer2"] = self.layer2
+        if self.layer3 is not None:
+            model_data["layer3"] = self.layer3
+
+        return model_data
+
+
 class NATRule(BaseModel):
     """Model for NAT rule configurations."""
 
@@ -2648,10 +2707,24 @@ class Variable(BaseModel):
     def validate_type(cls, v: str) -> str:
         """Validate that the type is one of the allowed values."""
         allowed = [
-            "percent", "count", "ip-netmask", "zone", "ip-range",
-            "ip-wildcard", "device-priority", "device-id", "egress-max",
-            "as-number", "fqdn", "port", "link-tag", "group-id",
-            "rate", "router-id", "qos-profile", "timer",
+            "percent",
+            "count",
+            "ip-netmask",
+            "zone",
+            "ip-range",
+            "ip-wildcard",
+            "device-priority",
+            "device-id",
+            "egress-max",
+            "as-number",
+            "fqdn",
+            "port",
+            "link-tag",
+            "group-id",
+            "rate",
+            "router-id",
+            "qos-profile",
+            "timer",
         ]
         if v not in allowed:
             raise ValueError(f"type must be one of {allowed}, got {v}")

--- a/tests/test_network_commands.py
+++ b/tests/test_network_commands.py
@@ -2,24 +2,28 @@
 
 import typer  # noqa: I001
 from scm_cli.commands.network import (
+    delete_aggregate_interface,
     delete_app,
     delete_ike_crypto_profile,
     delete_ike_gateway,
     delete_ipsec_crypto_profile,
     delete_nat_rule,
     delete_zone,
+    load_aggregate_interface,
     load_app,
     load_ike_crypto_profile,
     load_ike_gateway,
     load_ipsec_crypto_profile,
     load_nat_rule,
     load_security_zone as load_zone,
+    set_aggregate_interface,
     set_app,
     set_ike_crypto_profile,
     set_ike_gateway,
     set_ipsec_crypto_profile,
     set_nat_rule,
     set_zone,
+    show_aggregate_interface,
     show_ike_crypto_profile,
     show_ike_gateway,
     show_ipsec_crypto_profile,
@@ -393,14 +397,22 @@ class TestIKEGatewayCommands:
         monkeypatch.setattr(scm_client, "create_ike_gateway", mock_create)
         test_app = typer.Typer()
         test_app.command()(set_ike_gateway)
-        result = runner.invoke(test_app, [
-            "test-gw",
-            "--folder", "test-folder",
-            "--pre-shared-key", "my-secret",
-            "--peer-address-ip", "203.0.113.1",
-            "--protocol-version", "ikev2-preferred",
-            "--ike-crypto-profile", "default",
-        ])
+        result = runner.invoke(
+            test_app,
+            [
+                "test-gw",
+                "--folder",
+                "test-folder",
+                "--pre-shared-key",
+                "my-secret",
+                "--peer-address-ip",
+                "203.0.113.1",
+                "--protocol-version",
+                "ikev2-preferred",
+                "--ike-crypto-profile",
+                "default",
+            ],
+        )
         assert result.exit_code == 0
         assert "Created IKE gateway" in result.stdout
         assert "test-gw" in result.stdout
@@ -415,12 +427,18 @@ class TestIKEGatewayCommands:
         monkeypatch.setattr(scm_client, "create_ike_gateway", mock_create_error)
         test_app = typer.Typer()
         test_app.command()(set_ike_gateway)
-        result = runner.invoke(test_app, [
-            "test-gw",
-            "--folder", "test-folder",
-            "--pre-shared-key", "my-secret",
-            "--peer-address-ip", "203.0.113.1",
-        ])
+        result = runner.invoke(
+            test_app,
+            [
+                "test-gw",
+                "--folder",
+                "test-folder",
+                "--pre-shared-key",
+                "my-secret",
+                "--peer-address-ip",
+                "203.0.113.1",
+            ],
+        )
         assert result.exit_code == 1
         assert "Error" in result.stdout
 
@@ -428,22 +446,32 @@ class TestIKEGatewayCommands:
         """Test set ike-gateway command requires authentication."""
         test_app = typer.Typer()
         test_app.command()(set_ike_gateway)
-        result = runner.invoke(test_app, [
-            "test-gw",
-            "--folder", "test-folder",
-            "--peer-address-ip", "203.0.113.1",
-        ])
+        result = runner.invoke(
+            test_app,
+            [
+                "test-gw",
+                "--folder",
+                "test-folder",
+                "--peer-address-ip",
+                "203.0.113.1",
+            ],
+        )
         assert result.exit_code == 1
 
     def test_set_ike_gateway_missing_peer_address(self, runner, monkeypatch):
         """Test set ike-gateway command requires peer address."""
         test_app = typer.Typer()
         test_app.command()(set_ike_gateway)
-        result = runner.invoke(test_app, [
-            "test-gw",
-            "--folder", "test-folder",
-            "--pre-shared-key", "my-secret",
-        ])
+        result = runner.invoke(
+            test_app,
+            [
+                "test-gw",
+                "--folder",
+                "test-folder",
+                "--pre-shared-key",
+                "my-secret",
+            ],
+        )
         assert result.exit_code == 1
 
     def test_show_ike_gateway_list(self, runner, monkeypatch):
@@ -519,13 +547,15 @@ class TestIKEGatewayCommands:
         from scm_cli.utils.sdk_client import scm_client
 
         yaml_data = {
-            "ike_gateways": [{
-                "name": "test-gw",
-                "folder": "test-folder",
-                "authentication": {"pre_shared_key": {"key": "secret"}},
-                "peer_address": {"ip": "203.0.113.1"},
-                "protocol": {"version": "ikev2-preferred", "ikev1": {"ike_crypto_profile": "default"}, "ikev2": {"ike_crypto_profile": "default"}},
-            }]
+            "ike_gateways": [
+                {
+                    "name": "test-gw",
+                    "folder": "test-folder",
+                    "authentication": {"pre_shared_key": {"key": "secret"}},
+                    "peer_address": {"ip": "203.0.113.1"},
+                    "protocol": {"version": "ikev2-preferred", "ikev1": {"ike_crypto_profile": "default"}, "ikev2": {"ike_crypto_profile": "default"}},
+                }
+            ]
         }
         yaml_file = tmp_path / "ike-gateways.yaml"
         with yaml_file.open("w") as f:
@@ -552,13 +582,15 @@ class TestIKEGatewayCommands:
         from scm_cli.utils.sdk_client import scm_client
 
         yaml_data = {
-            "ike_gateways": [{
-                "name": "test-gw",
-                "folder": "test-folder",
-                "authentication": {"pre_shared_key": {"key": "secret"}},
-                "peer_address": {"ip": "203.0.113.1"},
-                "protocol": {"version": "ikev2", "ikev2": {"ike_crypto_profile": "default"}},
-            }]
+            "ike_gateways": [
+                {
+                    "name": "test-gw",
+                    "folder": "test-folder",
+                    "authentication": {"pre_shared_key": {"key": "secret"}},
+                    "peer_address": {"ip": "203.0.113.1"},
+                    "protocol": {"version": "ikev2", "ikev2": {"ike_crypto_profile": "default"}},
+                }
+            ]
         }
         yaml_file = tmp_path / "ike-gateways.yaml"
         with yaml_file.open("w") as f:
@@ -1096,6 +1128,187 @@ class TestNATRuleCommands:
 
         result = runner.invoke(test_app, ["--file", str(mock_nat_rules_yaml_file), "--dry-run"])
 
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+        assert not mock_called
+
+
+class TestAggregateInterfaceCommands:
+    """Test the aggregate interface commands."""
+
+    def test_set_aggregate_interface_created(self, runner, monkeypatch):
+        """Test set aggregate-interface command creates a new interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(iface_data):
+            result = iface_data.copy()
+            result["id"] = "ae-12345"
+            result["__action__"] = "created"
+            return result
+
+        monkeypatch.setattr(scm_client, "create_aggregate_interface", mock_create)
+        test_app = typer.Typer()
+        test_app.command()(set_aggregate_interface)
+        result = runner.invoke(
+            test_app,
+            [
+                "ae1",
+                "--folder",
+                "test-folder",
+                "--layer3-json",
+                '{"mtu": 1500}',
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Created aggregate interface" in result.stdout
+        assert "ae1" in result.stdout
+
+    def test_set_aggregate_interface_error(self, runner, monkeypatch):
+        """Test set aggregate-interface command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create_error(iface_data):
+            raise ValueError("Test error")
+
+        monkeypatch.setattr(scm_client, "create_aggregate_interface", mock_create_error)
+        test_app = typer.Typer()
+        test_app.command()(set_aggregate_interface)
+        result = runner.invoke(
+            test_app,
+            [
+                "ae1",
+                "--folder",
+                "test-folder",
+                "--layer3-json",
+                '{"mtu": 1500}',
+            ],
+        )
+        assert result.exit_code == 1
+        assert "Error" in result.stdout
+
+    def test_show_aggregate_interface_list(self, runner, monkeypatch):
+        """Test show aggregate-interface command lists interfaces."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(**kwargs):
+            return [
+                {
+                    "id": "ae-1",
+                    "name": "ae1",
+                    "folder": "test-folder",
+                    "layer3": {"mtu": 1500},
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_aggregate_interfaces", mock_list)
+        test_app = typer.Typer()
+        test_app.command()(show_aggregate_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "ae1" in result.stdout
+
+    def test_show_aggregate_interface_specific(self, runner, monkeypatch):
+        """Test show aggregate-interface command shows a specific interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(**kwargs):
+            return {
+                "id": "ae-1",
+                "name": "ae1",
+                "folder": "test-folder",
+                "comment": "test interface",
+                "layer3": {"mtu": 9000, "ip": [{"name": "10.0.0.1/24"}]},
+            }
+
+        monkeypatch.setattr(scm_client, "get_aggregate_interface", mock_get)
+        test_app = typer.Typer()
+        test_app.command()(show_aggregate_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "ae1"])
+        assert result.exit_code == 0
+        assert "ae1" in result.stdout
+        assert "9000" in result.stdout
+
+    def test_delete_aggregate_interface_command(self, runner, monkeypatch):
+        """Test delete aggregate-interface command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(**kwargs):
+            return {"id": "ae-1", "name": "ae1", "folder": "test-folder"}
+
+        def mock_delete(**kwargs):
+            return None
+
+        monkeypatch.setattr(scm_client, "get_aggregate_interface", mock_get)
+        monkeypatch.setattr(scm_client, "delete_aggregate_interface", mock_delete)
+        test_app = typer.Typer()
+        test_app.command()(delete_aggregate_interface)
+        result = runner.invoke(test_app, ["ae1", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted aggregate interface" in result.stdout
+
+    def test_load_aggregate_interface_command(self, runner, monkeypatch, tmp_path):
+        """Test load aggregate-interface command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {
+            "aggregate_interfaces": [
+                {
+                    "name": "ae1",
+                    "folder": "test-folder",
+                    "layer3": {"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]},
+                }
+            ]
+        }
+        yaml_file = tmp_path / "aggregate-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        def mock_create(iface_data):
+            result = iface_data.copy()
+            result["id"] = "ae-12345"
+            result["__action__"] = "created"
+            return result
+
+        monkeypatch.setattr(scm_client, "create_aggregate_interface", mock_create)
+        test_app = typer.Typer()
+        test_app.command()(load_aggregate_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created aggregate interface" in result.stdout
+        assert "ae1" in result.stdout
+
+    def test_load_aggregate_interface_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test load aggregate-interface command with dry-run."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {
+            "aggregate_interfaces": [
+                {
+                    "name": "ae1",
+                    "folder": "test-folder",
+                    "layer3": {"mtu": 1500},
+                }
+            ]
+        }
+        yaml_file = tmp_path / "aggregate-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        mock_called = False
+
+        def mock_create(iface_data):
+            nonlocal mock_called
+            mock_called = True
+            return {}
+
+        monkeypatch.setattr(scm_client, "create_aggregate_interface", mock_create)
+        test_app = typer.Typer()
+        test_app.command()(load_aggregate_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run mode" in result.stdout
         assert not mock_called

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from scm_cli.utils.validators import (
     AddressGroup,
+    AggregateInterface,
     BandwidthAllocation,
     BGPRouting,
     DNSSecurityProfile,
@@ -951,6 +952,8 @@ class TestWildfireAntivirusProfile:
                 rules=[{"name": "rule1", "direction": "both", "analysis": analysis}],
             )
             assert profile.rules[0]["analysis"] == analysis
+
+
 class TestIPSecCryptoProfile:
     """Test cases for the IPSecCryptoProfile model."""
 
@@ -1685,3 +1688,81 @@ class TestAuthSetting:
         sdk_data = setting.to_sdk_model()
         assert sdk_data["auth_type"] == "ldap"
         assert sdk_data["ldap_profile"] == "corp-ldap"
+
+
+class TestAggregateInterface:
+    """Test cases for the AggregateInterface model."""
+
+    def test_valid_layer3(self):
+        """Test creating a valid layer3 aggregate interface."""
+        iface = AggregateInterface(
+            name="ae1",
+            folder="test-folder",
+            layer3={"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]},
+        )
+        assert iface.name == "ae1"
+        assert iface.folder == "test-folder"
+        assert iface.layer3 == {"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]}
+        assert iface.layer2 is None
+
+    def test_valid_layer2(self):
+        """Test creating a valid layer2 aggregate interface."""
+        iface = AggregateInterface(
+            name="ae2",
+            folder="test-folder",
+            layer2={"vlan_tag": "100"},
+        )
+        assert iface.name == "ae2"
+        assert iface.layer2 == {"vlan_tag": "100"}
+        assert iface.layer3 is None
+
+    def test_missing_name_raises(self):
+        """Test that missing name raises error."""
+        with pytest.raises(ValidationError):
+            AggregateInterface(folder="test-folder")
+
+    def test_no_container_raises(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            AggregateInterface(name="ae1")
+
+    def test_multiple_containers_raises(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            AggregateInterface(name="ae1", folder="f", snippet="s")
+
+    def test_both_modes_raises(self):
+        """Test that specifying both layer2 and layer3 raises error."""
+        with pytest.raises(ValidationError):
+            AggregateInterface(
+                name="ae1",
+                folder="test-folder",
+                layer2={"vlan_tag": "100"},
+                layer3={"mtu": 1500},
+            )
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        iface = AggregateInterface(
+            name="ae1",
+            folder="test-folder",
+            comment="test interface",
+            layer3={"mtu": 9000, "ip": [{"name": "10.0.0.1/24"}]},
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["name"] == "ae1"
+        assert sdk_data["folder"] == "test-folder"
+        assert sdk_data["comment"] == "test interface"
+        assert sdk_data["layer3"]["mtu"] == 9000
+
+    def test_minimal_creation(self):
+        """Test minimal aggregate interface creation."""
+        iface = AggregateInterface(
+            name="ae1",
+            folder="test-folder",
+        )
+        assert iface.name == "ae1"
+        assert iface.folder == "test-folder"
+        assert iface.layer2 is None
+        assert iface.layer3 is None
+        assert iface.comment is None


### PR DESCRIPTION
## Summary
- Aggregate interface commands (set/show/delete/load/backup) for SDK 0.12.0 parity
- Supports layer2 and layer3 modes with mutual exclusion validation
- Smart upsert, mock mode, complex nested config via JSON options

## Changes
- Added `AggregateInterface` Pydantic validator with container + mode validation
- Added SDK client methods (create/get/list/delete + mock)
- Added 5 CLI commands in network module
- Version bump 0.5.2 → 0.5.3

## Testing
- 8 new validator tests (all pass)
- 7 new command tests

Closes #70