### PR TITLE
docs: use gear logo on homepage

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -64,20 +64,14 @@
 }
 
 .hero-logo {
-  width: 320px;
-  max-width: 80%;
-  height: auto;
+  width: 120px;
+  height: 120px;
   margin-bottom: 0.5rem;
   filter: drop-shadow(0 4px 12px rgba(248, 182, 32, 0.25));
 }
 
 [data-md-color-scheme="slate"] .hero-logo {
   filter: drop-shadow(0 4px 12px rgba(248, 182, 32, 0.4));
-}
-
-/* Invert dark text in banner SVG for dark mode */
-[data-md-color-scheme="slate"] .hero-logo .cls-3 {
-  fill: #fff;
 }
 
 /* ── Admonition accent colors ─────────────────────────────────────── */

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: Home
 
 <div class="hero" markdown>
 
-![SCM CLI Banner](images/logo - banner.svg){ .hero-logo }
+![SCM CLI Logo](images/logo.svg){ .hero-logo }
 
 # pan-scm-cli
 


### PR DESCRIPTION
## Summary
- Swap hero image from banner SVG to gear logo SVG
- Resize hero-logo to 120x120 for square icon
- Remove unused dark-mode banner text inversion rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)