### PR TITLE
docs: restore banner as homepage hero

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -64,14 +64,20 @@
 }
 
 .hero-logo {
-  width: 120px;
-  height: 120px;
+  width: 320px;
+  max-width: 80%;
+  height: auto;
   margin-bottom: 0.5rem;
   filter: drop-shadow(0 4px 12px rgba(248, 182, 32, 0.25));
 }
 
 [data-md-color-scheme="slate"] .hero-logo {
   filter: drop-shadow(0 4px 12px rgba(248, 182, 32, 0.4));
+}
+
+/* Invert dark text in banner SVG for dark mode */
+[data-md-color-scheme="slate"] .hero-logo .cls-3 {
+  fill: #fff;
 }
 
 /* ── Admonition accent colors ─────────────────────────────────────── */

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: Home
 
 <div class="hero" markdown>
 
-![SCM CLI Logo](images/logo.svg){ .hero-logo }
+![SCM CLI Banner](images/logo - banner.svg){ .hero-logo }
 
 # pan-scm-cli
 


### PR DESCRIPTION
## Summary
- Restore banner SVG (gear + text) as homepage hero image
- Resize hero-logo back to 320px wide for banner aspect ratio
- Re-add dark mode text inversion for banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)