### PR TITLE
docs: standardize Setup CLI reference pages

### DIFF
--- a/docs/cli/setup/device.md
+++ b/docs/cli/setup/device.md
@@ -1,8 +1,12 @@
 # Device
 
-Devices represent managed firewall appliances. Device management is read-only through the CLI.
+Devices represent managed firewall appliances in Strata Cloud Manager. Device management is read-only through the CLI.
 
 ## Show Device
+
+Display devices.
+
+### Syntax
 
 ```bash
 scm show setup device [OPTIONS]
@@ -17,16 +21,65 @@ scm show setup device [OPTIONS]
 
 ### Examples
 
+#### List All Devices
+
 ```bash
-# List all devices
 $ scm show setup device
+---> 100%
+Devices (3):
+--------------------------------------------------------------------------------
+Name: PA-VM-01
+  Serial: 012345678901
+  Model: PA-VM
+  Folder: Texas
+  Connected: True
+--------------------------------------------------------------------------------
+Name: PA-3260-01
+  Serial: 098765432109
+  Model: PA-3260
+  Folder: Austin
+  Connected: True
+--------------------------------------------------------------------------------
+```
 
-# Show a specific device
+#### Show a Specific Device
+
+```bash
 $ scm show setup device --name "PA-VM-01"
+---> 100%
+Device: PA-VM-01
+================================================================================
+Serial Number: 012345678901
+Model: PA-VM
+Family: vm
+Hostname: PA-VM-01
+IP Address: 10.0.1.100
+Folder: Texas
+Software Version: 11.1.0
+Connected: True
+```
 
-# Filter by folder
+#### Filter by Folder
+
+```bash
 $ scm show setup device --folder Texas
+---> 100%
+Devices (2):
+--------------------------------------------------------------------------------
+Name: PA-VM-01
+  Serial: 012345678901
+  Model: PA-VM
+  Folder: Texas
+  Connected: True
+--------------------------------------------------------------------------------
+Name: PA-VM-02
+  Serial: 012345678902
+  Model: PA-VM
+  Folder: Texas
+  Connected: False
+--------------------------------------------------------------------------------
 ```
 
 !!! note
-    Device management is read-only. Devices cannot be created, updated, or deleted through the CLI.
+    Device management is read-only. Devices cannot be created, updated, or deleted
+    through the CLI.

--- a/docs/cli/setup/folder.md
+++ b/docs/cli/setup/folder.md
@@ -1,8 +1,22 @@
 # Folder
 
-Folders organize configurations hierarchically in Strata Cloud Manager.
+Folders organize configurations hierarchically in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, list, bulk import, and back up folders.
+
+## Overview
+
+The `folder` commands allow you to:
+
+- Create folders with a parent hierarchy and optional labels
+- Update existing folder configurations
+- Delete folders that are no longer needed
+- Bulk import folders from YAML files
+- Export folders for backup or migration
 
 ## Set Folder
+
+Create or update a folder.
+
+### Syntax
 
 ```bash
 scm set setup folder [OPTIONS]
@@ -20,27 +34,220 @@ scm set setup folder [OPTIONS]
 
 ### Examples
 
+#### Create a Top-Level Folder
+
 ```bash
-$ scm set setup folder --name Texas --parent "All"
-$ scm set setup folder --name Branch --parent Texas --description "Branch offices"
+$ scm set setup folder \
+    --name Texas \
+    --parent "All"
+---> 100%
+Created folder: Texas (parent: All)
 ```
 
-## Show Folder
+#### Create a Child Folder with Description
 
 ```bash
-scm show setup folder
-scm show setup folder --name Texas
+$ scm set setup folder \
+    --name Branch \
+    --parent Texas \
+    --description "Branch offices"
+---> 100%
+Created folder: Branch (parent: Texas)
+```
+
+#### Create a Folder with Labels
+
+```bash
+$ scm set setup folder \
+    --name Austin \
+    --parent Texas \
+    --labels production \
+    --labels west-region
+---> 100%
+Created folder: Austin (parent: Texas)
 ```
 
 ## Delete Folder
 
-```bash
-scm delete setup folder --name Branch
-```
+Delete a folder from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load setup folder --file folders.yaml
-scm backup setup folder
+scm delete setup folder [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the folder to delete | Yes |
+
+### Example
+
+```bash
+$ scm delete setup folder --name Branch
+---> 100%
+Deleted folder: Branch
+```
+
+## Load Folder
+
+Load multiple folders from a YAML file.
+
+### Syntax
+
+```bash
+scm load setup folder [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file PATH` | YAML file to load configurations from | Yes |
+| `--dry-run` | Simulate execution without applying changes | No |
+
+### YAML File Format
+
+```yaml
+---
+folders:
+  - name: Texas
+    parent: "All"
+    description: "Texas regional office"
+
+  - name: Austin
+    parent: Texas
+    description: "Austin branch"
+    labels:
+      - production
+```
+
+### Examples
+
+#### Load Folders from File
+
+```bash
+$ scm load setup folder --file folders.yaml
+---> 100%
+✓ Loaded folder: Texas
+✓ Loaded folder: Austin
+
+Processed 2 folders from folders.yaml
+```
+
+#### Dry Run
+
+```bash
+$ scm load setup folder --file folders.yaml --dry-run
+---> 100%
+Dry run mode: would apply the following configurations:
+- name: Texas
+  parent: All
+  description: Texas regional office
+- name: Austin
+  parent: Texas
+  description: Austin branch
+```
+
+## Show Folder
+
+Display folder objects.
+
+### Syntax
+
+```bash
+scm show setup folder [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the folder to show | No |
+
+!!! note
+    When no `--name` is specified, all folders are listed by default.
+
+### Examples
+
+#### Show Specific Folder
+
+```bash
+$ scm show setup folder --name Texas
+---> 100%
+Folder: Texas
+================================================================================
+Parent: All
+Description: Texas regional office
+Labels: production, west-region
+```
+
+#### List All Folders (Default Behavior)
+
+```bash
+$ scm show setup folder
+---> 100%
+Folders (3):
+--------------------------------------------------------------------------------
+Name: All
+  Parent: N/A
+--------------------------------------------------------------------------------
+Name: Texas
+  Parent: All
+  Description: Texas regional office
+--------------------------------------------------------------------------------
+Name: Austin
+  Parent: Texas
+  Description: Austin branch
+--------------------------------------------------------------------------------
+```
+
+## Backup Folders
+
+Backup all folder objects to a YAML file.
+
+### Syntax
+
+```bash
+scm backup setup folder [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Output filename for backup | No |
+
+### Examples
+
+#### Backup with Default Filename
+
+```bash
+$ scm backup setup folder
+---> 100%
+Successfully backed up 12 folders to folders_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup setup folder --file my-folders.yaml
+---> 100%
+Successfully backed up 12 folders to my-folders.yaml
+```
+
+## Best Practices
+
+1. **Plan Your Hierarchy**: Design the folder structure before creating folders to avoid reorganization later.
+2. **Use Descriptive Names**: Choose folder names that clearly indicate their purpose or geographic scope.
+3. **Apply Labels Consistently**: Use labels to categorize folders for easier filtering and management.
+4. **Back Up Before Changes**: Export your folder structure before making significant modifications.
+5. **Use Dry Run for Bulk Imports**: Always preview bulk imports with `--dry-run` before applying changes.
+
+## Related Topics
+
+- [Label](label.md)
+- [Snippet](snippet.md)
+- [Variable](variable.md)

--- a/docs/cli/setup/label.md
+++ b/docs/cli/setup/label.md
@@ -1,8 +1,22 @@
 # Label
 
-Labels provide metadata tags for organizing folders and resources in SCM.
+Labels provide metadata tags for organizing folders and resources in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, list, bulk import, and back up labels.
+
+## Overview
+
+The `label` commands allow you to:
+
+- Create labels with optional descriptions
+- Update existing label configurations
+- Delete labels that are no longer needed
+- Bulk import labels from YAML files
+- Export labels for backup or migration
 
 ## Set Label
+
+Create or update a label.
+
+### Syntax
 
 ```bash
 scm set setup label [OPTIONS]
@@ -17,27 +31,194 @@ scm set setup label [OPTIONS]
 
 ### Examples
 
+#### Create a Simple Label
+
 ```bash
 $ scm set setup label --name production
-$ scm set setup label --name staging --description "Staging environment"
+---> 100%
+Created label: production
 ```
 
-## Show Label
+#### Create a Label with Description
 
 ```bash
-scm show setup label
-scm show setup label --name production
+$ scm set setup label \
+    --name staging \
+    --description "Staging environment"
+---> 100%
+Created label: staging
 ```
 
 ## Delete Label
 
-```bash
-scm delete setup label --name staging
-```
+Delete a label from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load setup label --file labels.yaml
-scm backup setup label
+scm delete setup label [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the label to delete | Yes |
+
+### Example
+
+```bash
+$ scm delete setup label --name staging
+---> 100%
+Deleted label: staging
+```
+
+## Load Label
+
+Load multiple labels from a YAML file.
+
+### Syntax
+
+```bash
+scm load setup label [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file PATH` | YAML file to load configurations from | Yes |
+| `--dry-run` | Simulate execution without applying changes | No |
+
+### YAML File Format
+
+```yaml
+---
+labels:
+  - name: production
+    description: "Production environment"
+
+  - name: staging
+    description: "Staging environment"
+```
+
+### Examples
+
+#### Load Labels from File
+
+```bash
+$ scm load setup label --file labels.yaml
+---> 100%
+✓ Loaded label: production
+✓ Loaded label: staging
+
+Processed 2 labels from labels.yaml
+```
+
+#### Dry Run
+
+```bash
+$ scm load setup label --file labels.yaml --dry-run
+---> 100%
+Dry run mode: would apply the following configurations:
+- name: production
+  description: Production environment
+- name: staging
+  description: Staging environment
+```
+
+## Show Label
+
+Display label objects.
+
+### Syntax
+
+```bash
+scm show setup label [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the label to show | No |
+
+!!! note
+    When no `--name` is specified, all labels are listed by default.
+
+### Examples
+
+#### Show Specific Label
+
+```bash
+$ scm show setup label --name production
+---> 100%
+Label: production
+================================================================================
+Description: Production environment
+```
+
+#### List All Labels (Default Behavior)
+
+```bash
+$ scm show setup label
+---> 100%
+Labels (3):
+--------------------------------------------------------------------------------
+Name: production
+  Description: Production environment
+--------------------------------------------------------------------------------
+Name: staging
+  Description: Staging environment
+--------------------------------------------------------------------------------
+Name: development
+  Description: Development environment
+--------------------------------------------------------------------------------
+```
+
+## Backup Labels
+
+Backup all label objects to a YAML file.
+
+### Syntax
+
+```bash
+scm backup setup label [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Output filename for backup | No |
+
+### Examples
+
+#### Backup with Default Filename
+
+```bash
+$ scm backup setup label
+---> 100%
+Successfully backed up 5 labels to labels_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup setup label --file my-labels.yaml
+---> 100%
+Successfully backed up 5 labels to my-labels.yaml
+```
+
+## Best Practices
+
+1. **Use Consistent Naming**: Adopt a naming convention for labels (e.g., lowercase with hyphens) and apply it uniformly.
+2. **Add Descriptions**: Include descriptions to clarify each label's purpose for team members.
+3. **Back Up Regularly**: Export labels before making bulk changes to preserve your organization scheme.
+4. **Use Dry Run for Bulk Imports**: Preview bulk imports with `--dry-run` before applying changes.
+
+## Related Topics
+
+- [Folder](folder.md)
+- [Snippet](snippet.md)
+- [Variable](variable.md)

--- a/docs/cli/setup/snippet.md
+++ b/docs/cli/setup/snippet.md
@@ -1,8 +1,22 @@
 # Snippet
 
-Snippets are reusable configuration templates that can be shared across multiple folders.
+Snippets are reusable configuration templates that can be shared across multiple folders in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, list, bulk import, and back up snippets.
+
+## Overview
+
+The `snippet` commands allow you to:
+
+- Create snippets with optional labels and prefix settings
+- Update existing snippet configurations
+- Delete snippets that are no longer needed
+- Bulk import snippets from YAML files
+- Export snippets for backup or migration
 
 ## Set Snippet
+
+Create or update a snippet.
+
+### Syntax
 
 ```bash
 scm set setup snippet [OPTIONS]
@@ -19,27 +33,219 @@ scm set setup snippet [OPTIONS]
 
 ### Examples
 
+#### Create a Simple Snippet
+
 ```bash
 $ scm set setup snippet --name "DNS-Best-Practice"
-$ scm set setup snippet --name "Web-Security" --description "Web security config" --labels prod
+---> 100%
+Created snippet: DNS-Best-Practice
 ```
 
-## Show Snippet
+#### Create a Snippet with Description and Labels
 
 ```bash
-scm show setup snippet
-scm show setup snippet --name "DNS-Best-Practice"
+$ scm set setup snippet \
+    --name "Web-Security" \
+    --description "Web security config" \
+    --labels prod
+---> 100%
+Created snippet: Web-Security
+```
+
+#### Create a Snippet with Prefix Enabled
+
+```bash
+$ scm set setup snippet \
+    --name "Branch-Template" \
+    --description "Standard branch config" \
+    --enable-prefix
+---> 100%
+Created snippet: Branch-Template
 ```
 
 ## Delete Snippet
 
-```bash
-scm delete setup snippet --name "DNS-Best-Practice"
-```
+Delete a snippet from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load setup snippet --file snippets.yaml
-scm backup setup snippet
+scm delete setup snippet [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the snippet to delete | Yes |
+
+### Example
+
+```bash
+$ scm delete setup snippet --name "DNS-Best-Practice"
+---> 100%
+Deleted snippet: DNS-Best-Practice
+```
+
+## Load Snippet
+
+Load multiple snippets from a YAML file.
+
+### Syntax
+
+```bash
+scm load setup snippet [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file PATH` | YAML file to load configurations from | Yes |
+| `--dry-run` | Simulate execution without applying changes | No |
+
+### YAML File Format
+
+```yaml
+---
+snippets:
+  - name: DNS-Best-Practice
+    description: "DNS security best practices"
+
+  - name: Web-Security
+    description: "Web security config"
+    labels:
+      - prod
+    enable_prefix: true
+```
+
+### Examples
+
+#### Load Snippets from File
+
+```bash
+$ scm load setup snippet --file snippets.yaml
+---> 100%
+✓ Loaded snippet: DNS-Best-Practice
+✓ Loaded snippet: Web-Security
+
+Processed 2 snippets from snippets.yaml
+```
+
+#### Dry Run
+
+```bash
+$ scm load setup snippet --file snippets.yaml --dry-run
+---> 100%
+Dry run mode: would apply the following configurations:
+- name: DNS-Best-Practice
+  description: DNS security best practices
+- name: Web-Security
+  description: Web security config
+  labels:
+    - prod
+  enable_prefix: true
+```
+
+## Show Snippet
+
+Display snippet objects.
+
+### Syntax
+
+```bash
+scm show setup snippet [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the snippet to show | No |
+
+!!! note
+    When no `--name` is specified, all snippets are listed by default.
+
+### Examples
+
+#### Show Specific Snippet
+
+```bash
+$ scm show setup snippet --name "DNS-Best-Practice"
+---> 100%
+Snippet: DNS-Best-Practice
+================================================================================
+Description: DNS security best practices
+Type: predefined
+Labels: prod
+Enable Prefix: true
+```
+
+#### List All Snippets (Default Behavior)
+
+```bash
+$ scm show setup snippet
+---> 100%
+Snippets (3):
+--------------------------------------------------------------------------------
+Name: DNS-Best-Practice
+  Description: DNS security best practices
+  Type: predefined
+--------------------------------------------------------------------------------
+Name: Web-Security
+  Description: Web security config
+  Type: custom
+--------------------------------------------------------------------------------
+Name: Branch-Template
+  Description: Standard branch config
+  Type: custom
+--------------------------------------------------------------------------------
+```
+
+## Backup Snippets
+
+Backup all snippet objects to a YAML file.
+
+### Syntax
+
+```bash
+scm backup setup snippet [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Output filename for backup | No |
+
+### Examples
+
+#### Backup with Default Filename
+
+```bash
+$ scm backup setup snippet
+---> 100%
+Successfully backed up 8 snippets to snippets_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup setup snippet --file my-snippets.yaml
+---> 100%
+Successfully backed up 8 snippets to my-snippets.yaml
+```
+
+## Best Practices
+
+1. **Use Descriptive Names**: Choose snippet names that clearly indicate the configuration purpose.
+2. **Apply Labels for Organization**: Use labels to categorize snippets by function or environment.
+3. **Enable Prefix When Sharing**: Use `--enable-prefix` when snippets are shared across folders to avoid naming conflicts.
+4. **Back Up Before Changes**: Export your snippets before making significant modifications.
+5. **Use Dry Run for Bulk Imports**: Preview bulk imports with `--dry-run` before applying changes.
+
+## Related Topics
+
+- [Folder](folder.md)
+- [Label](label.md)
+- [Variable](variable.md)

--- a/docs/cli/setup/variable.md
+++ b/docs/cli/setup/variable.md
@@ -1,8 +1,36 @@
 # Variable
 
-Variables define reusable values scoped to folders, snippets, or devices. Variable names must start with `$`.
+Variables define reusable values scoped to folders, snippets, or devices in Strata Cloud Manager. Variable names must start with `$`. The `scm` CLI provides commands to create, update, delete, list, bulk import, and back up variables.
+
+## Overview
+
+The `variable` commands allow you to:
+
+- Create variables with typed values scoped to a container
+- Update existing variable configurations
+- Delete variables that are no longer needed
+- Bulk import variables from YAML files
+- Export variables for backup or migration
+
+## Variable Types
+
+| Type | Description | Example Value |
+| --- | --- | --- |
+| `percent` | Percentage value | `80` |
+| `count` | Numeric count | `100` |
+| `ip-netmask` | IP address with netmask | `192.168.1.0/24` |
+| `zone` | Security zone name | `trust` |
+| `ip-range` | IP address range | `192.168.1.1-192.168.1.254` |
+| `ip-wildcard` | Wildcard IP pattern | `10.0.0.0/0.0.255.255` |
+| `fqdn` | Fully qualified domain name | `dns.example.com` |
+| `port` | Port number | `8080` |
+| `egress-max` | Maximum egress bandwidth | `1000` |
 
 ## Set Variable
+
+Create or update a variable.
+
+### Syntax
 
 ```bash
 scm set setup variable [OPTIONS]
@@ -12,39 +40,267 @@ scm set setup variable [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--name TEXT` | Variable name (e.g., $egress-max) | Yes |
-| `--type TEXT` | Variable type (percent, count, ip-netmask, zone, ip-range, ip-wildcard, fqdn, port, egress-max) | Yes |
+| `--name TEXT` | Variable name (must start with $) | Yes |
+| `--type TEXT` | Variable type | Yes |
 | `--value TEXT` | Variable value | Yes |
-| `--folder TEXT` | Folder scope | No* |
-| `--snippet TEXT` | Snippet scope | No* |
-| `--device TEXT` | Device scope | No* |
+| `--folder TEXT` | Folder scope | No\* |
+| `--snippet TEXT` | Snippet scope | No\* |
+| `--device TEXT` | Device scope | No\* |
 | `--description TEXT` | Description | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Examples
 
+#### Create an Egress Max Variable
+
 ```bash
-$ scm set setup variable --name "\$egress-max" --type egress-max --value 1000 --folder Texas
-$ scm set setup variable --name "\$dns-server" --type fqdn --value dns.example.com --snippet "DNS-Config"
+$ scm set setup variable \
+    --name "\$egress-max" \
+    --type egress-max \
+    --value 1000 \
+    --folder Texas
+---> 100%
+Created variable: $egress-max in folder Texas
 ```
 
-## Show Variable
+#### Create an FQDN Variable in a Snippet
 
 ```bash
-scm show setup variable --folder Texas
-scm show setup variable --folder Texas --name "\$egress-max"
+$ scm set setup variable \
+    --name "\$dns-server" \
+    --type fqdn \
+    --value dns.example.com \
+    --snippet "DNS-Config"
+---> 100%
+Created variable: $dns-server in snippet DNS-Config
+```
+
+#### Create a Variable with Description
+
+```bash
+$ scm set setup variable \
+    --name "\$web-port" \
+    --type port \
+    --value 8080 \
+    --folder Texas \
+    --description "Primary web server port"
+---> 100%
+Created variable: $web-port in folder Texas
 ```
 
 ## Delete Variable
 
-```bash
-scm delete setup variable --name "\$egress-max" --folder Texas
-```
+Delete a variable from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load setup variable --file variables.yaml
-scm backup setup variable --folder Texas
+scm delete setup variable [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the variable to delete | Yes |
+| `--folder TEXT` | Folder scope | No\* |
+| `--snippet TEXT` | Snippet scope | No\* |
+| `--device TEXT` | Device scope | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete setup variable --name "\$egress-max" --folder Texas
+---> 100%
+Deleted variable: $egress-max from folder Texas
+```
+
+## Load Variable
+
+Load multiple variables from a YAML file.
+
+### Syntax
+
+```bash
+scm load setup variable [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file PATH` | YAML file to load configurations from | Yes |
+| `--dry-run` | Simulate execution without applying changes | No |
+
+### YAML File Format
+
+```yaml
+---
+variables:
+  - name: "$egress-max"
+    type: egress-max
+    value: "1000"
+    folder: Texas
+    description: "Maximum egress bandwidth"
+
+  - name: "$dns-server"
+    type: fqdn
+    value: "dns.example.com"
+    snippet: "DNS-Config"
+```
+
+### Examples
+
+#### Load Variables from File
+
+```bash
+$ scm load setup variable --file variables.yaml
+---> 100%
+✓ Loaded variable: $egress-max
+✓ Loaded variable: $dns-server
+
+Processed 2 variables from variables.yaml
+```
+
+#### Dry Run
+
+```bash
+$ scm load setup variable --file variables.yaml --dry-run
+---> 100%
+Dry run mode: would apply the following configurations:
+- name: $egress-max
+  type: egress-max
+  value: '1000'
+  folder: Texas
+  description: Maximum egress bandwidth
+- name: $dns-server
+  type: fqdn
+  value: dns.example.com
+  snippet: DNS-Config
+```
+
+## Show Variable
+
+Display variable objects.
+
+### Syntax
+
+```bash
+scm show setup variable [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the variable to show | No |
+| `--folder TEXT` | Folder scope | No\* |
+| `--snippet TEXT` | Snippet scope | No\* |
+| `--device TEXT` | Device scope | No\* |
+
+\* One of --folder, --snippet, or --device is required when listing variables.
+
+!!! note
+    When no `--name` is specified, all variables in the specified container are listed
+    by default.
+
+### Examples
+
+#### Show Specific Variable
+
+```bash
+$ scm show setup variable --folder Texas --name "\$egress-max"
+---> 100%
+Variable: $egress-max
+================================================================================
+Type: egress-max
+Value: 1000
+Folder: Texas
+```
+
+#### List All Variables in a Folder (Default Behavior)
+
+```bash
+$ scm show setup variable --folder Texas
+---> 100%
+Variables (3):
+--------------------------------------------------------------------------------
+Name: $egress-max
+  Type: egress-max
+  Value: 1000
+--------------------------------------------------------------------------------
+Name: $web-port
+  Type: port
+  Value: 8080
+  Description: Primary web server port
+--------------------------------------------------------------------------------
+Name: $dns-server
+  Type: fqdn
+  Value: dns.example.com
+--------------------------------------------------------------------------------
+```
+
+## Backup Variables
+
+Backup variable objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup setup variable [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder scope | No\* |
+| `--snippet TEXT` | Snippet scope | No\* |
+| `--device TEXT` | Device scope | No\* |
+| `--file TEXT` | Output filename for backup | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup setup variable --folder Texas
+---> 100%
+Successfully backed up 5 variables to variables_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup setup variable --folder Texas --file texas-variables.yaml
+---> 100%
+Successfully backed up 5 variables to texas-variables.yaml
+```
+
+#### Backup from Snippet
+
+```bash
+$ scm backup setup variable --snippet "DNS-Config"
+---> 100%
+Successfully backed up 2 variables to variables_20240115_120545.yaml
+```
+
+## Best Practices
+
+1. **Use the `$` Prefix**: Always prefix variable names with `$` as required by SCM convention.
+2. **Choose Correct Types**: Select the variable type that matches the intended use to ensure proper validation.
+3. **Scope Appropriately**: Assign variables to the most specific container (folder, snippet, or device) needed.
+4. **Add Descriptions**: Include descriptions to document each variable's purpose for team members.
+5. **Back Up Before Changes**: Export your variables before making significant modifications.
+6. **Use Dry Run for Bulk Imports**: Preview bulk imports with `--dry-run` before applying changes.
+
+## Related Topics
+
+- [Folder](folder.md)
+- [Label](label.md)
+- [Snippet](snippet.md)


### PR DESCRIPTION
## Summary
- Rewrote all 5 setup CLI reference pages (`device.md`, `folder.md`, `label.md`, `snippet.md`, `variable.md`) to conform to the docs-style skill
- `device.md` uses Read-Only template; the other 4 use Full CRUD template with all operations as separate H2 sections
- Each operation has its own Syntax, Options, and Examples subsections with proper formatting (option tables, `$` prefixes, `---> 100%` progress, Unicode `✓`, backslash continuation, admonitions)

Closes #118

## Test plan
- [ ] Verify `make docs-build` passes with no warnings
- [ ] Spot-check each page renders correctly in MkDocs Material

🤖 Generated with [Claude Code](https://claude.com/claude-code)