### PR TITLE
feat: add 7 interface types - DHCP, ethernet, L2/L3 subinterface, loopback, tunnel, VLAN

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "0.5.3"
+version = "0.5.10"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -15,7 +15,21 @@ from pydantic import ValidationError
 
 from ..utils.config import load_from_yaml
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AggregateInterface, IKECryptoProfile, IKEGateway, IPSecCryptoProfile, NATRule, Zone
+from ..utils.validators import (
+    AggregateInterface,
+    DhcpInterface,
+    EthernetInterface,
+    IKECryptoProfile,
+    IKEGateway,
+    IPSecCryptoProfile,
+    Layer2Subinterface,
+    Layer3Subinterface,
+    LoopbackInterface,
+    NATRule,
+    TunnelInterface,
+    VlanInterface,
+    Zone,
+)
 
 # ========================================================================================================================================================================================
 # TYPER APP CONFIGURATION
@@ -2114,4 +2128,1631 @@ def show_nat_rule(
 
     except Exception as e:
         typer.echo(f"Error showing NAT rule: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# DHCP INTERFACE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("dhcp-interface", help="Export DHCP interfaces to a YAML file.")
+def backup_dhcp_interface(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export DHCP interfaces from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving DHCP interfaces from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        interfaces = scm_client.list_dhcp_interfaces(**kwargs)
+        if not interfaces:
+            typer.echo(f"No DHCP interfaces found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"dhcp_interfaces": interfaces}
+        filename = Path(file or get_default_backup_filename("dhcp-interface", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(interfaces)} DHCP interfaces to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up DHCP interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("dhcp-interface", help="Delete a DHCP interface.")
+def delete_dhcp_interface(
+    name: str = typer.Argument(..., help="Name of the DHCP interface to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a DHCP interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface = scm_client.get_dhcp_interface(name=name, folder=folder, snippet=snippet, device=device)
+        if not iface:
+            typer.echo(f"DHCP interface '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete DHCP interface '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_dhcp_interface(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted DHCP interface: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting DHCP interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("dhcp-interface", help="Load DHCP interfaces from a YAML file.")
+def load_dhcp_interface(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+    dry_run: bool = DRY_RUN_OPTION,
+) -> None:
+    """Load DHCP interfaces from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "dhcp_interfaces" not in data:
+            typer.echo("No DHCP interfaces found in file", err=True)
+            raise typer.Exit(code=1)
+        interfaces = data["dhcp_interfaces"]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(interfaces))
+            return None
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+        for iface_data in interfaces:
+            try:
+                if folder:
+                    iface_data["folder"] = folder
+                    iface_data.pop("snippet", None)
+                    iface_data.pop("device", None)
+                elif snippet:
+                    iface_data["snippet"] = snippet
+                    iface_data.pop("folder", None)
+                    iface_data.pop("device", None)
+                elif device:
+                    iface_data["device"] = device
+                    iface_data.pop("folder", None)
+                    iface_data.pop("snippet", None)
+                validated_iface = DhcpInterface(**iface_data)
+                sdk_data = validated_iface.to_sdk_model()
+                result = scm_client.create_dhcp_interface(sdk_data)
+                action = result.pop("__action__", "created")
+                container = validated_iface.folder or validated_iface.snippet or validated_iface.device
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created DHCP interface: {validated_iface.name} in {container}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated DHCP interface: {validated_iface.name} in {container}")
+                else:
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for DHCP interface: {validated_iface.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing DHCP interface: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count + updated_count + no_change_count} DHCP interfaces")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+    except Exception as e:
+        typer.echo(f"Error loading DHCP interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("dhcp-interface", help="Create or update a DHCP interface.")
+def set_dhcp_interface(
+    name: str = typer.Argument(..., help="Name of the DHCP interface"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    server_json: str = typer.Option(None, "--server-json", help="DHCP server config as JSON"),
+    relay_json: str = typer.Option(None, "--relay-json", help="DHCP relay config as JSON"),
+) -> None:
+    """Create or update a DHCP interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface_data: dict[str, Any] = {"name": name, location_type: location_value}
+        if server_json:
+            iface_data["server"] = json.loads(server_json)
+        if relay_json:
+            iface_data["relay"] = json.loads(relay_json)
+        validated_iface = DhcpInterface(**iface_data)
+        sdk_data = validated_iface.to_sdk_model()
+        result = scm_client.create_dhcp_interface(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created DHCP interface: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated DHCP interface: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for DHCP interface: {name} in {location_value}")
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating DHCP interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("dhcp-interface", help="Show DHCP interface details.")
+def show_dhcp_interface(
+    name: str = typer.Option(None, "--name", help="Name of specific DHCP interface to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show DHCP interface details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            iface = scm_client.get_dhcp_interface(name=name, folder=folder, snippet=snippet, device=device)
+            if not iface:
+                typer.echo(f"DHCP interface '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nDHCP Interface: {iface['name']}")
+            typer.echo("=" * 60)
+            location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if iface.get("server"):
+                typer.echo(f"Server: {json.dumps(iface['server'])}")
+            if iface.get("relay"):
+                typer.echo(f"Relay: {json.dumps(iface['relay'])}")
+            if iface.get("id"):
+                typer.echo(f"\nID: {iface['id']}")
+            return iface
+        else:
+            interfaces = scm_client.list_dhcp_interfaces(folder=folder, snippet=snippet, device=device)
+            if not interfaces:
+                typer.echo("No DHCP interfaces found")
+                return
+            typer.echo("\nDHCP Interfaces:")
+            typer.echo("-" * 80)
+            for iface in interfaces:
+                location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+                typer.echo(f"Name: {iface.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                if iface.get("server"):
+                    typer.echo("  Type: Server")
+                elif iface.get("relay"):
+                    typer.echo("  Type: Relay")
+                if iface.get("id"):
+                    typer.echo(f"  ID: {iface['id']}")
+                typer.echo("-" * 80)
+            return interfaces
+    except Exception as e:
+        typer.echo(f"Error showing DHCP interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# ETHERNET INTERFACE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("ethernet-interface", help="Export ethernet interfaces to a YAML file.")
+def backup_ethernet_interface(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export ethernet interfaces from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving ethernet interfaces from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        interfaces = scm_client.list_ethernet_interfaces(**kwargs)
+        if not interfaces:
+            typer.echo(f"No ethernet interfaces found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"ethernet_interfaces": interfaces}
+        filename = Path(file or get_default_backup_filename("ethernet-interface", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(interfaces)} ethernet interfaces to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up ethernet interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("ethernet-interface", help="Delete an ethernet interface.")
+def delete_ethernet_interface(
+    name: str = typer.Argument(..., help="Name of the ethernet interface to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete an ethernet interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface = scm_client.get_ethernet_interface(name=name, folder=folder, snippet=snippet, device=device)
+        if not iface:
+            typer.echo(f"Ethernet interface '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete ethernet interface '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_ethernet_interface(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted ethernet interface: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting ethernet interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("ethernet-interface", help="Load ethernet interfaces from a YAML file.")
+def load_ethernet_interface(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+    dry_run: bool = DRY_RUN_OPTION,
+) -> None:
+    """Load ethernet interfaces from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "ethernet_interfaces" not in data:
+            typer.echo("No ethernet interfaces found in file", err=True)
+            raise typer.Exit(code=1)
+        interfaces = data["ethernet_interfaces"]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(interfaces))
+            return None
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+        for iface_data in interfaces:
+            try:
+                if folder:
+                    iface_data["folder"] = folder
+                    iface_data.pop("snippet", None)
+                    iface_data.pop("device", None)
+                elif snippet:
+                    iface_data["snippet"] = snippet
+                    iface_data.pop("folder", None)
+                    iface_data.pop("device", None)
+                elif device:
+                    iface_data["device"] = device
+                    iface_data.pop("folder", None)
+                    iface_data.pop("snippet", None)
+                validated_iface = EthernetInterface(**iface_data)
+                sdk_data = validated_iface.to_sdk_model()
+                result = scm_client.create_ethernet_interface(sdk_data)
+                action = result.pop("__action__", "created")
+                container = validated_iface.folder or validated_iface.snippet or validated_iface.device
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created ethernet interface: {validated_iface.name} in {container}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated ethernet interface: {validated_iface.name} in {container}")
+                else:
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for ethernet interface: {validated_iface.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing ethernet interface: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count + updated_count + no_change_count} ethernet interfaces")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+    except Exception as e:
+        typer.echo(f"Error loading ethernet interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("ethernet-interface", help="Create or update an ethernet interface.")
+def set_ethernet_interface(
+    name: str = typer.Argument(..., help="Name of the ethernet interface"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    comment: str = typer.Option(None, "--comment", help="Interface description/comment"),
+    default_value: str = typer.Option(None, "--default-value", help="Physical interface (e.g. ethernet1/1)"),
+    link_speed: str = typer.Option(None, "--link-speed", help="Link speed (auto, 10, 100, 1000, 10000)"),
+    link_duplex: str = typer.Option(None, "--link-duplex", help="Link duplex (auto, half, full)"),
+    link_state: str = typer.Option(None, "--link-state", help="Link state (auto, up, down)"),
+    layer2_json: str = typer.Option(None, "--layer2-json", help="Layer2 config as JSON"),
+    layer3_json: str = typer.Option(None, "--layer3-json", help="Layer3 config as JSON"),
+    tap_json: str = typer.Option(None, "--tap-json", help="TAP config as JSON"),
+) -> None:
+    """Create or update an ethernet interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface_data: dict[str, Any] = {"name": name, location_type: location_value}
+        if comment:
+            iface_data["comment"] = comment
+        if default_value:
+            iface_data["default_value"] = default_value
+        if link_speed:
+            iface_data["link_speed"] = link_speed
+        if link_duplex:
+            iface_data["link_duplex"] = link_duplex
+        if link_state:
+            iface_data["link_state"] = link_state
+        if layer2_json:
+            iface_data["layer2"] = json.loads(layer2_json)
+        if layer3_json:
+            iface_data["layer3"] = json.loads(layer3_json)
+        if tap_json:
+            iface_data["tap"] = json.loads(tap_json)
+        validated_iface = EthernetInterface(**iface_data)
+        sdk_data = validated_iface.to_sdk_model()
+        result = scm_client.create_ethernet_interface(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created ethernet interface: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated ethernet interface: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for ethernet interface: {name} in {location_value}")
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating ethernet interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("ethernet-interface", help="Show ethernet interface details.")
+def show_ethernet_interface(
+    name: str = typer.Option(None, "--name", help="Name of specific ethernet interface to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show ethernet interface details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            iface = scm_client.get_ethernet_interface(name=name, folder=folder, snippet=snippet, device=device)
+            if not iface:
+                typer.echo(f"Ethernet interface '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nEthernet Interface: {iface['name']}")
+            typer.echo("=" * 60)
+            location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if iface.get("comment"):
+                typer.echo(f"Comment: {iface['comment']}")
+            if iface.get("layer3"):
+                typer.echo("Mode: Layer3")
+                l3 = iface["layer3"]
+                if l3.get("mtu"):
+                    typer.echo(f"  MTU: {l3['mtu']}")
+                if l3.get("ip"):
+                    for ip_entry in l3["ip"]:
+                        typer.echo(f"  IP: {ip_entry.get('name', 'N/A')}")
+            elif iface.get("layer2"):
+                typer.echo("Mode: Layer2")
+                l2 = iface["layer2"]
+                if l2.get("vlan_tag"):
+                    typer.echo(f"  VLAN Tag: {l2['vlan_tag']}")
+            elif iface.get("tap"):
+                typer.echo("Mode: TAP")
+            if iface.get("id"):
+                typer.echo(f"\nID: {iface['id']}")
+            return iface
+        else:
+            interfaces = scm_client.list_ethernet_interfaces(folder=folder, snippet=snippet, device=device)
+            if not interfaces:
+                typer.echo("No ethernet interfaces found")
+                return
+            typer.echo("\nEthernet Interfaces:")
+            typer.echo("-" * 80)
+            for iface in interfaces:
+                location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+                typer.echo(f"Name: {iface.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                if iface.get("comment"):
+                    typer.echo(f"  Comment: {iface['comment']}")
+                if iface.get("layer3"):
+                    typer.echo("  Mode: Layer3")
+                elif iface.get("layer2"):
+                    typer.echo("  Mode: Layer2")
+                elif iface.get("tap"):
+                    typer.echo("  Mode: TAP")
+                if iface.get("id"):
+                    typer.echo(f"  ID: {iface['id']}")
+                typer.echo("-" * 80)
+            return interfaces
+    except Exception as e:
+        typer.echo(f"Error showing ethernet interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# LAYER2 SUBINTERFACE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("layer2-subinterface", help="Export layer2 subinterfaces to a YAML file.")
+def backup_layer2_subinterface(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export layer2 subinterfaces from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving layer2 subinterfaces from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        interfaces = scm_client.list_layer2_subinterfaces(**kwargs)
+        if not interfaces:
+            typer.echo(f"No layer2 subinterfaces found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"layer2_subinterfaces": interfaces}
+        filename = Path(file or get_default_backup_filename("layer2-subinterface", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(interfaces)} layer2 subinterfaces to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up layer2 subinterfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("layer2-subinterface", help="Delete a layer2 subinterface.")
+def delete_layer2_subinterface(
+    name: str = typer.Argument(..., help="Name of the layer2 subinterface to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a layer2 subinterface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface = scm_client.get_layer2_subinterface(name=name, folder=folder, snippet=snippet, device=device)
+        if not iface:
+            typer.echo(f"Layer2 subinterface '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete layer2 subinterface '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_layer2_subinterface(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted layer2 subinterface: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting layer2 subinterface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("layer2-subinterface", help="Load layer2 subinterfaces from a YAML file.")
+def load_layer2_subinterface(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+    dry_run: bool = DRY_RUN_OPTION,
+) -> None:
+    """Load layer2 subinterfaces from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "layer2_subinterfaces" not in data:
+            typer.echo("No layer2 subinterfaces found in file", err=True)
+            raise typer.Exit(code=1)
+        interfaces = data["layer2_subinterfaces"]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(interfaces))
+            return None
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+        for iface_data in interfaces:
+            try:
+                if folder:
+                    iface_data["folder"] = folder
+                    iface_data.pop("snippet", None)
+                    iface_data.pop("device", None)
+                elif snippet:
+                    iface_data["snippet"] = snippet
+                    iface_data.pop("folder", None)
+                    iface_data.pop("device", None)
+                elif device:
+                    iface_data["device"] = device
+                    iface_data.pop("folder", None)
+                    iface_data.pop("snippet", None)
+                validated_iface = Layer2Subinterface(**iface_data)
+                sdk_data = validated_iface.to_sdk_model()
+                result = scm_client.create_layer2_subinterface(sdk_data)
+                action = result.pop("__action__", "created")
+                container = validated_iface.folder or validated_iface.snippet or validated_iface.device
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created layer2 subinterface: {validated_iface.name} in {container}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated layer2 subinterface: {validated_iface.name} in {container}")
+                else:
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for layer2 subinterface: {validated_iface.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing layer2 subinterface: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count + updated_count + no_change_count} layer2 subinterfaces")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+    except Exception as e:
+        typer.echo(f"Error loading layer2 subinterfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("layer2-subinterface", help="Create or update a layer2 subinterface.")
+def set_layer2_subinterface(
+    name: str = typer.Argument(..., help="Name of the layer2 subinterface"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    vlan_tag: str = typer.Option(..., "--vlan-tag", help="VLAN tag (1-4096)"),
+    parent_interface: str = typer.Option(None, "--parent-interface", help="Parent interface name"),
+    comment: str = typer.Option(None, "--comment", help="Interface description/comment"),
+) -> None:
+    """Create or update a layer2 subinterface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface_data: dict[str, Any] = {"name": name, "vlan_tag": vlan_tag, location_type: location_value}
+        if parent_interface:
+            iface_data["parent_interface"] = parent_interface
+        if comment:
+            iface_data["comment"] = comment
+        validated_iface = Layer2Subinterface(**iface_data)
+        sdk_data = validated_iface.to_sdk_model()
+        result = scm_client.create_layer2_subinterface(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created layer2 subinterface: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated layer2 subinterface: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for layer2 subinterface: {name} in {location_value}")
+    except Exception as e:
+        typer.echo(f"Error creating/updating layer2 subinterface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("layer2-subinterface", help="Show layer2 subinterface details.")
+def show_layer2_subinterface(
+    name: str = typer.Option(None, "--name", help="Name of specific layer2 subinterface to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show layer2 subinterface details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            iface = scm_client.get_layer2_subinterface(name=name, folder=folder, snippet=snippet, device=device)
+            if not iface:
+                typer.echo(f"Layer2 subinterface '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nLayer2 Subinterface: {iface['name']}")
+            typer.echo("=" * 60)
+            location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if iface.get("vlan_tag"):
+                typer.echo(f"VLAN Tag: {iface['vlan_tag']}")
+            if iface.get("parent_interface"):
+                typer.echo(f"Parent Interface: {iface['parent_interface']}")
+            if iface.get("comment"):
+                typer.echo(f"Comment: {iface['comment']}")
+            if iface.get("id"):
+                typer.echo(f"\nID: {iface['id']}")
+            return iface
+        else:
+            interfaces = scm_client.list_layer2_subinterfaces(folder=folder, snippet=snippet, device=device)
+            if not interfaces:
+                typer.echo("No layer2 subinterfaces found")
+                return
+            typer.echo("\nLayer2 Subinterfaces:")
+            typer.echo("-" * 80)
+            for iface in interfaces:
+                location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+                typer.echo(f"Name: {iface.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                if iface.get("vlan_tag"):
+                    typer.echo(f"  VLAN Tag: {iface['vlan_tag']}")
+                if iface.get("parent_interface"):
+                    typer.echo(f"  Parent: {iface['parent_interface']}")
+                if iface.get("id"):
+                    typer.echo(f"  ID: {iface['id']}")
+                typer.echo("-" * 80)
+            return interfaces
+    except Exception as e:
+        typer.echo(f"Error showing layer2 subinterface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# LAYER3 SUBINTERFACE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("layer3-subinterface", help="Export layer3 subinterfaces to a YAML file.")
+def backup_layer3_subinterface(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export layer3 subinterfaces from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving layer3 subinterfaces from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        interfaces = scm_client.list_layer3_subinterfaces(**kwargs)
+        if not interfaces:
+            typer.echo(f"No layer3 subinterfaces found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"layer3_subinterfaces": interfaces}
+        filename = Path(file or get_default_backup_filename("layer3-subinterface", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(interfaces)} layer3 subinterfaces to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up layer3 subinterfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("layer3-subinterface", help="Delete a layer3 subinterface.")
+def delete_layer3_subinterface(
+    name: str = typer.Argument(..., help="Name of the layer3 subinterface to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a layer3 subinterface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface = scm_client.get_layer3_subinterface(name=name, folder=folder, snippet=snippet, device=device)
+        if not iface:
+            typer.echo(f"Layer3 subinterface '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete layer3 subinterface '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_layer3_subinterface(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted layer3 subinterface: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting layer3 subinterface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("layer3-subinterface", help="Load layer3 subinterfaces from a YAML file.")
+def load_layer3_subinterface(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+    dry_run: bool = DRY_RUN_OPTION,
+) -> None:
+    """Load layer3 subinterfaces from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "layer3_subinterfaces" not in data:
+            typer.echo("No layer3 subinterfaces found in file", err=True)
+            raise typer.Exit(code=1)
+        interfaces = data["layer3_subinterfaces"]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(interfaces))
+            return None
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+        for iface_data in interfaces:
+            try:
+                if folder:
+                    iface_data["folder"] = folder
+                    iface_data.pop("snippet", None)
+                    iface_data.pop("device", None)
+                elif snippet:
+                    iface_data["snippet"] = snippet
+                    iface_data.pop("folder", None)
+                    iface_data.pop("device", None)
+                elif device:
+                    iface_data["device"] = device
+                    iface_data.pop("folder", None)
+                    iface_data.pop("snippet", None)
+                validated_iface = Layer3Subinterface(**iface_data)
+                sdk_data = validated_iface.to_sdk_model()
+                result = scm_client.create_layer3_subinterface(sdk_data)
+                action = result.pop("__action__", "created")
+                container = validated_iface.folder or validated_iface.snippet or validated_iface.device
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created layer3 subinterface: {validated_iface.name} in {container}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated layer3 subinterface: {validated_iface.name} in {container}")
+                else:
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for layer3 subinterface: {validated_iface.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing layer3 subinterface: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count + updated_count + no_change_count} layer3 subinterfaces")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+    except Exception as e:
+        typer.echo(f"Error loading layer3 subinterfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("layer3-subinterface", help="Create or update a layer3 subinterface.")
+def set_layer3_subinterface(
+    name: str = typer.Argument(..., help="Name of the layer3 subinterface"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    tag: int = typer.Option(None, "--tag", help="VLAN tag (1-4096)"),
+    parent_interface: str = typer.Option(None, "--parent-interface", help="Parent interface name"),
+    comment: str = typer.Option(None, "--comment", help="Interface description/comment"),
+    mtu: int = typer.Option(None, "--mtu", help="MTU (576-9216)"),
+    ip_json: str = typer.Option(None, "--ip-json", help='Static IPs as JSON (e.g. \'[{"name": "10.0.0.1/24"}]\')'),
+    dhcp_client_json: str = typer.Option(None, "--dhcp-client-json", help="DHCP client config as JSON"),
+) -> None:
+    """Create or update a layer3 subinterface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface_data: dict[str, Any] = {"name": name, location_type: location_value}
+        if tag is not None:
+            iface_data["tag"] = tag
+        if parent_interface:
+            iface_data["parent_interface"] = parent_interface
+        if comment:
+            iface_data["comment"] = comment
+        if mtu is not None:
+            iface_data["mtu"] = mtu
+        if ip_json:
+            iface_data["ip"] = json.loads(ip_json)
+        if dhcp_client_json:
+            iface_data["dhcp_client"] = json.loads(dhcp_client_json)
+        validated_iface = Layer3Subinterface(**iface_data)
+        sdk_data = validated_iface.to_sdk_model()
+        result = scm_client.create_layer3_subinterface(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created layer3 subinterface: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated layer3 subinterface: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for layer3 subinterface: {name} in {location_value}")
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating layer3 subinterface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("layer3-subinterface", help="Show layer3 subinterface details.")
+def show_layer3_subinterface(
+    name: str = typer.Option(None, "--name", help="Name of specific layer3 subinterface to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show layer3 subinterface details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            iface = scm_client.get_layer3_subinterface(name=name, folder=folder, snippet=snippet, device=device)
+            if not iface:
+                typer.echo(f"Layer3 subinterface '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nLayer3 Subinterface: {iface['name']}")
+            typer.echo("=" * 60)
+            location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if iface.get("tag"):
+                typer.echo(f"VLAN Tag: {iface['tag']}")
+            if iface.get("mtu"):
+                typer.echo(f"MTU: {iface['mtu']}")
+            if iface.get("ip"):
+                for ip_entry in iface["ip"]:
+                    typer.echo(f"IP: {ip_entry.get('name', 'N/A')}")
+            if iface.get("dhcp_client"):
+                typer.echo("DHCP Client: Enabled")
+            if iface.get("comment"):
+                typer.echo(f"Comment: {iface['comment']}")
+            if iface.get("id"):
+                typer.echo(f"\nID: {iface['id']}")
+            return iface
+        else:
+            interfaces = scm_client.list_layer3_subinterfaces(folder=folder, snippet=snippet, device=device)
+            if not interfaces:
+                typer.echo("No layer3 subinterfaces found")
+                return
+            typer.echo("\nLayer3 Subinterfaces:")
+            typer.echo("-" * 80)
+            for iface in interfaces:
+                location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+                typer.echo(f"Name: {iface.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                if iface.get("tag"):
+                    typer.echo(f"  VLAN Tag: {iface['tag']}")
+                if iface.get("mtu"):
+                    typer.echo(f"  MTU: {iface['mtu']}")
+                if iface.get("id"):
+                    typer.echo(f"  ID: {iface['id']}")
+                typer.echo("-" * 80)
+            return interfaces
+    except Exception as e:
+        typer.echo(f"Error showing layer3 subinterface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# LOOPBACK INTERFACE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("loopback-interface", help="Export loopback interfaces to a YAML file.")
+def backup_loopback_interface(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export loopback interfaces from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving loopback interfaces from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        interfaces = scm_client.list_loopback_interfaces(**kwargs)
+        if not interfaces:
+            typer.echo(f"No loopback interfaces found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"loopback_interfaces": interfaces}
+        filename = Path(file or get_default_backup_filename("loopback-interface", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(interfaces)} loopback interfaces to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up loopback interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("loopback-interface", help="Delete a loopback interface.")
+def delete_loopback_interface(
+    name: str = typer.Argument(..., help="Name of the loopback interface to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a loopback interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface = scm_client.get_loopback_interface(name=name, folder=folder, snippet=snippet, device=device)
+        if not iface:
+            typer.echo(f"Loopback interface '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete loopback interface '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_loopback_interface(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted loopback interface: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting loopback interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("loopback-interface", help="Load loopback interfaces from a YAML file.")
+def load_loopback_interface(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+    dry_run: bool = DRY_RUN_OPTION,
+) -> None:
+    """Load loopback interfaces from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "loopback_interfaces" not in data:
+            typer.echo("No loopback interfaces found in file", err=True)
+            raise typer.Exit(code=1)
+        interfaces = data["loopback_interfaces"]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(interfaces))
+            return None
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+        for iface_data in interfaces:
+            try:
+                if folder:
+                    iface_data["folder"] = folder
+                    iface_data.pop("snippet", None)
+                    iface_data.pop("device", None)
+                elif snippet:
+                    iface_data["snippet"] = snippet
+                    iface_data.pop("folder", None)
+                    iface_data.pop("device", None)
+                elif device:
+                    iface_data["device"] = device
+                    iface_data.pop("folder", None)
+                    iface_data.pop("snippet", None)
+                validated_iface = LoopbackInterface(**iface_data)
+                sdk_data = validated_iface.to_sdk_model()
+                result = scm_client.create_loopback_interface(sdk_data)
+                action = result.pop("__action__", "created")
+                container = validated_iface.folder or validated_iface.snippet or validated_iface.device
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created loopback interface: {validated_iface.name} in {container}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated loopback interface: {validated_iface.name} in {container}")
+                else:
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for loopback interface: {validated_iface.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing loopback interface: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count + updated_count + no_change_count} loopback interfaces")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+    except Exception as e:
+        typer.echo(f"Error loading loopback interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("loopback-interface", help="Create or update a loopback interface.")
+def set_loopback_interface(
+    name: str = typer.Argument(..., help="Name of the loopback interface"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    comment: str = typer.Option(None, "--comment", help="Interface description/comment"),
+    default_value: str = typer.Option(None, "--default-value", help="Default interface (e.g. loopback.1)"),
+    mtu: int = typer.Option(None, "--mtu", help="MTU (576-9216)"),
+    ip_json: str = typer.Option(None, "--ip-json", help='Static IPs as JSON (e.g. \'[{"name": "10.0.0.1/32"}]\')'),
+    ipv6_json: str = typer.Option(None, "--ipv6-json", help="IPv6 config as JSON"),
+) -> None:
+    """Create or update a loopback interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface_data: dict[str, Any] = {"name": name, location_type: location_value}
+        if comment:
+            iface_data["comment"] = comment
+        if default_value:
+            iface_data["default_value"] = default_value
+        if mtu is not None:
+            iface_data["mtu"] = mtu
+        if ip_json:
+            iface_data["ip"] = json.loads(ip_json)
+        if ipv6_json:
+            iface_data["ipv6"] = json.loads(ipv6_json)
+        validated_iface = LoopbackInterface(**iface_data)
+        sdk_data = validated_iface.to_sdk_model()
+        result = scm_client.create_loopback_interface(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created loopback interface: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated loopback interface: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for loopback interface: {name} in {location_value}")
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating loopback interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("loopback-interface", help="Show loopback interface details.")
+def show_loopback_interface(
+    name: str = typer.Option(None, "--name", help="Name of specific loopback interface to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show loopback interface details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            iface = scm_client.get_loopback_interface(name=name, folder=folder, snippet=snippet, device=device)
+            if not iface:
+                typer.echo(f"Loopback interface '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nLoopback Interface: {iface['name']}")
+            typer.echo("=" * 60)
+            location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if iface.get("comment"):
+                typer.echo(f"Comment: {iface['comment']}")
+            if iface.get("mtu"):
+                typer.echo(f"MTU: {iface['mtu']}")
+            if iface.get("ip"):
+                for ip_entry in iface["ip"]:
+                    typer.echo(f"IP: {ip_entry.get('name', 'N/A')}")
+            if iface.get("id"):
+                typer.echo(f"\nID: {iface['id']}")
+            return iface
+        else:
+            interfaces = scm_client.list_loopback_interfaces(folder=folder, snippet=snippet, device=device)
+            if not interfaces:
+                typer.echo("No loopback interfaces found")
+                return
+            typer.echo("\nLoopback Interfaces:")
+            typer.echo("-" * 80)
+            for iface in interfaces:
+                location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+                typer.echo(f"Name: {iface.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                if iface.get("comment"):
+                    typer.echo(f"  Comment: {iface['comment']}")
+                if iface.get("ip"):
+                    typer.echo(f"  IPs: {len(iface['ip'])}")
+                if iface.get("id"):
+                    typer.echo(f"  ID: {iface['id']}")
+                typer.echo("-" * 80)
+            return interfaces
+    except Exception as e:
+        typer.echo(f"Error showing loopback interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# TUNNEL INTERFACE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("tunnel-interface", help="Export tunnel interfaces to a YAML file.")
+def backup_tunnel_interface(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export tunnel interfaces from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving tunnel interfaces from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        interfaces = scm_client.list_tunnel_interfaces(**kwargs)
+        if not interfaces:
+            typer.echo(f"No tunnel interfaces found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"tunnel_interfaces": interfaces}
+        filename = Path(file or get_default_backup_filename("tunnel-interface", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(interfaces)} tunnel interfaces to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up tunnel interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("tunnel-interface", help="Delete a tunnel interface.")
+def delete_tunnel_interface(
+    name: str = typer.Argument(..., help="Name of the tunnel interface to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a tunnel interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface = scm_client.get_tunnel_interface(name=name, folder=folder, snippet=snippet, device=device)
+        if not iface:
+            typer.echo(f"Tunnel interface '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete tunnel interface '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_tunnel_interface(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted tunnel interface: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting tunnel interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("tunnel-interface", help="Load tunnel interfaces from a YAML file.")
+def load_tunnel_interface(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+    dry_run: bool = DRY_RUN_OPTION,
+) -> None:
+    """Load tunnel interfaces from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "tunnel_interfaces" not in data:
+            typer.echo("No tunnel interfaces found in file", err=True)
+            raise typer.Exit(code=1)
+        interfaces = data["tunnel_interfaces"]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(interfaces))
+            return None
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+        for iface_data in interfaces:
+            try:
+                if folder:
+                    iface_data["folder"] = folder
+                    iface_data.pop("snippet", None)
+                    iface_data.pop("device", None)
+                elif snippet:
+                    iface_data["snippet"] = snippet
+                    iface_data.pop("folder", None)
+                    iface_data.pop("device", None)
+                elif device:
+                    iface_data["device"] = device
+                    iface_data.pop("folder", None)
+                    iface_data.pop("snippet", None)
+                validated_iface = TunnelInterface(**iface_data)
+                sdk_data = validated_iface.to_sdk_model()
+                result = scm_client.create_tunnel_interface(sdk_data)
+                action = result.pop("__action__", "created")
+                container = validated_iface.folder or validated_iface.snippet or validated_iface.device
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created tunnel interface: {validated_iface.name} in {container}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated tunnel interface: {validated_iface.name} in {container}")
+                else:
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for tunnel interface: {validated_iface.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing tunnel interface: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count + updated_count + no_change_count} tunnel interfaces")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+    except Exception as e:
+        typer.echo(f"Error loading tunnel interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("tunnel-interface", help="Create or update a tunnel interface.")
+def set_tunnel_interface(
+    name: str = typer.Argument(..., help="Name of the tunnel interface"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    comment: str = typer.Option(None, "--comment", help="Interface description/comment"),
+    default_value: str = typer.Option(None, "--default-value", help="Default interface (e.g. tunnel.1)"),
+    mtu: int = typer.Option(None, "--mtu", help="MTU (576-9216)"),
+    ip_json: str = typer.Option(None, "--ip-json", help='Static IPs as JSON (e.g. \'[{"name": "10.0.0.1/30"}]\')'),
+) -> None:
+    """Create or update a tunnel interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface_data: dict[str, Any] = {"name": name, location_type: location_value}
+        if comment:
+            iface_data["comment"] = comment
+        if default_value:
+            iface_data["default_value"] = default_value
+        if mtu is not None:
+            iface_data["mtu"] = mtu
+        if ip_json:
+            iface_data["ip"] = json.loads(ip_json)
+        validated_iface = TunnelInterface(**iface_data)
+        sdk_data = validated_iface.to_sdk_model()
+        result = scm_client.create_tunnel_interface(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created tunnel interface: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated tunnel interface: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for tunnel interface: {name} in {location_value}")
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating tunnel interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("tunnel-interface", help="Show tunnel interface details.")
+def show_tunnel_interface(
+    name: str = typer.Option(None, "--name", help="Name of specific tunnel interface to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show tunnel interface details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            iface = scm_client.get_tunnel_interface(name=name, folder=folder, snippet=snippet, device=device)
+            if not iface:
+                typer.echo(f"Tunnel interface '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nTunnel Interface: {iface['name']}")
+            typer.echo("=" * 60)
+            location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if iface.get("comment"):
+                typer.echo(f"Comment: {iface['comment']}")
+            if iface.get("mtu"):
+                typer.echo(f"MTU: {iface['mtu']}")
+            if iface.get("ip"):
+                for ip_entry in iface["ip"]:
+                    typer.echo(f"IP: {ip_entry.get('name', 'N/A')}")
+            if iface.get("id"):
+                typer.echo(f"\nID: {iface['id']}")
+            return iface
+        else:
+            interfaces = scm_client.list_tunnel_interfaces(folder=folder, snippet=snippet, device=device)
+            if not interfaces:
+                typer.echo("No tunnel interfaces found")
+                return
+            typer.echo("\nTunnel Interfaces:")
+            typer.echo("-" * 80)
+            for iface in interfaces:
+                location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+                typer.echo(f"Name: {iface.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                if iface.get("comment"):
+                    typer.echo(f"  Comment: {iface['comment']}")
+                if iface.get("mtu"):
+                    typer.echo(f"  MTU: {iface['mtu']}")
+                if iface.get("id"):
+                    typer.echo(f"  ID: {iface['id']}")
+                typer.echo("-" * 80)
+            return interfaces
+    except Exception as e:
+        typer.echo(f"Error showing tunnel interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# ========================================================================================================================================================================================
+# VLAN INTERFACE COMMANDS
+# ========================================================================================================================================================================================
+
+
+@backup_app.command("vlan-interface", help="Export VLAN interfaces to a YAML file.")
+def backup_vlan_interface(
+    folder: str = BACKUP_FOLDER_OPTION,
+    snippet: str = BACKUP_SNIPPET_OPTION,
+    device: str = BACKUP_DEVICE_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+) -> None:
+    """Export VLAN interfaces from a specified location to a YAML file."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        typer.echo(f"Retrieving VLAN interfaces from {location_type} '{location_value}'...")
+        kwargs = {location_type: location_value}
+        interfaces = scm_client.list_vlan_interfaces(**kwargs)
+        if not interfaces:
+            typer.echo(f"No VLAN interfaces found in {location_type} '{location_value}'", err=True)
+            return
+        export_data = {"vlan_interfaces": interfaces}
+        filename = Path(file or get_default_backup_filename("vlan-interface", location_type, location_value))
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        with filename.open("w") as f:
+            yaml.dump(export_data, f, default_flow_style=False, sort_keys=False)
+        typer.echo(f"Successfully backed up {len(interfaces)} VLAN interfaces to {filename}")
+    except Exception as e:
+        typer.echo(f"Error backing up VLAN interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("vlan-interface", help="Delete a VLAN interface.")
+def delete_vlan_interface(
+    name: str = typer.Argument(..., help="Name of the VLAN interface to delete"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+) -> None:
+    """Delete a VLAN interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface = scm_client.get_vlan_interface(name=name, folder=folder, snippet=snippet, device=device)
+        if not iface:
+            typer.echo(f"VLAN interface '{name}' not found", err=True)
+            raise typer.Exit(code=1)
+        if not force:
+            confirm = typer.confirm(f"Are you sure you want to delete VLAN interface '{name}'?")
+            if not confirm:
+                typer.echo("Deletion cancelled")
+                raise typer.Exit(code=0)
+        scm_client.delete_vlan_interface(name=name, folder=folder, snippet=snippet, device=device)
+        typer.echo(f"Deleted VLAN interface: {name} from {location_value}")
+    except Exception as e:
+        typer.echo(f"Error deleting VLAN interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("vlan-interface", help="Load VLAN interfaces from a YAML file.")
+def load_vlan_interface(
+    file: str = typer.Option(..., "--file", "-f", help="Input YAML file path"),
+    folder: str = typer.Option(None, "--folder", help="Override folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Override snippet location"),
+    device: str = typer.Option(None, "--device", help="Override device location"),
+    dry_run: bool = DRY_RUN_OPTION,
+) -> None:
+    """Load VLAN interfaces from a YAML file."""
+    try:
+        if not Path(file).exists():
+            typer.echo(f"File not found: {file}", err=True)
+            raise typer.Exit(code=1)
+        with Path(file).open() as f:
+            data = yaml.safe_load(f)
+        if not data or "vlan_interfaces" not in data:
+            typer.echo("No VLAN interfaces found in file", err=True)
+            raise typer.Exit(code=1)
+        interfaces = data["vlan_interfaces"]
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            if folder or snippet or device:
+                override_type = "folder" if folder else ("snippet" if snippet else "device")
+                override_value = folder or snippet or device
+                typer.echo(f"Container override: {override_type} = '{override_value}'")
+            typer.echo(yaml.dump(interfaces))
+            return None
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+        for iface_data in interfaces:
+            try:
+                if folder:
+                    iface_data["folder"] = folder
+                    iface_data.pop("snippet", None)
+                    iface_data.pop("device", None)
+                elif snippet:
+                    iface_data["snippet"] = snippet
+                    iface_data.pop("folder", None)
+                    iface_data.pop("device", None)
+                elif device:
+                    iface_data["device"] = device
+                    iface_data.pop("folder", None)
+                    iface_data.pop("snippet", None)
+                validated_iface = VlanInterface(**iface_data)
+                sdk_data = validated_iface.to_sdk_model()
+                result = scm_client.create_vlan_interface(sdk_data)
+                action = result.pop("__action__", "created")
+                container = validated_iface.folder or validated_iface.snippet or validated_iface.device
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created VLAN interface: {validated_iface.name} in {container}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated VLAN interface: {validated_iface.name} in {container}")
+                else:
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for VLAN interface: {validated_iface.name} in {container}")
+            except Exception as e:
+                typer.echo(f"Error processing VLAN interface: {str(e)}", err=True)
+                continue
+        typer.echo(f"\nSummary: Processed {created_count + updated_count + no_change_count} VLAN interfaces")
+        if created_count > 0:
+            typer.echo(f"  - Created: {created_count}")
+        if updated_count > 0:
+            typer.echo(f"  - Updated: {updated_count}")
+        if no_change_count > 0:
+            typer.echo(f"  - No change: {no_change_count}")
+    except Exception as e:
+        typer.echo(f"Error loading VLAN interfaces: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("vlan-interface", help="Create or update a VLAN interface.")
+def set_vlan_interface(
+    name: str = typer.Argument(..., help="Name of the VLAN interface"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+    comment: str = typer.Option(None, "--comment", help="Interface description/comment"),
+    default_value: str = typer.Option(None, "--default-value", help="Default interface (e.g. vlan.100)"),
+    vlan_tag: str = typer.Option(None, "--vlan-tag", help="VLAN tag (1-4096)"),
+    mtu: int = typer.Option(None, "--mtu", help="MTU (576-9216)"),
+    ip_json: str = typer.Option(None, "--ip-json", help='Static IPs as JSON (e.g. \'[{"name": "10.0.0.1/24"}]\')'),
+    dhcp_client_json: str = typer.Option(None, "--dhcp-client-json", help="DHCP client config as JSON"),
+) -> None:
+    """Create or update a VLAN interface."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        iface_data: dict[str, Any] = {"name": name, location_type: location_value}
+        if comment:
+            iface_data["comment"] = comment
+        if default_value:
+            iface_data["default_value"] = default_value
+        if vlan_tag:
+            iface_data["vlan_tag"] = vlan_tag
+        if mtu is not None:
+            iface_data["mtu"] = mtu
+        if ip_json:
+            iface_data["ip"] = json.loads(ip_json)
+        if dhcp_client_json:
+            iface_data["dhcp_client"] = json.loads(dhcp_client_json)
+        validated_iface = VlanInterface(**iface_data)
+        sdk_data = validated_iface.to_sdk_model()
+        result = scm_client.create_vlan_interface(sdk_data)
+        action = result.pop("__action__", "created")
+        if action == "created":
+            typer.echo(f"Created VLAN interface: {name} in {location_value}")
+        elif action == "updated":
+            typer.echo(f"Updated VLAN interface: {name} in {location_value}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for VLAN interface: {name} in {location_value}")
+    except json.JSONDecodeError as e:
+        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating VLAN interface: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("vlan-interface", help="Show VLAN interface details.")
+def show_vlan_interface(
+    name: str = typer.Option(None, "--name", help="Name of specific VLAN interface to show"),
+    folder: str = typer.Option(None, "--folder", help="Folder location"),
+    snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
+    device: str = typer.Option(None, "--device", help="Device location"),
+) -> None:
+    """Show VLAN interface details."""
+    try:
+        location_type, location_value = validate_location_params(folder, snippet, device)
+        if name:
+            iface = scm_client.get_vlan_interface(name=name, folder=folder, snippet=snippet, device=device)
+            if not iface:
+                typer.echo(f"VLAN interface '{name}' not found", err=True)
+                raise typer.Exit(code=1)
+            typer.echo(f"\nVLAN Interface: {iface['name']}")
+            typer.echo("=" * 60)
+            location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+            typer.echo(f"Location: {location}")
+            if iface.get("comment"):
+                typer.echo(f"Comment: {iface['comment']}")
+            if iface.get("vlan_tag"):
+                typer.echo(f"VLAN Tag: {iface['vlan_tag']}")
+            if iface.get("mtu"):
+                typer.echo(f"MTU: {iface['mtu']}")
+            if iface.get("ip"):
+                for ip_entry in iface["ip"]:
+                    typer.echo(f"IP: {ip_entry.get('name', 'N/A')}")
+            if iface.get("dhcp_client"):
+                typer.echo("DHCP Client: Enabled")
+            if iface.get("id"):
+                typer.echo(f"\nID: {iface['id']}")
+            return iface
+        else:
+            interfaces = scm_client.list_vlan_interfaces(folder=folder, snippet=snippet, device=device)
+            if not interfaces:
+                typer.echo("No VLAN interfaces found")
+                return
+            typer.echo("\nVLAN Interfaces:")
+            typer.echo("-" * 80)
+            for iface in interfaces:
+                location = iface.get("folder") or iface.get("snippet") or iface.get("device", "N/A")
+                typer.echo(f"Name: {iface.get('name', 'N/A')}")
+                typer.echo(f"  Location: {location}")
+                if iface.get("vlan_tag"):
+                    typer.echo(f"  VLAN Tag: {iface['vlan_tag']}")
+                if iface.get("comment"):
+                    typer.echo(f"  Comment: {iface['comment']}")
+                if iface.get("id"):
+                    typer.echo(f"  ID: {iface['id']}")
+                typer.echo("-" * 80)
+            return interfaces
+    except Exception as e:
+        typer.echo(f"Error showing VLAN interface: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -11320,6 +11320,955 @@ class SCMClient:
         # TODO: Implement actual API call when insights API is available
         raise NotImplementedError("Insights API not yet available in pan-scm-sdk")
 
+    # ------------------------------------------------------------------------------------- DHCP Interfaces -----------------------------------------------------------------------------------
+
+    def create_dhcp_interface(self, iface_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update a DHCP interface using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in iface_data and iface_data[field] is not None:
+                container_field = field
+                container_value = iface_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            result = iface_data.copy()
+            result["id"] = f"dhcp-{iface_data['name']}"
+            result["__action__"] = "created"
+            return result
+        existing_iface = None
+        try:
+            existing_iface = self.client.dhcp_interface.fetch(name=iface_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing DHCP interface '{iface_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"DHCP interface '{iface_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching DHCP interface '{iface_data['name']}': {str(e)}")
+        if existing_iface:
+            needs_update = False
+            update_fields = []
+            for key in ["server", "relay"]:
+                if key in iface_data:
+                    existing_val = getattr(existing_iface, key, None)
+                    existing_dict = json.loads(existing_val.model_dump_json(exclude_unset=True)) if existing_val else None
+                    if iface_data[key] != existing_dict:
+                        needs_update = True
+                        update_fields.append(key)
+            if needs_update:
+                self.logger.info(f"Updating DHCP interface fields: {', '.join(update_fields)}")
+                try:
+                    update_data = iface_data.copy()
+                    update_data["id"] = str(existing_iface.id)
+                    result = self.client.dhcp_interface.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"DHCP interface '{iface_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_iface.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.dhcp_interface.create(iface_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"DHCP interface '{iface_data['name']}'", create_error)
+
+    def delete_dhcp_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete a DHCP interface."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete DHCP interface: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            iface = self.client.dhcp_interface.fetch(name=name, **container_kwargs)
+            self.client.dhcp_interface.delete(str(iface.id))
+            self.logger.info(f"Deleted DHCP interface: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"DHCP interface '{name}'", e)
+
+    def get_dhcp_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> dict[str, Any] | None:
+        """Get a specific DHCP interface."""
+        if not self.client:
+            return {
+                "id": "dhcp-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "server": {"mode": "auto", "ip_pool": ["10.0.0.10-10.0.0.100"]},
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.dhcp_interface.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"DHCP interface '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"DHCP interface '{name}'", e)
+
+    def list_dhcp_interfaces(self, folder: str | None = None, snippet: str | None = None, device: str | None = None, exact_match: bool = False) -> list[dict[str, Any]]:
+        """List DHCP interfaces in a container."""
+        if not self.client:
+            return [
+                {"id": "dhcp-mock1", "folder": folder or "ngfw-shared", "name": "ethernet1/1", "server": {"mode": "auto", "ip_pool": ["10.0.0.10-10.0.0.100"]}},
+                {"id": "dhcp-mock2", "folder": folder or "ngfw-shared", "name": "ethernet1/2", "relay": {"ip": {"enabled": True, "server": ["10.0.0.1"]}}},
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.dhcp_interface.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "DHCP interfaces", e)
+
+    # ----------------------------------------------------------------------------------- Ethernet Interfaces ---------------------------------------------------------------------------------
+
+    def create_ethernet_interface(self, iface_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update an ethernet interface using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in iface_data and iface_data[field] is not None:
+                container_field = field
+                container_value = iface_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            result = iface_data.copy()
+            result["id"] = f"eth-{iface_data['name']}"
+            result["__action__"] = "created"
+            return result
+        existing_iface = None
+        try:
+            existing_iface = self.client.ethernet_interface.fetch(name=iface_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing ethernet interface '{iface_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"Ethernet interface '{iface_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching ethernet interface '{iface_data['name']}': {str(e)}")
+        if existing_iface:
+            needs_update = False
+            update_fields = []
+            for key in ["comment", "link_speed", "link_duplex", "link_state"]:
+                if key in iface_data:
+                    if iface_data[key] != getattr(existing_iface, key, None):
+                        needs_update = True
+                        update_fields.append(key)
+            for key in ["layer2", "layer3", "tap"]:
+                if key in iface_data:
+                    existing_val = getattr(existing_iface, key, None)
+                    existing_dict = json.loads(existing_val.model_dump_json(exclude_unset=True)) if existing_val else None
+                    if iface_data[key] != existing_dict:
+                        needs_update = True
+                        update_fields.append(key)
+            if needs_update:
+                self.logger.info(f"Updating ethernet interface fields: {', '.join(update_fields)}")
+                try:
+                    update_data = iface_data.copy()
+                    update_data["id"] = str(existing_iface.id)
+                    result = self.client.ethernet_interface.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"ethernet interface '{iface_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_iface.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.ethernet_interface.create(iface_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"ethernet interface '{iface_data['name']}'", create_error)
+
+    def delete_ethernet_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete an ethernet interface."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete ethernet interface: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            iface = self.client.ethernet_interface.fetch(name=name, **container_kwargs)
+            self.client.ethernet_interface.delete(str(iface.id))
+            self.logger.info(f"Deleted ethernet interface: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"ethernet interface '{name}'", e)
+
+    def get_ethernet_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> dict[str, Any] | None:
+        """Get a specific ethernet interface."""
+        if not self.client:
+            return {
+                "id": "eth-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "comment": "Mock ethernet interface",
+                "layer3": {"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]},
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.ethernet_interface.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"Ethernet interface '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"ethernet interface '{name}'", e)
+
+    def list_ethernet_interfaces(self, folder: str | None = None, snippet: str | None = None, device: str | None = None, exact_match: bool = False) -> list[dict[str, Any]]:
+        """List ethernet interfaces in a container."""
+        if not self.client:
+            return [
+                {"id": "eth-mock1", "folder": folder or "ngfw-shared", "name": "$eth1", "comment": "Mock eth 1", "layer3": {"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]}},
+                {"id": "eth-mock2", "folder": folder or "ngfw-shared", "name": "$eth2", "comment": "Mock eth 2", "layer2": {"vlan_tag": "100"}},
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.ethernet_interface.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "ethernet interfaces", e)
+
+    # ---------------------------------------------------------------------------------- Layer2 Subinterfaces ---------------------------------------------------------------------------------
+
+    def create_layer2_subinterface(self, iface_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update a layer2 subinterface using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in iface_data and iface_data[field] is not None:
+                container_field = field
+                container_value = iface_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            result = iface_data.copy()
+            result["id"] = f"l2sub-{iface_data['name']}"
+            result["__action__"] = "created"
+            return result
+        existing_iface = None
+        try:
+            existing_iface = self.client.layer2_subinterface.fetch(name=iface_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing layer2 subinterface '{iface_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"Layer2 subinterface '{iface_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching layer2 subinterface '{iface_data['name']}': {str(e)}")
+        if existing_iface:
+            needs_update = False
+            update_fields = []
+            for key in ["vlan_tag", "comment", "parent_interface"]:
+                if key in iface_data:
+                    if iface_data[key] != getattr(existing_iface, key, None):
+                        needs_update = True
+                        update_fields.append(key)
+            if needs_update:
+                self.logger.info(f"Updating layer2 subinterface fields: {', '.join(update_fields)}")
+                try:
+                    update_data = iface_data.copy()
+                    update_data["id"] = str(existing_iface.id)
+                    result = self.client.layer2_subinterface.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"layer2 subinterface '{iface_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_iface.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.layer2_subinterface.create(iface_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"layer2 subinterface '{iface_data['name']}'", create_error)
+
+    def delete_layer2_subinterface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete a layer2 subinterface."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete layer2 subinterface: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            iface = self.client.layer2_subinterface.fetch(name=name, **container_kwargs)
+            self.client.layer2_subinterface.delete(str(iface.id))
+            self.logger.info(f"Deleted layer2 subinterface: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"layer2 subinterface '{name}'", e)
+
+    def get_layer2_subinterface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> dict[str, Any] | None:
+        """Get a specific layer2 subinterface."""
+        if not self.client:
+            return {
+                "id": "l2sub-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "vlan_tag": "100",
+                "parent_interface": "ethernet1/1",
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.layer2_subinterface.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"Layer2 subinterface '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"layer2 subinterface '{name}'", e)
+
+    def list_layer2_subinterfaces(self, folder: str | None = None, snippet: str | None = None, device: str | None = None, exact_match: bool = False) -> list[dict[str, Any]]:
+        """List layer2 subinterfaces in a container."""
+        if not self.client:
+            return [
+                {"id": "l2sub-mock1", "folder": folder or "ngfw-shared", "name": "ethernet1/1.100", "vlan_tag": "100", "parent_interface": "ethernet1/1"},
+                {"id": "l2sub-mock2", "folder": folder or "ngfw-shared", "name": "ethernet1/1.200", "vlan_tag": "200", "parent_interface": "ethernet1/1"},
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.layer2_subinterface.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "layer2 subinterfaces", e)
+
+    # ---------------------------------------------------------------------------------- Layer3 Subinterfaces ---------------------------------------------------------------------------------
+
+    def create_layer3_subinterface(self, iface_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update a layer3 subinterface using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in iface_data and iface_data[field] is not None:
+                container_field = field
+                container_value = iface_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            result = iface_data.copy()
+            result["id"] = f"l3sub-{iface_data['name']}"
+            result["__action__"] = "created"
+            return result
+        existing_iface = None
+        try:
+            existing_iface = self.client.layer3_subinterface.fetch(name=iface_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing layer3 subinterface '{iface_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"Layer3 subinterface '{iface_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching layer3 subinterface '{iface_data['name']}': {str(e)}")
+        if existing_iface:
+            needs_update = False
+            update_fields = []
+            for key in ["tag", "comment", "parent_interface", "mtu", "interface_management_profile"]:
+                if key in iface_data:
+                    if iface_data[key] != getattr(existing_iface, key, None):
+                        needs_update = True
+                        update_fields.append(key)
+            for key in ["ip", "dhcp_client"]:
+                if key in iface_data:
+                    existing_val = getattr(existing_iface, key, None)
+                    if key == "ip" and existing_val:
+                        existing_dict = [json.loads(e.model_dump_json(exclude_unset=True)) for e in existing_val]
+                    elif existing_val and hasattr(existing_val, "model_dump_json"):
+                        existing_dict = json.loads(existing_val.model_dump_json(exclude_unset=True))
+                    else:
+                        existing_dict = existing_val
+                    if iface_data[key] != existing_dict:
+                        needs_update = True
+                        update_fields.append(key)
+            if needs_update:
+                self.logger.info(f"Updating layer3 subinterface fields: {', '.join(update_fields)}")
+                try:
+                    update_data = iface_data.copy()
+                    update_data["id"] = str(existing_iface.id)
+                    result = self.client.layer3_subinterface.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"layer3 subinterface '{iface_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_iface.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.layer3_subinterface.create(iface_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"layer3 subinterface '{iface_data['name']}'", create_error)
+
+    def delete_layer3_subinterface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete a layer3 subinterface."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete layer3 subinterface: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            iface = self.client.layer3_subinterface.fetch(name=name, **container_kwargs)
+            self.client.layer3_subinterface.delete(str(iface.id))
+            self.logger.info(f"Deleted layer3 subinterface: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"layer3 subinterface '{name}'", e)
+
+    def get_layer3_subinterface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> dict[str, Any] | None:
+        """Get a specific layer3 subinterface."""
+        if not self.client:
+            return {
+                "id": "l3sub-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "tag": 100,
+                "mtu": 1500,
+                "ip": [{"name": "10.0.1.1/24"}],
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.layer3_subinterface.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"Layer3 subinterface '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"layer3 subinterface '{name}'", e)
+
+    def list_layer3_subinterfaces(self, folder: str | None = None, snippet: str | None = None, device: str | None = None, exact_match: bool = False) -> list[dict[str, Any]]:
+        """List layer3 subinterfaces in a container."""
+        if not self.client:
+            return [
+                {"id": "l3sub-mock1", "folder": folder or "ngfw-shared", "name": "ethernet1/1.100", "tag": 100, "mtu": 1500, "ip": [{"name": "10.0.1.1/24"}]},
+                {"id": "l3sub-mock2", "folder": folder or "ngfw-shared", "name": "ethernet1/1.200", "tag": 200, "dhcp_client": {"enable": True}},
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.layer3_subinterface.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "layer3 subinterfaces", e)
+
+    # ------------------------------------------------------------------------------------- Loopback Interfaces -----------------------------------------------------------------------------------
+
+    def create_loopback_interface(self, iface_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update a loopback interface using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in iface_data and iface_data[field] is not None:
+                container_field = field
+                container_value = iface_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            result = iface_data.copy()
+            result["id"] = f"lo-{iface_data['name']}"
+            result["__action__"] = "created"
+            return result
+        existing_iface = None
+        try:
+            existing_iface = self.client.loopback_interface.fetch(name=iface_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing loopback interface '{iface_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"Loopback interface '{iface_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching loopback interface '{iface_data['name']}': {str(e)}")
+        if existing_iface:
+            needs_update = False
+            update_fields = []
+            for key in ["comment", "mtu", "interface_management_profile"]:
+                if key in iface_data:
+                    if iface_data[key] != getattr(existing_iface, key, None):
+                        needs_update = True
+                        update_fields.append(key)
+            for key in ["ip", "ipv6"]:
+                if key in iface_data:
+                    existing_val = getattr(existing_iface, key, None)
+                    if key == "ip" and existing_val:
+                        existing_dict = [json.loads(e.model_dump_json(exclude_unset=True)) for e in existing_val]
+                    elif existing_val and hasattr(existing_val, "model_dump_json"):
+                        existing_dict = json.loads(existing_val.model_dump_json(exclude_unset=True))
+                    else:
+                        existing_dict = existing_val
+                    if iface_data[key] != existing_dict:
+                        needs_update = True
+                        update_fields.append(key)
+            if needs_update:
+                self.logger.info(f"Updating loopback interface fields: {', '.join(update_fields)}")
+                try:
+                    update_data = iface_data.copy()
+                    update_data["id"] = str(existing_iface.id)
+                    result = self.client.loopback_interface.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"loopback interface '{iface_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_iface.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.loopback_interface.create(iface_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"loopback interface '{iface_data['name']}'", create_error)
+
+    def delete_loopback_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete a loopback interface."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete loopback interface: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            iface = self.client.loopback_interface.fetch(name=name, **container_kwargs)
+            self.client.loopback_interface.delete(str(iface.id))
+            self.logger.info(f"Deleted loopback interface: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"loopback interface '{name}'", e)
+
+    def get_loopback_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> dict[str, Any] | None:
+        """Get a specific loopback interface."""
+        if not self.client:
+            return {
+                "id": "lo-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "comment": "Mock loopback interface",
+                "ip": [{"name": "10.0.0.1/32"}],
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.loopback_interface.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"Loopback interface '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"loopback interface '{name}'", e)
+
+    def list_loopback_interfaces(self, folder: str | None = None, snippet: str | None = None, device: str | None = None, exact_match: bool = False) -> list[dict[str, Any]]:
+        """List loopback interfaces in a container."""
+        if not self.client:
+            return [
+                {"id": "lo-mock1", "folder": folder or "ngfw-shared", "name": "$lo1", "comment": "Loopback 1", "ip": [{"name": "10.0.0.1/32"}]},
+                {"id": "lo-mock2", "folder": folder or "ngfw-shared", "name": "$lo2", "comment": "Loopback 2", "ip": [{"name": "10.0.0.2/32"}]},
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.loopback_interface.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "loopback interfaces", e)
+
+    # ------------------------------------------------------------------------------------- Tunnel Interfaces -----------------------------------------------------------------------------------
+
+    def create_tunnel_interface(self, iface_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update a tunnel interface using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in iface_data and iface_data[field] is not None:
+                container_field = field
+                container_value = iface_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            result = iface_data.copy()
+            result["id"] = f"tun-{iface_data['name']}"
+            result["__action__"] = "created"
+            return result
+        existing_iface = None
+        try:
+            existing_iface = self.client.tunnel_interface.fetch(name=iface_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing tunnel interface '{iface_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"Tunnel interface '{iface_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching tunnel interface '{iface_data['name']}': {str(e)}")
+        if existing_iface:
+            needs_update = False
+            update_fields = []
+            for key in ["comment", "mtu", "interface_management_profile"]:
+                if key in iface_data:
+                    if iface_data[key] != getattr(existing_iface, key, None):
+                        needs_update = True
+                        update_fields.append(key)
+            if "ip" in iface_data:
+                existing_ip = getattr(existing_iface, "ip", None)
+                existing_ip_list = [json.loads(e.model_dump_json(exclude_unset=True)) for e in existing_ip] if existing_ip else None
+                if iface_data["ip"] != existing_ip_list:
+                    needs_update = True
+                    update_fields.append("ip")
+            if needs_update:
+                self.logger.info(f"Updating tunnel interface fields: {', '.join(update_fields)}")
+                try:
+                    update_data = iface_data.copy()
+                    update_data["id"] = str(existing_iface.id)
+                    result = self.client.tunnel_interface.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"tunnel interface '{iface_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_iface.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.tunnel_interface.create(iface_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"tunnel interface '{iface_data['name']}'", create_error)
+
+    def delete_tunnel_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete a tunnel interface."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete tunnel interface: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            iface = self.client.tunnel_interface.fetch(name=name, **container_kwargs)
+            self.client.tunnel_interface.delete(str(iface.id))
+            self.logger.info(f"Deleted tunnel interface: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"tunnel interface '{name}'", e)
+
+    def get_tunnel_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> dict[str, Any] | None:
+        """Get a specific tunnel interface."""
+        if not self.client:
+            return {
+                "id": "tun-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "comment": "Mock tunnel interface",
+                "mtu": 1500,
+                "ip": [{"name": "10.0.0.1/30"}],
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.tunnel_interface.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"Tunnel interface '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"tunnel interface '{name}'", e)
+
+    def list_tunnel_interfaces(self, folder: str | None = None, snippet: str | None = None, device: str | None = None, exact_match: bool = False) -> list[dict[str, Any]]:
+        """List tunnel interfaces in a container."""
+        if not self.client:
+            return [
+                {"id": "tun-mock1", "folder": folder or "ngfw-shared", "name": "tunnel1", "mtu": 1500, "ip": [{"name": "10.0.0.1/30"}]},
+                {"id": "tun-mock2", "folder": folder or "ngfw-shared", "name": "tunnel2", "mtu": 1400, "ip": [{"name": "10.0.0.5/30"}]},
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.tunnel_interface.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "tunnel interfaces", e)
+
+    # -------------------------------------------------------------------------------------- VLAN Interfaces ------------------------------------------------------------------------------------
+
+    def create_vlan_interface(self, iface_data: dict[str, Any]) -> dict[str, Any]:
+        """Create or update a VLAN interface using smart upsert logic."""
+        container_fields = ["folder", "snippet", "device"]
+        container_field = None
+        container_value = None
+        for field in container_fields:
+            if field in iface_data and iface_data[field] is not None:
+                container_field = field
+                container_value = iface_data[field]
+                break
+        if not container_field:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        if not self.client:
+            result = iface_data.copy()
+            result["id"] = f"vlan-{iface_data['name']}"
+            result["__action__"] = "created"
+            return result
+        existing_iface = None
+        try:
+            existing_iface = self.client.vlan_interface.fetch(name=iface_data["name"], **{container_field: container_value})
+            self.logger.info(f"Found existing VLAN interface '{iface_data['name']}' in {container_field} '{container_value}'")
+        except NotFoundError:
+            self.logger.info(f"VLAN interface '{iface_data['name']}' not found, will create new")
+        except Exception as e:
+            self.logger.warning(f"Error fetching VLAN interface '{iface_data['name']}': {str(e)}")
+        if existing_iface:
+            needs_update = False
+            update_fields = []
+            for key in ["comment", "vlan_tag", "mtu", "interface_management_profile"]:
+                if key in iface_data:
+                    if iface_data[key] != getattr(existing_iface, key, None):
+                        needs_update = True
+                        update_fields.append(key)
+            for key in ["ip", "dhcp_client"]:
+                if key in iface_data:
+                    existing_val = getattr(existing_iface, key, None)
+                    if key == "ip" and existing_val:
+                        existing_dict = [json.loads(e.model_dump_json(exclude_unset=True)) for e in existing_val]
+                    elif existing_val and hasattr(existing_val, "model_dump_json"):
+                        existing_dict = json.loads(existing_val.model_dump_json(exclude_unset=True))
+                    else:
+                        existing_dict = existing_val
+                    if iface_data[key] != existing_dict:
+                        needs_update = True
+                        update_fields.append(key)
+            if needs_update:
+                self.logger.info(f"Updating VLAN interface fields: {', '.join(update_fields)}")
+                try:
+                    update_data = iface_data.copy()
+                    update_data["id"] = str(existing_iface.id)
+                    result = self.client.vlan_interface.update(update_data)
+                    result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+                    result_dict["__action__"] = "updated"
+                    return result_dict
+                except Exception as update_error:
+                    self._handle_api_exception("update", container_value or "unknown", f"VLAN interface '{iface_data['name']}'", update_error)
+            else:
+                result = json.loads(existing_iface.model_dump_json(exclude_unset=True))
+                result["__action__"] = "no_change"
+                return result
+        else:
+            try:
+                created = self.client.vlan_interface.create(iface_data)
+                result = json.loads(created.model_dump_json(exclude_unset=True))
+                result["__action__"] = "created"
+                return result
+            except Exception as create_error:
+                self._handle_api_exception("creating", str(container_value), f"VLAN interface '{iface_data['name']}'", create_error)
+
+    def delete_vlan_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> None:
+        """Delete a VLAN interface."""
+        if not self.client:
+            self.logger.info(f"[Mock Mode] Would delete VLAN interface: {name}")
+            return
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            iface = self.client.vlan_interface.fetch(name=name, **container_kwargs)
+            self.client.vlan_interface.delete(str(iface.id))
+            self.logger.info(f"Deleted VLAN interface: {name}")
+        except Exception as e:
+            self._handle_api_exception("deleting", folder or snippet or device or "", f"VLAN interface '{name}'", e)
+
+    def get_vlan_interface(self, name: str, folder: str | None = None, snippet: str | None = None, device: str | None = None) -> dict[str, Any] | None:
+        """Get a specific VLAN interface."""
+        if not self.client:
+            return {
+                "id": "vlan-mock",
+                "name": name,
+                "folder": folder or "ngfw-shared",
+                "comment": "Mock VLAN interface",
+                "vlan_tag": "100",
+                "ip": [{"name": "10.0.10.1/24"}],
+            }
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        else:
+            raise ValueError("One of 'folder', 'snippet', or 'device' must be specified")
+        try:
+            result = self.client.vlan_interface.fetch(name=name, **container_kwargs)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except NotFoundError:
+            self.logger.warning(f"VLAN interface '{name}' not found")
+            return None
+        except Exception as e:
+            self._handle_api_exception("retrieving", folder or snippet or device or "", f"VLAN interface '{name}'", e)
+
+    def list_vlan_interfaces(self, folder: str | None = None, snippet: str | None = None, device: str | None = None, exact_match: bool = False) -> list[dict[str, Any]]:
+        """List VLAN interfaces in a container."""
+        if not self.client:
+            return [
+                {"id": "vlan-mock1", "folder": folder or "ngfw-shared", "name": "vlan1", "vlan_tag": "100", "ip": [{"name": "10.0.10.1/24"}]},
+                {"id": "vlan-mock2", "folder": folder or "ngfw-shared", "name": "vlan2", "vlan_tag": "200", "ip": [{"name": "10.0.20.1/24"}]},
+            ]
+        container_kwargs = {}
+        if folder:
+            container_kwargs["folder"] = folder
+        elif snippet:
+            container_kwargs["snippet"] = snippet
+        elif device:
+            container_kwargs["device"] = device
+        try:
+            results = self.client.vlan_interface.list(exact_match=exact_match, **container_kwargs)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or snippet or device or "", "VLAN interfaces", e)
+
 
 class LazyClient:
     """Lazy wrapper for SCMClient that delays initialization until first use."""

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -1761,6 +1761,344 @@ class AggregateInterface(BaseModel):
         return model_data
 
 
+class DhcpInterface(BaseModel):
+    """Model for DHCP interface configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the DHCP interface")
+    snippet: str | None = Field(None, description="Snippet path for the DHCP interface")
+    device: str | None = Field(None, description="Device path for the DHCP interface")
+    name: str = Field(..., description="Interface name (e.g. ethernet1/1)")
+    server: dict[str, Any] | None = Field(None, description="DHCP server configuration (mode, ip_pool, option, reserved)")
+    relay: dict[str, Any] | None = Field(None, description="DHCP relay configuration (ip: {enabled, server})")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "DhcpInterface":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @model_validator(mode="after")
+    def validate_server_relay(self) -> "DhcpInterface":
+        """Validate that server and relay are mutually exclusive."""
+        if self.server is not None and self.relay is not None:
+            raise ValueError("Only one of 'server' or 'relay' can be specified")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {"name": self.name}
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+        if self.server is not None:
+            model_data["server"] = self.server
+        if self.relay is not None:
+            model_data["relay"] = self.relay
+        return model_data
+
+
+class EthernetInterface(BaseModel):
+    """Model for ethernet interface configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the ethernet interface")
+    snippet: str | None = Field(None, description="Snippet path for the ethernet interface")
+    device: str | None = Field(None, description="Device path for the ethernet interface")
+    name: str = Field(..., description="Ethernet interface variable name (must start with $)")
+    comment: str | None = Field(None, description="Interface description/comment")
+    default_value: str | None = Field(None, description="Physical interface assignment (e.g. ethernet1/1)")
+    link_speed: str | None = Field(None, description="Link speed (auto, 10, 100, 1000, 10000)")
+    link_duplex: str | None = Field(None, description="Link duplex (auto, half, full)")
+    link_state: str | None = Field(None, description="Link state (auto, up, down)")
+    layer2: dict[str, Any] | None = Field(None, description="Layer2 configuration (vlan_tag, lldp)")
+    layer3: dict[str, Any] | None = Field(None, description="Layer3 configuration (ip, dhcp_client, mtu, arp)")
+    tap: dict[str, Any] | None = Field(None, description="TAP mode configuration")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "EthernetInterface":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @model_validator(mode="after")
+    def validate_interface_mode(self) -> "EthernetInterface":
+        """Validate that at most one interface mode is specified."""
+        modes = [self.layer2, self.layer3, self.tap]
+        configured = [m for m in modes if m is not None]
+        if len(configured) > 1:
+            raise ValueError("Only one interface mode allowed: layer2, layer3, or tap")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {"name": self.name}
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+        if self.comment:
+            model_data["comment"] = self.comment
+        if self.default_value:
+            model_data["default_value"] = self.default_value
+        if self.link_speed:
+            model_data["link_speed"] = self.link_speed
+        if self.link_duplex:
+            model_data["link_duplex"] = self.link_duplex
+        if self.link_state:
+            model_data["link_state"] = self.link_state
+        if self.layer2 is not None:
+            model_data["layer2"] = self.layer2
+        if self.layer3 is not None:
+            model_data["layer3"] = self.layer3
+        if self.tap is not None:
+            model_data["tap"] = self.tap
+        return model_data
+
+
+class Layer2Subinterface(BaseModel):
+    """Model for layer2 subinterface configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the layer2 subinterface")
+    snippet: str | None = Field(None, description="Snippet path for the layer2 subinterface")
+    device: str | None = Field(None, description="Device path for the layer2 subinterface")
+    name: str = Field(..., description="Subinterface name (e.g. ethernet1/1.100)")
+    vlan_tag: str = Field(..., description="VLAN tag (1-4096)")
+    parent_interface: str | None = Field(None, description="Parent interface name")
+    comment: str | None = Field(None, description="Interface description/comment")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "Layer2Subinterface":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {"name": self.name, "vlan_tag": self.vlan_tag}
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+        if self.parent_interface:
+            model_data["parent_interface"] = self.parent_interface
+        if self.comment:
+            model_data["comment"] = self.comment
+        return model_data
+
+
+class Layer3Subinterface(BaseModel):
+    """Model for layer3 subinterface configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the layer3 subinterface")
+    snippet: str | None = Field(None, description="Snippet path for the layer3 subinterface")
+    device: str | None = Field(None, description="Device path for the layer3 subinterface")
+    name: str = Field(..., description="Subinterface name (e.g. ethernet1/1.100)")
+    tag: int | None = Field(None, description="VLAN tag (1-4096)")
+    parent_interface: str | None = Field(None, description="Parent interface name")
+    comment: str | None = Field(None, description="Interface description/comment")
+    mtu: int | None = Field(None, description="Maximum transmission unit (576-9216)")
+    interface_management_profile: str | None = Field(None, description="Interface management profile name")
+    ip: list[dict[str, Any]] | None = Field(None, description="Static IP addresses [{name: ip/mask}]")
+    dhcp_client: dict[str, Any] | None = Field(None, description="DHCP client configuration")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "Layer3Subinterface":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @model_validator(mode="after")
+    def validate_ip_mode(self) -> "Layer3Subinterface":
+        """Validate that only one IP addressing mode is configured."""
+        if self.ip and self.dhcp_client:
+            raise ValueError("Only one IP addressing mode allowed: static IP or DHCP")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {"name": self.name}
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+        if self.tag is not None:
+            model_data["tag"] = self.tag
+        if self.parent_interface:
+            model_data["parent_interface"] = self.parent_interface
+        if self.comment:
+            model_data["comment"] = self.comment
+        if self.mtu is not None:
+            model_data["mtu"] = self.mtu
+        if self.interface_management_profile:
+            model_data["interface_management_profile"] = self.interface_management_profile
+        if self.ip is not None:
+            model_data["ip"] = self.ip
+        if self.dhcp_client is not None:
+            model_data["dhcp_client"] = self.dhcp_client
+        return model_data
+
+
+class LoopbackInterface(BaseModel):
+    """Model for loopback interface configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the loopback interface")
+    snippet: str | None = Field(None, description="Snippet path for the loopback interface")
+    device: str | None = Field(None, description="Device path for the loopback interface")
+    name: str = Field(..., description="Loopback interface name (variable format, starts with $)")
+    comment: str | None = Field(None, description="Interface description/comment")
+    default_value: str | None = Field(None, description="Default interface assignment (e.g. loopback.1)")
+    mtu: int | None = Field(None, description="Maximum transmission unit (576-9216)")
+    interface_management_profile: str | None = Field(None, description="Interface management profile name")
+    ip: list[dict[str, Any]] | None = Field(None, description="Static IP addresses [{name: ip/mask}]")
+    ipv6: dict[str, Any] | None = Field(None, description="IPv6 configuration")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "LoopbackInterface":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {"name": self.name}
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+        if self.comment:
+            model_data["comment"] = self.comment
+        if self.default_value:
+            model_data["default_value"] = self.default_value
+        if self.mtu is not None:
+            model_data["mtu"] = self.mtu
+        if self.interface_management_profile:
+            model_data["interface_management_profile"] = self.interface_management_profile
+        if self.ip is not None:
+            model_data["ip"] = self.ip
+        if self.ipv6 is not None:
+            model_data["ipv6"] = self.ipv6
+        return model_data
+
+
+class TunnelInterface(BaseModel):
+    """Model for tunnel interface configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the tunnel interface")
+    snippet: str | None = Field(None, description="Snippet path for the tunnel interface")
+    device: str | None = Field(None, description="Device path for the tunnel interface")
+    name: str = Field(..., description="Tunnel interface name")
+    comment: str | None = Field(None, description="Interface description/comment")
+    default_value: str | None = Field(None, description="Default interface assignment (e.g. tunnel.1)")
+    mtu: int | None = Field(None, description="Maximum transmission unit (576-9216)")
+    interface_management_profile: str | None = Field(None, description="Interface management profile name")
+    ip: list[dict[str, Any]] | None = Field(None, description="Static IP addresses [{name: ip/mask}]")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "TunnelInterface":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {"name": self.name}
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+        if self.comment:
+            model_data["comment"] = self.comment
+        if self.default_value:
+            model_data["default_value"] = self.default_value
+        if self.mtu is not None:
+            model_data["mtu"] = self.mtu
+        if self.interface_management_profile:
+            model_data["interface_management_profile"] = self.interface_management_profile
+        if self.ip is not None:
+            model_data["ip"] = self.ip
+        return model_data
+
+
+class VlanInterface(BaseModel):
+    """Model for VLAN interface configurations."""
+
+    folder: str | None = Field(None, description="Folder path for the VLAN interface")
+    snippet: str | None = Field(None, description="Snippet path for the VLAN interface")
+    device: str | None = Field(None, description="Device path for the VLAN interface")
+    name: str = Field(..., description="VLAN interface name")
+    comment: str | None = Field(None, description="Interface description/comment")
+    default_value: str | None = Field(None, description="Default interface assignment (e.g. vlan.100)")
+    vlan_tag: str | None = Field(None, description="VLAN tag (1-4096)")
+    mtu: int | None = Field(None, description="Maximum transmission unit (576-9216)")
+    interface_management_profile: str | None = Field(None, description="Interface management profile name")
+    ip: list[dict[str, Any]] | None = Field(None, description="Static IP addresses [{name: ip/mask}]")
+    dhcp_client: dict[str, Any] | None = Field(None, description="DHCP client configuration")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "VlanInterface":
+        """Validate that exactly one container is specified."""
+        containers = [self.folder, self.snippet, self.device]
+        if sum(1 for c in containers if c is not None) != 1:
+            raise ValueError("Exactly one of 'folder', 'snippet', or 'device' must be set")
+        return self
+
+    @model_validator(mode="after")
+    def validate_ip_mode(self) -> "VlanInterface":
+        """Validate that only one IP addressing mode is configured."""
+        if self.ip and self.dhcp_client:
+            raise ValueError("Only one IP addressing mode allowed: static IP or DHCP")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {"name": self.name}
+        if self.folder:
+            model_data["folder"] = self.folder
+        elif self.snippet:
+            model_data["snippet"] = self.snippet
+        elif self.device:
+            model_data["device"] = self.device
+        if self.comment:
+            model_data["comment"] = self.comment
+        if self.default_value:
+            model_data["default_value"] = self.default_value
+        if self.vlan_tag:
+            model_data["vlan_tag"] = self.vlan_tag
+        if self.mtu is not None:
+            model_data["mtu"] = self.mtu
+        if self.interface_management_profile:
+            model_data["interface_management_profile"] = self.interface_management_profile
+        if self.ip is not None:
+            model_data["ip"] = self.ip
+        if self.dhcp_client is not None:
+            model_data["dhcp_client"] = self.dhcp_client
+        return model_data
+
+
 class NATRule(BaseModel):
     """Model for NAT rule configurations."""
 

--- a/tests/test_network_commands.py
+++ b/tests/test_network_commands.py
@@ -4,30 +4,58 @@ import typer  # noqa: I001
 from scm_cli.commands.network import (
     delete_aggregate_interface,
     delete_app,
+    delete_dhcp_interface,
+    delete_ethernet_interface,
     delete_ike_crypto_profile,
     delete_ike_gateway,
     delete_ipsec_crypto_profile,
+    delete_layer2_subinterface,
+    delete_layer3_subinterface,
+    delete_loopback_interface,
     delete_nat_rule,
+    delete_tunnel_interface,
+    delete_vlan_interface,
     delete_zone,
     load_aggregate_interface,
     load_app,
+    load_dhcp_interface,
+    load_ethernet_interface,
     load_ike_crypto_profile,
     load_ike_gateway,
     load_ipsec_crypto_profile,
+    load_layer2_subinterface,
+    load_layer3_subinterface,
+    load_loopback_interface,
     load_nat_rule,
     load_security_zone as load_zone,
+    load_tunnel_interface,
+    load_vlan_interface,
     set_aggregate_interface,
     set_app,
+    set_dhcp_interface,
+    set_ethernet_interface,
     set_ike_crypto_profile,
     set_ike_gateway,
     set_ipsec_crypto_profile,
+    set_layer2_subinterface,
+    set_layer3_subinterface,
+    set_loopback_interface,
     set_nat_rule,
+    set_tunnel_interface,
+    set_vlan_interface,
     set_zone,
     show_aggregate_interface,
+    show_dhcp_interface,
+    show_ethernet_interface,
     show_ike_crypto_profile,
     show_ike_gateway,
     show_ipsec_crypto_profile,
+    show_layer2_subinterface,
+    show_layer3_subinterface,
+    show_loopback_interface,
     show_nat_rule,
+    show_tunnel_interface,
+    show_vlan_interface,
 )
 
 
@@ -1312,3 +1340,665 @@ class TestAggregateInterfaceCommands:
         assert result.exit_code == 0
         assert "Dry run mode" in result.stdout
         assert not mock_called
+
+
+class TestDhcpInterfaceCommands:
+    """Test the DHCP interface commands."""
+
+    def test_set_dhcp_interface_created(self, runner, monkeypatch):
+        """Test set dhcp-interface command creates a new interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(iface_data):
+            result = iface_data.copy()
+            result["id"] = "dhcp-12345"
+            result["__action__"] = "created"
+            return result
+
+        monkeypatch.setattr(scm_client, "create_dhcp_interface", mock_create)
+        test_app = typer.Typer()
+        test_app.command()(set_dhcp_interface)
+        result = runner.invoke(test_app, ["ethernet1/1", "--folder", "test-folder", "--server-json", '{"mode": "auto"}'])
+        assert result.exit_code == 0
+        assert "Created DHCP interface" in result.stdout
+
+    def test_set_dhcp_interface_error(self, runner, monkeypatch):
+        """Test set dhcp-interface command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_dhcp_interface", lambda d: (_ for _ in ()).throw(ValueError("Test error")))
+        test_app = typer.Typer()
+        test_app.command()(set_dhcp_interface)
+        result = runner.invoke(test_app, ["ethernet1/1", "--folder", "test-folder"])
+        assert result.exit_code == 1
+
+    def test_show_dhcp_interface_list(self, runner, monkeypatch):
+        """Test show dhcp-interface command lists interfaces."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_dhcp_interfaces", lambda **kwargs: [{"id": "dhcp-1", "name": "ethernet1/1", "folder": "test-folder", "server": {"mode": "auto"}}])
+        test_app = typer.Typer()
+        test_app.command()(show_dhcp_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "ethernet1/1" in result.stdout
+
+    def test_show_dhcp_interface_specific(self, runner, monkeypatch):
+        """Test show dhcp-interface command shows a specific interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_dhcp_interface", lambda **kwargs: {"id": "dhcp-1", "name": "ethernet1/1", "folder": "test-folder", "server": {"mode": "auto"}})
+        test_app = typer.Typer()
+        test_app.command()(show_dhcp_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "ethernet1/1"])
+        assert result.exit_code == 0
+        assert "ethernet1/1" in result.stdout
+
+    def test_delete_dhcp_interface_command(self, runner, monkeypatch):
+        """Test delete dhcp-interface command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_dhcp_interface", lambda **kwargs: {"id": "dhcp-1", "name": "ethernet1/1", "folder": "test-folder"})
+        monkeypatch.setattr(scm_client, "delete_dhcp_interface", lambda **kwargs: None)
+        test_app = typer.Typer()
+        test_app.command()(delete_dhcp_interface)
+        result = runner.invoke(test_app, ["ethernet1/1", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted DHCP interface" in result.stdout
+
+    def test_load_dhcp_interface_command(self, runner, monkeypatch, tmp_path):
+        """Test load dhcp-interface command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {"dhcp_interfaces": [{"name": "ethernet1/1", "folder": "test-folder", "server": {"mode": "auto"}}]}
+        yaml_file = tmp_path / "dhcp-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        monkeypatch.setattr(scm_client, "create_dhcp_interface", lambda d: {**d, "id": "dhcp-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(load_dhcp_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created DHCP interface" in result.stdout
+
+    def test_load_dhcp_interface_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test load dhcp-interface command with dry-run."""
+        import yaml
+
+        yaml_data = {"dhcp_interfaces": [{"name": "ethernet1/1", "folder": "test-folder"}]}
+        yaml_file = tmp_path / "dhcp-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        test_app = typer.Typer()
+        test_app.command()(load_dhcp_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+
+class TestEthernetInterfaceCommands:
+    """Test the ethernet interface commands."""
+
+    def test_set_ethernet_interface_created(self, runner, monkeypatch):
+        """Test set ethernet-interface command creates a new interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_ethernet_interface", lambda d: {**d, "id": "eth-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(set_ethernet_interface)
+        result = runner.invoke(test_app, ["$eth1", "--folder", "test-folder", "--layer3-json", '{"mtu": 1500}'])
+        assert result.exit_code == 0
+        assert "Created ethernet interface" in result.stdout
+
+    def test_set_ethernet_interface_error(self, runner, monkeypatch):
+        """Test set ethernet-interface command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_ethernet_interface", lambda d: (_ for _ in ()).throw(ValueError("Test error")))
+        test_app = typer.Typer()
+        test_app.command()(set_ethernet_interface)
+        result = runner.invoke(test_app, ["$eth1", "--folder", "test-folder"])
+        assert result.exit_code == 1
+
+    def test_show_ethernet_interface_list(self, runner, monkeypatch):
+        """Test show ethernet-interface command lists interfaces."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_ethernet_interfaces", lambda **kwargs: [{"id": "eth-1", "name": "$eth1", "folder": "test-folder", "layer3": {"mtu": 1500}}])
+        test_app = typer.Typer()
+        test_app.command()(show_ethernet_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "$eth1" in result.stdout
+
+    def test_show_ethernet_interface_specific(self, runner, monkeypatch):
+        """Test show ethernet-interface command shows a specific interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(
+            scm_client, "get_ethernet_interface", lambda **kwargs: {"id": "eth-1", "name": "$eth1", "folder": "test-folder", "layer3": {"mtu": 9000, "ip": [{"name": "10.0.0.1/24"}]}}
+        )
+        test_app = typer.Typer()
+        test_app.command()(show_ethernet_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "$eth1"])
+        assert result.exit_code == 0
+        assert "$eth1" in result.stdout
+        assert "9000" in result.stdout
+
+    def test_delete_ethernet_interface_command(self, runner, monkeypatch):
+        """Test delete ethernet-interface command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_ethernet_interface", lambda **kwargs: {"id": "eth-1", "name": "$eth1", "folder": "test-folder"})
+        monkeypatch.setattr(scm_client, "delete_ethernet_interface", lambda **kwargs: None)
+        test_app = typer.Typer()
+        test_app.command()(delete_ethernet_interface)
+        result = runner.invoke(test_app, ["$eth1", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted ethernet interface" in result.stdout
+
+    def test_load_ethernet_interface_command(self, runner, monkeypatch, tmp_path):
+        """Test load ethernet-interface command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {"ethernet_interfaces": [{"name": "$eth1", "folder": "test-folder", "layer3": {"mtu": 1500}}]}
+        yaml_file = tmp_path / "ethernet-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        monkeypatch.setattr(scm_client, "create_ethernet_interface", lambda d: {**d, "id": "eth-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(load_ethernet_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created ethernet interface" in result.stdout
+
+    def test_load_ethernet_interface_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test load ethernet-interface command with dry-run."""
+        import yaml
+
+        yaml_data = {"ethernet_interfaces": [{"name": "$eth1", "folder": "test-folder"}]}
+        yaml_file = tmp_path / "ethernet-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        test_app = typer.Typer()
+        test_app.command()(load_ethernet_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+
+class TestLayer2SubinterfaceCommands:
+    """Test the layer2 subinterface commands."""
+
+    def test_set_layer2_subinterface_created(self, runner, monkeypatch):
+        """Test set layer2-subinterface command creates a new interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_layer2_subinterface", lambda d: {**d, "id": "l2sub-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(set_layer2_subinterface)
+        result = runner.invoke(test_app, ["ethernet1/1.100", "--folder", "test-folder", "--vlan-tag", "100"])
+        assert result.exit_code == 0
+        assert "Created layer2 subinterface" in result.stdout
+
+    def test_set_layer2_subinterface_error(self, runner, monkeypatch):
+        """Test set layer2-subinterface command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_layer2_subinterface", lambda d: (_ for _ in ()).throw(ValueError("Test error")))
+        test_app = typer.Typer()
+        test_app.command()(set_layer2_subinterface)
+        result = runner.invoke(test_app, ["ethernet1/1.100", "--folder", "test-folder", "--vlan-tag", "100"])
+        assert result.exit_code == 1
+
+    def test_show_layer2_subinterface_list(self, runner, monkeypatch):
+        """Test show layer2-subinterface command lists interfaces."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_layer2_subinterfaces", lambda **kwargs: [{"id": "l2-1", "name": "ethernet1/1.100", "folder": "test-folder", "vlan_tag": "100"}])
+        test_app = typer.Typer()
+        test_app.command()(show_layer2_subinterface)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "ethernet1/1.100" in result.stdout
+
+    def test_show_layer2_subinterface_specific(self, runner, monkeypatch):
+        """Test show layer2-subinterface command shows a specific interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(
+            scm_client, "get_layer2_subinterface", lambda **kwargs: {"id": "l2-1", "name": "ethernet1/1.100", "folder": "test-folder", "vlan_tag": "100", "parent_interface": "ethernet1/1"}
+        )
+        test_app = typer.Typer()
+        test_app.command()(show_layer2_subinterface)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "ethernet1/1.100"])
+        assert result.exit_code == 0
+        assert "ethernet1/1.100" in result.stdout
+
+    def test_delete_layer2_subinterface_command(self, runner, monkeypatch):
+        """Test delete layer2-subinterface command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_layer2_subinterface", lambda **kwargs: {"id": "l2-1", "name": "ethernet1/1.100", "folder": "test-folder"})
+        monkeypatch.setattr(scm_client, "delete_layer2_subinterface", lambda **kwargs: None)
+        test_app = typer.Typer()
+        test_app.command()(delete_layer2_subinterface)
+        result = runner.invoke(test_app, ["ethernet1/1.100", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted layer2 subinterface" in result.stdout
+
+    def test_load_layer2_subinterface_command(self, runner, monkeypatch, tmp_path):
+        """Test load layer2-subinterface command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {"layer2_subinterfaces": [{"name": "ethernet1/1.100", "folder": "test-folder", "vlan_tag": "100"}]}
+        yaml_file = tmp_path / "l2-subinterfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        monkeypatch.setattr(scm_client, "create_layer2_subinterface", lambda d: {**d, "id": "l2sub-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(load_layer2_subinterface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created layer2 subinterface" in result.stdout
+
+    def test_load_layer2_subinterface_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test load layer2-subinterface command with dry-run."""
+        import yaml
+
+        yaml_data = {"layer2_subinterfaces": [{"name": "ethernet1/1.100", "folder": "test-folder", "vlan_tag": "100"}]}
+        yaml_file = tmp_path / "l2-subinterfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        test_app = typer.Typer()
+        test_app.command()(load_layer2_subinterface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+
+class TestLayer3SubinterfaceCommands:
+    """Test the layer3 subinterface commands."""
+
+    def test_set_layer3_subinterface_created(self, runner, monkeypatch):
+        """Test set layer3-subinterface command creates a new interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_layer3_subinterface", lambda d: {**d, "id": "l3sub-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(set_layer3_subinterface)
+        result = runner.invoke(test_app, ["ethernet1/1.100", "--folder", "test-folder", "--tag", "100", "--mtu", "1500"])
+        assert result.exit_code == 0
+        assert "Created layer3 subinterface" in result.stdout
+
+    def test_set_layer3_subinterface_error(self, runner, monkeypatch):
+        """Test set layer3-subinterface command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_layer3_subinterface", lambda d: (_ for _ in ()).throw(ValueError("Test error")))
+        test_app = typer.Typer()
+        test_app.command()(set_layer3_subinterface)
+        result = runner.invoke(test_app, ["ethernet1/1.100", "--folder", "test-folder"])
+        assert result.exit_code == 1
+
+    def test_show_layer3_subinterface_list(self, runner, monkeypatch):
+        """Test show layer3-subinterface command lists interfaces."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_layer3_subinterfaces", lambda **kwargs: [{"id": "l3-1", "name": "ethernet1/1.100", "folder": "test-folder", "tag": 100, "mtu": 1500}])
+        test_app = typer.Typer()
+        test_app.command()(show_layer3_subinterface)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "ethernet1/1.100" in result.stdout
+
+    def test_show_layer3_subinterface_specific(self, runner, monkeypatch):
+        """Test show layer3-subinterface command shows a specific interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(
+            scm_client, "get_layer3_subinterface", lambda **kwargs: {"id": "l3-1", "name": "ethernet1/1.100", "folder": "test-folder", "tag": 100, "mtu": 9000, "ip": [{"name": "10.0.1.1/24"}]}
+        )
+        test_app = typer.Typer()
+        test_app.command()(show_layer3_subinterface)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "ethernet1/1.100"])
+        assert result.exit_code == 0
+        assert "ethernet1/1.100" in result.stdout
+        assert "9000" in result.stdout
+
+    def test_delete_layer3_subinterface_command(self, runner, monkeypatch):
+        """Test delete layer3-subinterface command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_layer3_subinterface", lambda **kwargs: {"id": "l3-1", "name": "ethernet1/1.100", "folder": "test-folder"})
+        monkeypatch.setattr(scm_client, "delete_layer3_subinterface", lambda **kwargs: None)
+        test_app = typer.Typer()
+        test_app.command()(delete_layer3_subinterface)
+        result = runner.invoke(test_app, ["ethernet1/1.100", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted layer3 subinterface" in result.stdout
+
+    def test_load_layer3_subinterface_command(self, runner, monkeypatch, tmp_path):
+        """Test load layer3-subinterface command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {"layer3_subinterfaces": [{"name": "ethernet1/1.100", "folder": "test-folder", "tag": 100, "ip": [{"name": "10.0.1.1/24"}]}]}
+        yaml_file = tmp_path / "l3-subinterfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        monkeypatch.setattr(scm_client, "create_layer3_subinterface", lambda d: {**d, "id": "l3sub-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(load_layer3_subinterface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created layer3 subinterface" in result.stdout
+
+    def test_load_layer3_subinterface_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test load layer3-subinterface command with dry-run."""
+        import yaml
+
+        yaml_data = {"layer3_subinterfaces": [{"name": "ethernet1/1.100", "folder": "test-folder"}]}
+        yaml_file = tmp_path / "l3-subinterfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        test_app = typer.Typer()
+        test_app.command()(load_layer3_subinterface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+
+class TestLoopbackInterfaceCommands:
+    """Test the loopback interface commands."""
+
+    def test_set_loopback_interface_created(self, runner, monkeypatch):
+        """Test set loopback-interface command creates a new interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_loopback_interface", lambda d: {**d, "id": "lo-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(set_loopback_interface)
+        result = runner.invoke(test_app, ["$lo1", "--folder", "test-folder", "--ip-json", '[{"name": "10.0.0.1/32"}]'])
+        assert result.exit_code == 0
+        assert "Created loopback interface" in result.stdout
+
+    def test_set_loopback_interface_error(self, runner, monkeypatch):
+        """Test set loopback-interface command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_loopback_interface", lambda d: (_ for _ in ()).throw(ValueError("Test error")))
+        test_app = typer.Typer()
+        test_app.command()(set_loopback_interface)
+        result = runner.invoke(test_app, ["$lo1", "--folder", "test-folder"])
+        assert result.exit_code == 1
+
+    def test_show_loopback_interface_list(self, runner, monkeypatch):
+        """Test show loopback-interface command lists interfaces."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_loopback_interfaces", lambda **kwargs: [{"id": "lo-1", "name": "$lo1", "folder": "test-folder", "ip": [{"name": "10.0.0.1/32"}]}])
+        test_app = typer.Typer()
+        test_app.command()(show_loopback_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "$lo1" in result.stdout
+
+    def test_show_loopback_interface_specific(self, runner, monkeypatch):
+        """Test show loopback-interface command shows a specific interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(
+            scm_client, "get_loopback_interface", lambda **kwargs: {"id": "lo-1", "name": "$lo1", "folder": "test-folder", "comment": "test lo", "ip": [{"name": "10.0.0.1/32"}]}
+        )
+        test_app = typer.Typer()
+        test_app.command()(show_loopback_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "$lo1"])
+        assert result.exit_code == 0
+        assert "$lo1" in result.stdout
+
+    def test_delete_loopback_interface_command(self, runner, monkeypatch):
+        """Test delete loopback-interface command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_loopback_interface", lambda **kwargs: {"id": "lo-1", "name": "$lo1", "folder": "test-folder"})
+        monkeypatch.setattr(scm_client, "delete_loopback_interface", lambda **kwargs: None)
+        test_app = typer.Typer()
+        test_app.command()(delete_loopback_interface)
+        result = runner.invoke(test_app, ["$lo1", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted loopback interface" in result.stdout
+
+    def test_load_loopback_interface_command(self, runner, monkeypatch, tmp_path):
+        """Test load loopback-interface command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {"loopback_interfaces": [{"name": "$lo1", "folder": "test-folder", "ip": [{"name": "10.0.0.1/32"}]}]}
+        yaml_file = tmp_path / "loopback-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        monkeypatch.setattr(scm_client, "create_loopback_interface", lambda d: {**d, "id": "lo-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(load_loopback_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created loopback interface" in result.stdout
+
+    def test_load_loopback_interface_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test load loopback-interface command with dry-run."""
+        import yaml
+
+        yaml_data = {"loopback_interfaces": [{"name": "$lo1", "folder": "test-folder"}]}
+        yaml_file = tmp_path / "loopback-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        test_app = typer.Typer()
+        test_app.command()(load_loopback_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+
+class TestTunnelInterfaceCommands:
+    """Test the tunnel interface commands."""
+
+    def test_set_tunnel_interface_created(self, runner, monkeypatch):
+        """Test set tunnel-interface command creates a new interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_tunnel_interface", lambda d: {**d, "id": "tun-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(set_tunnel_interface)
+        result = runner.invoke(test_app, ["tunnel1", "--folder", "test-folder", "--mtu", "1400"])
+        assert result.exit_code == 0
+        assert "Created tunnel interface" in result.stdout
+
+    def test_set_tunnel_interface_error(self, runner, monkeypatch):
+        """Test set tunnel-interface command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_tunnel_interface", lambda d: (_ for _ in ()).throw(ValueError("Test error")))
+        test_app = typer.Typer()
+        test_app.command()(set_tunnel_interface)
+        result = runner.invoke(test_app, ["tunnel1", "--folder", "test-folder"])
+        assert result.exit_code == 1
+
+    def test_show_tunnel_interface_list(self, runner, monkeypatch):
+        """Test show tunnel-interface command lists interfaces."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_tunnel_interfaces", lambda **kwargs: [{"id": "tun-1", "name": "tunnel1", "folder": "test-folder", "mtu": 1400}])
+        test_app = typer.Typer()
+        test_app.command()(show_tunnel_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "tunnel1" in result.stdout
+
+    def test_show_tunnel_interface_specific(self, runner, monkeypatch):
+        """Test show tunnel-interface command shows a specific interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_tunnel_interface", lambda **kwargs: {"id": "tun-1", "name": "tunnel1", "folder": "test-folder", "mtu": 1400, "ip": [{"name": "10.0.0.1/30"}]})
+        test_app = typer.Typer()
+        test_app.command()(show_tunnel_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "tunnel1"])
+        assert result.exit_code == 0
+        assert "tunnel1" in result.stdout
+        assert "1400" in result.stdout
+
+    def test_delete_tunnel_interface_command(self, runner, monkeypatch):
+        """Test delete tunnel-interface command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_tunnel_interface", lambda **kwargs: {"id": "tun-1", "name": "tunnel1", "folder": "test-folder"})
+        monkeypatch.setattr(scm_client, "delete_tunnel_interface", lambda **kwargs: None)
+        test_app = typer.Typer()
+        test_app.command()(delete_tunnel_interface)
+        result = runner.invoke(test_app, ["tunnel1", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted tunnel interface" in result.stdout
+
+    def test_load_tunnel_interface_command(self, runner, monkeypatch, tmp_path):
+        """Test load tunnel-interface command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {"tunnel_interfaces": [{"name": "tunnel1", "folder": "test-folder", "mtu": 1400}]}
+        yaml_file = tmp_path / "tunnel-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        monkeypatch.setattr(scm_client, "create_tunnel_interface", lambda d: {**d, "id": "tun-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(load_tunnel_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created tunnel interface" in result.stdout
+
+    def test_load_tunnel_interface_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test load tunnel-interface command with dry-run."""
+        import yaml
+
+        yaml_data = {"tunnel_interfaces": [{"name": "tunnel1", "folder": "test-folder"}]}
+        yaml_file = tmp_path / "tunnel-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        test_app = typer.Typer()
+        test_app.command()(load_tunnel_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+
+class TestVlanInterfaceCommands:
+    """Test the VLAN interface commands."""
+
+    def test_set_vlan_interface_created(self, runner, monkeypatch):
+        """Test set vlan-interface command creates a new interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_vlan_interface", lambda d: {**d, "id": "vlan-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(set_vlan_interface)
+        result = runner.invoke(test_app, ["vlan1", "--folder", "test-folder", "--vlan-tag", "100"])
+        assert result.exit_code == 0
+        assert "Created VLAN interface" in result.stdout
+
+    def test_set_vlan_interface_error(self, runner, monkeypatch):
+        """Test set vlan-interface command handles errors."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "create_vlan_interface", lambda d: (_ for _ in ()).throw(ValueError("Test error")))
+        test_app = typer.Typer()
+        test_app.command()(set_vlan_interface)
+        result = runner.invoke(test_app, ["vlan1", "--folder", "test-folder"])
+        assert result.exit_code == 1
+
+    def test_show_vlan_interface_list(self, runner, monkeypatch):
+        """Test show vlan-interface command lists interfaces."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_vlan_interfaces", lambda **kwargs: [{"id": "vlan-1", "name": "vlan1", "folder": "test-folder", "vlan_tag": "100"}])
+        test_app = typer.Typer()
+        test_app.command()(show_vlan_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder"])
+        assert result.exit_code == 0
+        assert "vlan1" in result.stdout
+
+    def test_show_vlan_interface_specific(self, runner, monkeypatch):
+        """Test show vlan-interface command shows a specific interface."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_vlan_interface", lambda **kwargs: {"id": "vlan-1", "name": "vlan1", "folder": "test-folder", "vlan_tag": "100", "ip": [{"name": "10.0.10.1/24"}]})
+        test_app = typer.Typer()
+        test_app.command()(show_vlan_interface)
+        result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "vlan1"])
+        assert result.exit_code == 0
+        assert "vlan1" in result.stdout
+        assert "100" in result.stdout
+
+    def test_delete_vlan_interface_command(self, runner, monkeypatch):
+        """Test delete vlan-interface command."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "get_vlan_interface", lambda **kwargs: {"id": "vlan-1", "name": "vlan1", "folder": "test-folder"})
+        monkeypatch.setattr(scm_client, "delete_vlan_interface", lambda **kwargs: None)
+        test_app = typer.Typer()
+        test_app.command()(delete_vlan_interface)
+        result = runner.invoke(test_app, ["vlan1", "--folder", "test-folder", "--force"])
+        assert result.exit_code == 0
+        assert "Deleted VLAN interface" in result.stdout
+
+    def test_load_vlan_interface_command(self, runner, monkeypatch, tmp_path):
+        """Test load vlan-interface command."""
+        import yaml
+
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_data = {"vlan_interfaces": [{"name": "vlan1", "folder": "test-folder", "vlan_tag": "100", "ip": [{"name": "10.0.10.1/24"}]}]}
+        yaml_file = tmp_path / "vlan-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        monkeypatch.setattr(scm_client, "create_vlan_interface", lambda d: {**d, "id": "vlan-12345", "__action__": "created"})
+        test_app = typer.Typer()
+        test_app.command()(load_vlan_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file)])
+        assert result.exit_code == 0
+        assert "Created VLAN interface" in result.stdout
+
+    def test_load_vlan_interface_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test load vlan-interface command with dry-run."""
+        import yaml
+
+        yaml_data = {"vlan_interfaces": [{"name": "vlan1", "folder": "test-folder"}]}
+        yaml_file = tmp_path / "vlan-interfaces.yaml"
+        with yaml_file.open("w") as f:
+            yaml.dump(yaml_data, f)
+
+        test_app = typer.Typer()
+        test_app.command()(load_vlan_interface)
+        result = runner.invoke(test_app, ["--file", str(yaml_file), "--dry-run"])
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,17 +8,24 @@ from scm_cli.utils.validators import (
     AggregateInterface,
     BandwidthAllocation,
     BGPRouting,
+    DhcpInterface,
     DNSSecurityProfile,
+    EthernetInterface,
     IKECryptoProfile,
     IKEGateway,
     InternalDNSServer,
     IPSecCryptoProfile,
+    Layer2Subinterface,
+    Layer3Subinterface,
+    LoopbackInterface,
     NATRule,
     QuarantinedDevice,
     Region,
     Schedule,
     SecurityRule,
+    TunnelInterface,
     URLCategory,
+    VlanInterface,
     VulnerabilityProtectionProfile,
     WildfireAntivirusProfile,
     Zone,
@@ -1766,3 +1773,488 @@ class TestAggregateInterface:
         assert iface.layer2 is None
         assert iface.layer3 is None
         assert iface.comment is None
+
+
+class TestDhcpInterface:
+    """Test cases for the DhcpInterface model."""
+
+    def test_valid_server(self):
+        """Test creating a valid DHCP server interface."""
+        iface = DhcpInterface(
+            name="ethernet1/1",
+            folder="test-folder",
+            server={"mode": "auto", "ip_pool": ["10.0.0.10-10.0.0.100"]},
+        )
+        assert iface.name == "ethernet1/1"
+        assert iface.server is not None
+        assert iface.relay is None
+
+    def test_valid_relay(self):
+        """Test creating a valid DHCP relay interface."""
+        iface = DhcpInterface(
+            name="ethernet1/2",
+            folder="test-folder",
+            relay={"ip": {"enabled": True, "server": ["10.0.0.1"]}},
+        )
+        assert iface.relay is not None
+        assert iface.server is None
+
+    def test_missing_name_raises(self):
+        """Test that missing name raises error."""
+        with pytest.raises(ValidationError):
+            DhcpInterface(folder="test-folder")
+
+    def test_no_container_raises(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            DhcpInterface(name="ethernet1/1")
+
+    def test_multiple_containers_raises(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            DhcpInterface(name="ethernet1/1", folder="f", snippet="s")
+
+    def test_both_server_relay_raises(self):
+        """Test that specifying both server and relay raises error."""
+        with pytest.raises(ValidationError):
+            DhcpInterface(
+                name="ethernet1/1",
+                folder="test-folder",
+                server={"mode": "auto"},
+                relay={"ip": {"enabled": True, "server": ["10.0.0.1"]}},
+            )
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        iface = DhcpInterface(
+            name="ethernet1/1",
+            folder="test-folder",
+            server={"mode": "auto", "ip_pool": ["10.0.0.10-10.0.0.100"]},
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["name"] == "ethernet1/1"
+        assert sdk_data["folder"] == "test-folder"
+        assert sdk_data["server"]["mode"] == "auto"
+
+    def test_minimal_creation(self):
+        """Test minimal DHCP interface creation."""
+        iface = DhcpInterface(name="ethernet1/1", folder="test-folder")
+        assert iface.name == "ethernet1/1"
+        assert iface.server is None
+        assert iface.relay is None
+
+
+class TestEthernetInterface:
+    """Test cases for the EthernetInterface model."""
+
+    def test_valid_layer3(self):
+        """Test creating a valid layer3 ethernet interface."""
+        iface = EthernetInterface(
+            name="$eth1",
+            folder="test-folder",
+            layer3={"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]},
+        )
+        assert iface.name == "$eth1"
+        assert iface.layer3 is not None
+        assert iface.layer2 is None
+
+    def test_valid_layer2(self):
+        """Test creating a valid layer2 ethernet interface."""
+        iface = EthernetInterface(
+            name="$eth2",
+            folder="test-folder",
+            layer2={"vlan_tag": "100"},
+        )
+        assert iface.layer2 is not None
+        assert iface.layer3 is None
+
+    def test_missing_name_raises(self):
+        """Test that missing name raises error."""
+        with pytest.raises(ValidationError):
+            EthernetInterface(folder="test-folder")
+
+    def test_no_container_raises(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            EthernetInterface(name="$eth1")
+
+    def test_multiple_containers_raises(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            EthernetInterface(name="$eth1", folder="f", snippet="s")
+
+    def test_multiple_modes_raises(self):
+        """Test that specifying multiple modes raises error."""
+        with pytest.raises(ValidationError):
+            EthernetInterface(
+                name="$eth1",
+                folder="test-folder",
+                layer2={"vlan_tag": "100"},
+                layer3={"mtu": 1500},
+            )
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        iface = EthernetInterface(
+            name="$eth1",
+            folder="test-folder",
+            comment="test eth",
+            layer3={"mtu": 9000},
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["name"] == "$eth1"
+        assert sdk_data["folder"] == "test-folder"
+        assert sdk_data["comment"] == "test eth"
+        assert sdk_data["layer3"]["mtu"] == 9000
+
+    def test_minimal_creation(self):
+        """Test minimal ethernet interface creation."""
+        iface = EthernetInterface(name="$eth1", folder="test-folder")
+        assert iface.name == "$eth1"
+        assert iface.layer2 is None
+        assert iface.layer3 is None
+        assert iface.tap is None
+
+
+class TestLayer2Subinterface:
+    """Test cases for the Layer2Subinterface model."""
+
+    def test_valid_creation(self):
+        """Test creating a valid layer2 subinterface."""
+        iface = Layer2Subinterface(
+            name="ethernet1/1.100",
+            folder="test-folder",
+            vlan_tag="100",
+        )
+        assert iface.name == "ethernet1/1.100"
+        assert iface.vlan_tag == "100"
+
+    def test_with_parent(self):
+        """Test layer2 subinterface with parent interface."""
+        iface = Layer2Subinterface(
+            name="ethernet1/1.100",
+            folder="test-folder",
+            vlan_tag="100",
+            parent_interface="ethernet1/1",
+        )
+        assert iface.parent_interface == "ethernet1/1"
+
+    def test_missing_vlan_tag_raises(self):
+        """Test that missing vlan_tag raises error."""
+        with pytest.raises(ValidationError):
+            Layer2Subinterface(name="ethernet1/1.100", folder="test-folder")
+
+    def test_missing_name_raises(self):
+        """Test that missing name raises error."""
+        with pytest.raises(ValidationError):
+            Layer2Subinterface(folder="test-folder", vlan_tag="100")
+
+    def test_no_container_raises(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            Layer2Subinterface(name="ethernet1/1.100", vlan_tag="100")
+
+    def test_multiple_containers_raises(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            Layer2Subinterface(name="ethernet1/1.100", vlan_tag="100", folder="f", snippet="s")
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        iface = Layer2Subinterface(
+            name="ethernet1/1.100",
+            folder="test-folder",
+            vlan_tag="100",
+            parent_interface="ethernet1/1",
+            comment="test sub",
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["name"] == "ethernet1/1.100"
+        assert sdk_data["vlan_tag"] == "100"
+        assert sdk_data["parent_interface"] == "ethernet1/1"
+        assert sdk_data["comment"] == "test sub"
+
+    def test_minimal_creation(self):
+        """Test minimal layer2 subinterface creation."""
+        iface = Layer2Subinterface(name="ethernet1/1.100", folder="test-folder", vlan_tag="100")
+        assert iface.parent_interface is None
+        assert iface.comment is None
+
+
+class TestLayer3Subinterface:
+    """Test cases for the Layer3Subinterface model."""
+
+    def test_valid_static_ip(self):
+        """Test creating a layer3 subinterface with static IP."""
+        iface = Layer3Subinterface(
+            name="ethernet1/1.100",
+            folder="test-folder",
+            tag=100,
+            ip=[{"name": "10.0.1.1/24"}],
+        )
+        assert iface.tag == 100
+        assert iface.ip == [{"name": "10.0.1.1/24"}]
+
+    def test_valid_dhcp(self):
+        """Test creating a layer3 subinterface with DHCP."""
+        iface = Layer3Subinterface(
+            name="ethernet1/1.200",
+            folder="test-folder",
+            dhcp_client={"enable": True},
+        )
+        assert iface.dhcp_client is not None
+        assert iface.ip is None
+
+    def test_missing_name_raises(self):
+        """Test that missing name raises error."""
+        with pytest.raises(ValidationError):
+            Layer3Subinterface(folder="test-folder")
+
+    def test_no_container_raises(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            Layer3Subinterface(name="ethernet1/1.100")
+
+    def test_multiple_containers_raises(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            Layer3Subinterface(name="ethernet1/1.100", folder="f", snippet="s")
+
+    def test_both_ip_modes_raises(self):
+        """Test that specifying both IP and DHCP raises error."""
+        with pytest.raises(ValidationError):
+            Layer3Subinterface(
+                name="ethernet1/1.100",
+                folder="test-folder",
+                ip=[{"name": "10.0.1.1/24"}],
+                dhcp_client={"enable": True},
+            )
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        iface = Layer3Subinterface(
+            name="ethernet1/1.100",
+            folder="test-folder",
+            tag=100,
+            mtu=9000,
+            ip=[{"name": "10.0.1.1/24"}],
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["name"] == "ethernet1/1.100"
+        assert sdk_data["tag"] == 100
+        assert sdk_data["mtu"] == 9000
+
+    def test_minimal_creation(self):
+        """Test minimal layer3 subinterface creation."""
+        iface = Layer3Subinterface(name="ethernet1/1.100", folder="test-folder")
+        assert iface.tag is None
+        assert iface.ip is None
+        assert iface.dhcp_client is None
+
+
+class TestLoopbackInterface:
+    """Test cases for the LoopbackInterface model."""
+
+    def test_valid_creation(self):
+        """Test creating a valid loopback interface."""
+        iface = LoopbackInterface(
+            name="$lo1",
+            folder="test-folder",
+            ip=[{"name": "10.0.0.1/32"}],
+        )
+        assert iface.name == "$lo1"
+        assert iface.ip == [{"name": "10.0.0.1/32"}]
+
+    def test_with_mtu(self):
+        """Test loopback interface with MTU."""
+        iface = LoopbackInterface(
+            name="$lo1",
+            folder="test-folder",
+            mtu=9000,
+        )
+        assert iface.mtu == 9000
+
+    def test_missing_name_raises(self):
+        """Test that missing name raises error."""
+        with pytest.raises(ValidationError):
+            LoopbackInterface(folder="test-folder")
+
+    def test_no_container_raises(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            LoopbackInterface(name="$lo1")
+
+    def test_multiple_containers_raises(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            LoopbackInterface(name="$lo1", folder="f", snippet="s")
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        iface = LoopbackInterface(
+            name="$lo1",
+            folder="test-folder",
+            comment="test lo",
+            ip=[{"name": "10.0.0.1/32"}],
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["name"] == "$lo1"
+        assert sdk_data["folder"] == "test-folder"
+        assert sdk_data["comment"] == "test lo"
+
+    def test_to_sdk_model_with_ipv6(self):
+        """Test conversion with IPv6 config."""
+        iface = LoopbackInterface(
+            name="$lo1",
+            folder="test-folder",
+            ipv6={"enabled": True},
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["ipv6"] == {"enabled": True}
+
+    def test_minimal_creation(self):
+        """Test minimal loopback interface creation."""
+        iface = LoopbackInterface(name="$lo1", folder="test-folder")
+        assert iface.ip is None
+        assert iface.mtu is None
+        assert iface.comment is None
+
+
+class TestTunnelInterface:
+    """Test cases for the TunnelInterface model."""
+
+    def test_valid_creation(self):
+        """Test creating a valid tunnel interface."""
+        iface = TunnelInterface(
+            name="tunnel1",
+            folder="test-folder",
+            ip=[{"name": "10.0.0.1/30"}],
+        )
+        assert iface.name == "tunnel1"
+        assert iface.ip == [{"name": "10.0.0.1/30"}]
+
+    def test_with_mtu(self):
+        """Test tunnel interface with MTU."""
+        iface = TunnelInterface(
+            name="tunnel1",
+            folder="test-folder",
+            mtu=1400,
+        )
+        assert iface.mtu == 1400
+
+    def test_missing_name_raises(self):
+        """Test that missing name raises error."""
+        with pytest.raises(ValidationError):
+            TunnelInterface(folder="test-folder")
+
+    def test_no_container_raises(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            TunnelInterface(name="tunnel1")
+
+    def test_multiple_containers_raises(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            TunnelInterface(name="tunnel1", folder="f", snippet="s")
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        iface = TunnelInterface(
+            name="tunnel1",
+            folder="test-folder",
+            comment="test tunnel",
+            mtu=1400,
+            ip=[{"name": "10.0.0.1/30"}],
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["name"] == "tunnel1"
+        assert sdk_data["folder"] == "test-folder"
+        assert sdk_data["mtu"] == 1400
+
+    def test_to_sdk_model_default_value(self):
+        """Test conversion with default_value."""
+        iface = TunnelInterface(
+            name="tunnel1",
+            folder="test-folder",
+            default_value="tunnel.1",
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["default_value"] == "tunnel.1"
+
+    def test_minimal_creation(self):
+        """Test minimal tunnel interface creation."""
+        iface = TunnelInterface(name="tunnel1", folder="test-folder")
+        assert iface.ip is None
+        assert iface.mtu is None
+        assert iface.comment is None
+
+
+class TestVlanInterface:
+    """Test cases for the VlanInterface model."""
+
+    def test_valid_static_ip(self):
+        """Test creating a VLAN interface with static IP."""
+        iface = VlanInterface(
+            name="vlan1",
+            folder="test-folder",
+            vlan_tag="100",
+            ip=[{"name": "10.0.10.1/24"}],
+        )
+        assert iface.vlan_tag == "100"
+        assert iface.ip == [{"name": "10.0.10.1/24"}]
+
+    def test_valid_dhcp(self):
+        """Test creating a VLAN interface with DHCP."""
+        iface = VlanInterface(
+            name="vlan2",
+            folder="test-folder",
+            dhcp_client={"enable": True},
+        )
+        assert iface.dhcp_client is not None
+        assert iface.ip is None
+
+    def test_missing_name_raises(self):
+        """Test that missing name raises error."""
+        with pytest.raises(ValidationError):
+            VlanInterface(folder="test-folder")
+
+    def test_no_container_raises(self):
+        """Test that missing container raises error."""
+        with pytest.raises(ValidationError):
+            VlanInterface(name="vlan1")
+
+    def test_multiple_containers_raises(self):
+        """Test that multiple containers raises error."""
+        with pytest.raises(ValidationError):
+            VlanInterface(name="vlan1", folder="f", snippet="s")
+
+    def test_both_ip_modes_raises(self):
+        """Test that specifying both IP and DHCP raises error."""
+        with pytest.raises(ValidationError):
+            VlanInterface(
+                name="vlan1",
+                folder="test-folder",
+                ip=[{"name": "10.0.10.1/24"}],
+                dhcp_client={"enable": True},
+            )
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        iface = VlanInterface(
+            name="vlan1",
+            folder="test-folder",
+            vlan_tag="100",
+            comment="test vlan",
+            ip=[{"name": "10.0.10.1/24"}],
+        )
+        sdk_data = iface.to_sdk_model()
+        assert sdk_data["name"] == "vlan1"
+        assert sdk_data["vlan_tag"] == "100"
+        assert sdk_data["comment"] == "test vlan"
+
+    def test_minimal_creation(self):
+        """Test minimal VLAN interface creation."""
+        iface = VlanInterface(name="vlan1", folder="test-folder")
+        assert iface.vlan_tag is None
+        assert iface.ip is None
+        assert iface.dhcp_client is None


### PR DESCRIPTION
## Summary
- 7 new interface types for SDK 0.12.0 parity
- DHCP (#71), ethernet (#72), layer2 subinterface (#73), layer3 subinterface (#74), loopback (#75), tunnel (#76), VLAN (#77)
- Each with full set/show/delete/load/backup commands

## Changes
- 7 Pydantic validators with container validation + mode exclusivity
- 28 SDK client methods (4 per type) with smart upsert + mock
- 35 CLI commands (5 per type)
- 56 new validator tests (all pass), 49 command tests
- Version 0.5.3 → 0.5.10

## Testing
- 199 validator tests pass (up from 143)
- 7 pre-existing failures unchanged

Closes #71, closes #72, closes #73, closes #74, closes #75, closes #76, closes #77