### PR TITLE
docs: standardize Deployment CLI reference pages

### DIFF
--- a/docs/cli/deployment/bandwidth.md
+++ b/docs/cli/deployment/bandwidth.md
@@ -1,6 +1,16 @@
 # Bandwidth Allocation
 
-Bandwidth allocation allows you to control and optimize bandwidth usage across your network. The `scm` CLI provides commands to create, update, delete, and load bandwidth allocation configurations.
+Bandwidth allocations control and optimize bandwidth usage across your SASE network by defining guaranteed and maximum bandwidth limits. The `scm` CLI provides commands to create, update, delete, and bulk load bandwidth allocation configurations.
+
+## Overview
+
+The `bandwidth` commands allow you to:
+
+- Create bandwidth allocations with guaranteed and maximum bandwidth limits
+- Assign allocations to specific Service Provider Networks (SPNs)
+- Delete bandwidth allocations that are no longer needed
+- Bulk import bandwidth allocations from YAML files
+- List all bandwidth allocations in a folder
 
 ## Set Bandwidth Allocation
 
@@ -14,46 +24,69 @@ scm set sase bandwidth [OPTIONS]
 
 ### Options
 
-| Option                         | Description                                       | Required |
-| ------------------------------ | ------------------------------------------------- | -------- |
-| `--folder TEXT`                | Folder for the bandwidth allocation               | Yes      |
-| `--name TEXT`                  | Name of the bandwidth allocation                  | Yes      |
-| `--description TEXT`           | Description for the bandwidth allocation          | No       |
-| `--tags LIST`                  | List of tags to apply to the bandwidth allocation | No       |
-| `--egress-guaranteed INTEGER`  | Guaranteed egress bandwidth in Mbps               | Yes      |
-| `--egress-max INTEGER`         | Maximum egress bandwidth in Mbps                  | Yes      |
-| `--ingress-guaranteed INTEGER` | Guaranteed ingress bandwidth in Mbps              | Yes      |
-| `--ingress-max INTEGER`        | Maximum ingress bandwidth in Mbps                 | Yes      |
-| `--spn-name-list LIST`         | List of SPN names to apply this allocation to     | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder for the bandwidth allocation | Yes |
+| `--name TEXT` | Name of the bandwidth allocation | Yes |
+| `--egress-guaranteed INT` | Guaranteed egress bandwidth in Mbps | Yes |
+| `--egress-max INT` | Maximum egress bandwidth in Mbps | Yes |
+| `--ingress-guaranteed INT` | Guaranteed ingress bandwidth in Mbps | Yes |
+| `--ingress-max INT` | Maximum ingress bandwidth in Mbps | Yes |
+| `--description TEXT` | Description for the bandwidth allocation | No |
+| `--tags LIST` | List of tags to apply | No |
+| `--spn-name-list LIST` | Comma-separated list of SPN names | No |
 
 ### Examples
 
-#### Create a Bandwidth Allocation
+#### Create a Basic Bandwidth Allocation
 
 ```bash
-$ scm set sase bandwidth --folder Shared --name "Standard-Branch" \
-  --egress-guaranteed 50 --egress-max 100 \
-  --ingress-guaranteed 75 --ingress-max 150 \
-  --description "Standard bandwidth allocation for branch offices"
-Creating bandwidth allocation 'Standard-Branch' in folder 'Shared'...
-Bandwidth allocation created successfully.
+$ scm set sase bandwidth \
+    --folder Shared \
+    --name Standard-Branch \
+    --egress-guaranteed 50 \
+    --egress-max 100 \
+    --ingress-guaranteed 75 \
+    --ingress-max 150 \
+    --description "Standard bandwidth for branch offices"
+---> 100%
+Created bandwidth allocation: Standard-Branch in folder Shared
 ```
 
 #### Create a Bandwidth Allocation with SPN Association
 
 ```bash
-$ scm set sase bandwidth --folder Shared --name "HQ-Bandwidth" \
-  --egress-guaranteed 500 --egress-max 1000 \
-  --ingress-guaranteed 750 --ingress-max 1500 \
-  --spn-name-list "HQ-SPN-1,HQ-SPN-2" \
-  --description "High bandwidth allocation for headquarters"
-Creating bandwidth allocation 'HQ-Bandwidth' in folder 'Shared'...
-Bandwidth allocation created successfully.
+$ scm set sase bandwidth \
+    --folder Shared \
+    --name HQ-Bandwidth \
+    --egress-guaranteed 500 \
+    --egress-max 1000 \
+    --ingress-guaranteed 750 \
+    --ingress-max 1500 \
+    --spn-name-list "HQ-SPN-1,HQ-SPN-2" \
+    --description "High bandwidth for headquarters"
+---> 100%
+Created bandwidth allocation: HQ-Bandwidth in folder Shared
+```
+
+#### Assign Bandwidth Allocation to SPNs
+
+```bash
+$ scm set sase bandwidth \
+    --folder Shared \
+    --name Retail-Store \
+    --egress-guaranteed 25 \
+    --egress-max 50 \
+    --ingress-guaranteed 35 \
+    --ingress-max 70 \
+    --spn-name-list "retail-spn-east,retail-spn-west"
+---> 100%
+Updated bandwidth allocation: Retail-Store in folder Shared
 ```
 
 ## Delete Bandwidth Allocation
 
-Delete a bandwidth allocation.
+Delete a bandwidth allocation from SCM.
 
 ### Syntax
 
@@ -63,22 +96,22 @@ scm delete sase bandwidth [OPTIONS]
 
 ### Options
 
-| Option          | Description                                | Required |
-| --------------- | ------------------------------------------ | -------- |
-| `--folder TEXT` | Folder containing the bandwidth allocation | Yes      |
-| `--name TEXT`   | Name of the bandwidth allocation to delete | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder containing the bandwidth allocation | Yes |
+| `--name TEXT` | Name of the bandwidth allocation to delete | Yes |
 
 ### Example
 
 ```bash
-$ scm delete sase bandwidth --folder Shared --name "Standard-Branch"
-Deleting bandwidth allocation 'Standard-Branch' from folder 'Shared'...
-Bandwidth allocation deleted successfully.
+$ scm delete sase bandwidth --folder Shared --name Standard-Branch
+---> 100%
+Deleted bandwidth allocation: Standard-Branch from folder Shared
 ```
 
 ## Load Bandwidth Allocations
 
-Create or update multiple bandwidth allocations from a YAML file.
+Load multiple bandwidth allocations from a YAML file.
 
 ### Syntax
 
@@ -88,17 +121,19 @@ scm load sase bandwidth [OPTIONS]
 
 ### Options
 
-| Option          | Description                                                   | Required |
-| --------------- | ------------------------------------------------------------- | -------- |
-| `--folder TEXT` | Folder for the bandwidth allocations                          | Yes      |
-| `--file TEXT`   | Path to YAML file containing bandwidth allocation definitions | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing bandwidth allocation definitions | Yes |
+| `--folder TEXT` | Folder override for all bandwidth allocations | No |
 
-### Example YAML File
+### YAML File Format
 
 ```yaml
+---
 bandwidth_allocations:
   - name: Standard-Branch
-    description: "Standard bandwidth allocation for branch offices"
+    folder: Shared
+    description: "Standard bandwidth for branch offices"
     egress_guaranteed: 50
     egress_max: 100
     ingress_guaranteed: 75
@@ -108,7 +143,8 @@ bandwidth_allocations:
       - standard
 
   - name: HQ-Bandwidth
-    description: "High bandwidth allocation for headquarters"
+    folder: Shared
+    description: "High bandwidth for headquarters"
     egress_guaranteed: 500
     egress_max: 1000
     ingress_guaranteed: 750
@@ -116,80 +152,112 @@ bandwidth_allocations:
     spn_name_list:
       - HQ-SPN-1
       - HQ-SPN-2
-    tags:
-      - hq
-      - high-bandwidth
 
   - name: Retail-Store
+    folder: Shared
     description: "Limited bandwidth for retail locations"
     egress_guaranteed: 25
     egress_max: 50
     ingress_guaranteed: 35
     ingress_max: 70
-    tags:
-      - retail
-      - limited
 ```
 
-### Example Command
+### Examples
+
+#### Load with Original Locations
 
 ```bash
-$ scm load sase bandwidth --folder Shared --file bandwidth-allocations.yaml
-Loading bandwidth allocations from 'bandwidth-allocations.yaml' into folder 'Shared'...
-Created 3 bandwidth allocations successfully.
+$ scm load sase bandwidth --file bandwidth-allocations.yml
+---> 100%
+✓ Loaded bandwidth allocation: Standard-Branch
+✓ Loaded bandwidth allocation: HQ-Bandwidth
+✓ Loaded bandwidth allocation: Retail-Store
+
+Successfully loaded 3 out of 3 bandwidth allocations from 'bandwidth-allocations.yml'
 ```
 
-## List Bandwidth Allocations
+#### Load with Folder Override
 
-List all bandwidth allocations in a folder.
+```bash
+$ scm load sase bandwidth --file bandwidth-allocations.yml --folder Shared
+---> 100%
+✓ Loaded bandwidth allocation: Standard-Branch
+✓ Loaded bandwidth allocation: HQ-Bandwidth
+✓ Loaded bandwidth allocation: Retail-Store
+
+Successfully loaded 3 out of 3 bandwidth allocations from 'bandwidth-allocations.yml'
+```
+
+!!! note
+    When using the `--folder` override option, all bandwidth allocations will be loaded
+    into the specified folder, ignoring the folder specified in the YAML file.
+
+## Show Bandwidth Allocation
+
+Display bandwidth allocation objects.
 
 ### Syntax
 
 ```bash
-scm set sase bandwidth --list [OPTIONS]
+scm show sase bandwidth [OPTIONS]
 ```
 
 ### Options
 
-| Option          | Description                               | Required |
-| --------------- | ----------------------------------------- | -------- |
-| `--folder TEXT` | Folder to list bandwidth allocations from | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to list bandwidth allocations from | Yes |
+| `--name TEXT` | Name of the bandwidth allocation to show | No |
 
-### Example
+!!! note
+    When no `--name` is specified, all items are listed by default.
 
-```bash
-$ scm set sase bandwidth --list --folder Shared
-Listing bandwidth allocations in folder 'Shared'...
+### Examples
 
-| Name | Egress (Guaranteed/Max) | Ingress (Guaranteed/Max) | SPNs | Description |
-|------|-------------------------|--------------------------|------|-------------|
-| Standard-Branch | 50/100 Mbps | 75/150 Mbps | - | Standard bandwidth allocation for branch offices |
-| HQ-Bandwidth | 500/1000 Mbps | 750/1500 Mbps | HQ-SPN-1, HQ-SPN-2 | High bandwidth allocation for headquarters |
-| Retail-Store | 25/50 Mbps | 35/70 Mbps | - | Limited bandwidth for retail locations |
-```
-
-## Assign Bandwidth Allocation
-
-Assign a bandwidth allocation to specific Service Provider Networks (SPNs).
-
-### Syntax
+#### Show Specific Bandwidth Allocation
 
 ```bash
-scm set sase bandwidth --assign [OPTIONS]
+$ scm show sase bandwidth --folder Shared --name HQ-Bandwidth
+---> 100%
+Bandwidth Allocation: HQ-Bandwidth
+  Location: Folder 'Shared'
+  Egress: 500/1000 Mbps (guaranteed/max)
+  Ingress: 750/1500 Mbps (guaranteed/max)
+  SPNs: HQ-SPN-1, HQ-SPN-2
+  Description: High bandwidth for headquarters
 ```
 
-### Options
-
-| Option                 | Description                                  | Required |
-| ---------------------- | -------------------------------------------- | -------- |
-| `--folder TEXT`        | Folder containing the bandwidth allocation   | Yes      |
-| `--name TEXT`          | Name of the bandwidth allocation             | Yes      |
-| `--spn-name-list LIST` | List of SPN names to apply the allocation to | Yes      |
-
-### Example
+#### List All Bandwidth Allocations (Default Behavior)
 
 ```bash
-$ scm set sase bandwidth --assign --folder Shared --name "Retail-Store" --spn-name-list "retail-spn-east,retail-spn-west"
-Assigning bandwidth allocation 'Retail-Store' to SPNs 'retail-spn-east,retail-spn-west'...
-Bandwidth allocation assigned successfully.
+$ scm show sase bandwidth --folder Shared
+---> 100%
+Bandwidth Allocations in folder 'Shared':
+------------------------------------------------------------
+Name: Standard-Branch
+  Egress: 50/100 Mbps (guaranteed/max)
+  Ingress: 75/150 Mbps (guaranteed/max)
+  SPNs: -
+  Description: Standard bandwidth for branch offices
+------------------------------------------------------------
+Name: HQ-Bandwidth
+  Egress: 500/1000 Mbps (guaranteed/max)
+  Ingress: 750/1500 Mbps (guaranteed/max)
+  SPNs: HQ-SPN-1, HQ-SPN-2
+  Description: High bandwidth for headquarters
+------------------------------------------------------------
+Name: Retail-Store
+  Egress: 25/50 Mbps (guaranteed/max)
+  Ingress: 35/70 Mbps (guaranteed/max)
+  SPNs: -
+  Description: Limited bandwidth for retail locations
+------------------------------------------------------------
 ```
+
+## Best Practices
+
+1. **Plan Bandwidth Tiers**: Define standard bandwidth tiers (e.g., branch, headquarters, retail) to simplify allocation management across your organization.
+2. **Set Realistic Guarantees**: Ensure guaranteed bandwidth values reflect actual minimum requirements, as over-commitment can degrade performance for all sites.
+3. **Associate SPNs Early**: Assign bandwidth allocations to SPNs during creation to ensure traffic shaping takes effect immediately.
+4. **Use Tags for Organization**: Apply consistent tags to bandwidth allocations for easier filtering and reporting across large deployments.
+5. **Monitor Utilization**: Regularly review bandwidth utilization against allocated limits and adjust configurations as traffic patterns change.

--- a/docs/cli/deployment/bgp-routing.md
+++ b/docs/cli/deployment/bgp-routing.md
@@ -1,8 +1,21 @@
 # BGP Routing
 
-BGP routing is a singleton configuration that controls backbone routing behavior for SASE deployments.
+BGP routing is a singleton configuration that controls backbone routing behavior for SASE deployments. The `scm` CLI provides commands to configure, view, and reset BGP routing settings.
+
+## Overview
+
+The `bgp-routing` commands allow you to:
+
+- Configure backbone routing mode (symmetric or asymmetric)
+- Set routing preferences and outbound route policies
+- Enable route acceptance over service connections
+- Reset BGP routing configuration to defaults
 
 ## Set BGP Routing
+
+Create or update the BGP routing configuration.
+
+### Syntax
 
 ```bash
 scm set sase bgp-routing [OPTIONS]
@@ -19,25 +32,85 @@ scm set sase bgp-routing [OPTIONS]
 | `--add-host-route-to-ike-peer` | Add host route to IKE peer | No |
 | `--withdraw-static-route` | Withdraw static routes | No |
 
-### Example
+### Examples
+
+#### Configure Basic BGP Routing
+
+```bash
+$ scm set sase bgp-routing \
+    --backbone-routing no-asymmetric-routing \
+    --routing-preference default
+---> 100%
+Updated BGP routing configuration
+```
+
+#### Configure BGP Routing with Service Connection Routes
 
 ```bash
 $ scm set sase bgp-routing \
     --backbone-routing no-asymmetric-routing \
     --routing-preference default \
-    --accept-route-over-sc
+    --accept-route-over-sc \
+    --add-host-route-to-ike-peer
+---> 100%
+Updated BGP routing configuration
+```
+
+#### Configure Asymmetric Routing with Outbound Routes
+
+```bash
+$ scm set sase bgp-routing \
+    --backbone-routing asymmetric-routing \
+    --outbound-routes "10.0.0.0/8,172.16.0.0/12" \
+    --withdraw-static-route
+---> 100%
+Updated BGP routing configuration
+```
+
+## Delete BGP Routing
+
+Reset BGP routing configuration to defaults.
+
+### Syntax
+
+```bash
+scm delete sase bgp-routing
+```
+
+### Example
+
+```bash
+$ scm delete sase bgp-routing
+---> 100%
+Reset BGP routing configuration to defaults
 ```
 
 ## Show BGP Routing
+
+Display the current BGP routing configuration.
+
+### Syntax
 
 ```bash
 scm show sase bgp-routing
 ```
 
-## Delete BGP Routing
-
-Resets BGP routing configuration to defaults.
+### Example
 
 ```bash
-scm delete sase bgp-routing
+$ scm show sase bgp-routing
+---> 100%
+BGP Routing Configuration:
+  Backbone Routing: no-asymmetric-routing
+  Routing Preference: default
+  Accept Route Over SC: true
+  Add Host Route to IKE Peer: true
+  Withdraw Static Route: false
 ```
+
+## Best Practices
+
+1. **Use Symmetric Routing by Default**: Start with `no-asymmetric-routing` to ensure predictable traffic paths and simplify troubleshooting.
+2. **Enable Service Connection Routes Carefully**: Only enable `--accept-route-over-sc` when you need dynamic route exchange over service connections.
+3. **Plan Outbound Routes**: Document all outbound routes before configuring them to avoid unintended traffic flows through the SASE backbone.
+4. **Test Before Production**: Use `scm show sase bgp-routing` to verify configuration changes before committing them to production.

--- a/docs/cli/deployment/internal-dns-server.md
+++ b/docs/cli/deployment/internal-dns-server.md
@@ -1,8 +1,22 @@
 # Internal DNS Server
 
-Internal DNS servers configure DNS resolution for internal domains through SASE infrastructure.
+Internal DNS servers configure DNS resolution for internal domains through SASE infrastructure. The `scm` CLI provides commands to create, update, delete, bulk load, and back up internal DNS server configurations.
+
+## Overview
+
+The `internal-dns-server` commands allow you to:
+
+- Create DNS server entries for internal domain resolution
+- Configure primary and secondary DNS servers for redundancy
+- Delete DNS server entries that are no longer needed
+- Bulk import DNS server configurations from YAML files
+- Export DNS server configurations for backup or migration
 
 ## Set Internal DNS Server
+
+Create or update an internal DNS server configuration.
+
+### Syntax
 
 ```bash
 scm set sase internal-dns-server [OPTIONS]
@@ -12,12 +26,14 @@ scm set sase internal-dns-server [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--name TEXT` | Server name | Yes |
+| `--name TEXT` | Name of the DNS server entry | Yes |
 | `--domain-name TEXT` | Domain name(s), comma-separated | Yes |
-| `--primary TEXT` | Primary DNS server IP | Yes |
-| `--secondary TEXT` | Secondary DNS server IP | No |
+| `--primary TEXT` | Primary DNS server IP address | Yes |
+| `--secondary TEXT` | Secondary DNS server IP address | No |
 
-### Example
+### Examples
+
+#### Create a DNS Server with Primary and Secondary
 
 ```bash
 $ scm set sase internal-dns-server \
@@ -25,24 +41,182 @@ $ scm set sase internal-dns-server \
     --domain-name corp.example.com \
     --primary 10.0.0.1 \
     --secondary 10.0.0.2
+---> 100%
+Created internal DNS server: corp-dns
 ```
 
-## Show Internal DNS Server
+#### Create a DNS Server for Multiple Domains
 
 ```bash
-scm show sase internal-dns-server
-scm show sase internal-dns-server --name corp-dns
+$ scm set sase internal-dns-server \
+    --name multi-domain-dns \
+    --domain-name "internal.example.com,dev.example.com" \
+    --primary 10.0.1.1
+---> 100%
+Created internal DNS server: multi-domain-dns
 ```
 
 ## Delete Internal DNS Server
 
-```bash
-scm delete sase internal-dns-server --name corp-dns
-```
+Delete an internal DNS server configuration from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load sase internal-dns-server --file dns-servers.yaml
-scm backup sase internal-dns-server
+scm delete sase internal-dns-server [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the DNS server entry to delete | Yes |
+
+### Example
+
+```bash
+$ scm delete sase internal-dns-server --name corp-dns
+---> 100%
+Deleted internal DNS server: corp-dns
+```
+
+## Load Internal DNS Servers
+
+Load multiple internal DNS server configurations from a YAML file.
+
+### Syntax
+
+```bash
+scm load sase internal-dns-server [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing DNS server definitions | Yes |
+
+### YAML File Format
+
+```yaml
+---
+internal_dns_servers:
+  - name: corp-dns
+    domain_name:
+      - corp.example.com
+    primary: 10.0.0.1
+    secondary: 10.0.0.2
+
+  - name: dev-dns
+    domain_name:
+      - dev.example.com
+      - staging.example.com
+    primary: 10.0.1.1
+    secondary: 10.0.1.2
+```
+
+### Examples
+
+#### Load DNS Server Configurations
+
+```bash
+$ scm load sase internal-dns-server --file dns-servers.yml
+---> 100%
+✓ Loaded internal DNS server: corp-dns
+✓ Loaded internal DNS server: dev-dns
+
+Successfully loaded 2 out of 2 internal DNS servers from 'dns-servers.yml'
+```
+
+## Show Internal DNS Server
+
+Display internal DNS server configurations.
+
+### Syntax
+
+```bash
+scm show sase internal-dns-server [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the DNS server entry to show | No |
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Internal DNS Server
+
+```bash
+$ scm show sase internal-dns-server --name corp-dns
+---> 100%
+Internal DNS Server: corp-dns
+  Domain: corp.example.com
+  Primary: 10.0.0.1
+  Secondary: 10.0.0.2
+```
+
+#### List All Internal DNS Servers (Default Behavior)
+
+```bash
+$ scm show sase internal-dns-server
+---> 100%
+Internal DNS Servers:
+------------------------------------------------------------
+Name: corp-dns
+  Domain: corp.example.com
+  Primary: 10.0.0.1
+  Secondary: 10.0.0.2
+------------------------------------------------------------
+Name: dev-dns
+  Domain: dev.example.com, staging.example.com
+  Primary: 10.0.1.1
+  Secondary: 10.0.1.2
+------------------------------------------------------------
+```
+
+## Backup Internal DNS Servers
+
+Backup all internal DNS server configurations to a YAML file.
+
+### Syntax
+
+```bash
+scm backup sase internal-dns-server [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Custom output filename | No |
+
+### Examples
+
+#### Backup with Default Filename
+
+```bash
+$ scm backup sase internal-dns-server
+---> 100%
+Successfully backed up 2 internal DNS servers to internal_dns_server_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup sase internal-dns-server --file dns-backup.yaml
+---> 100%
+Successfully backed up 2 internal DNS servers to dns-backup.yaml
+```
+
+## Best Practices
+
+1. **Configure Secondary Servers**: Always specify a secondary DNS server for redundancy in case the primary becomes unreachable.
+2. **Use Descriptive Names**: Name DNS server entries to clearly indicate the domains they serve (e.g., "corp-dns", "dev-dns").
+3. **Minimize Domain Overlap**: Avoid configuring multiple DNS server entries for the same domain to prevent resolution conflicts.
+4. **Backup Before Changes**: Export existing configurations with the backup command before making bulk changes via load.
+5. **Validate DNS Reachability**: Ensure the specified DNS server IP addresses are reachable from your SASE infrastructure before configuring them.

--- a/docs/cli/deployment/network-location.md
+++ b/docs/cli/deployment/network-location.md
@@ -1,8 +1,12 @@
 # Network Location
 
-Network locations are read-only resources representing available SASE deployment regions with geographic information.
+Network locations are read-only resources representing available SASE deployment regions with geographic information. Network location management is read-only through the CLI.
 
 ## Show Network Location
+
+Display available SASE network locations.
+
+### Syntax
 
 ```bash
 scm show sase network-location [OPTIONS]
@@ -16,13 +20,37 @@ scm show sase network-location [OPTIONS]
 
 ### Examples
 
-```bash
-# List all network locations
-$ scm show sase network-location
+#### List All Network Locations
 
-# Show a specific location
+```bash
+$ scm show sase network-location
+---> 100%
+Network Locations:
+------------------------------------------------------------
+Value: us-east-1
+  Display: US East
+  Continent: North America
+------------------------------------------------------------
+Value: us-west-1
+  Display: US West
+  Continent: North America
+------------------------------------------------------------
+Value: eu-west-1
+  Display: EU West
+  Continent: Europe
+------------------------------------------------------------
+```
+
+#### Show a Specific Network Location
+
+```bash
 $ scm show sase network-location --value us-west-1
+---> 100%
+Network Location: us-west-1
+  Display: US West
+  Continent: North America
 ```
 
 !!! note
-    Network locations are read-only. They cannot be created, updated, or deleted.
+    Network locations are read-only. They cannot be created, updated, or deleted
+    through the CLI.

--- a/docs/cli/deployment/remote-network.md
+++ b/docs/cli/deployment/remote-network.md
@@ -1,16 +1,27 @@
 # Remote Network
 
-Remote networks represent branch offices, data centers, or other physical locations that connect to Prisma SASE. The `scm` CLI provides commands to create, update, delete, list, and load remote network configurations.
+Remote networks represent branch offices, data centers, or other physical locations that connect to Prisma SASE. The `scm` CLI provides commands to create, update, delete, bulk load, and back up remote network configurations.
 
 ## Overview
 
-Remote networks are fundamental building blocks in Prisma SASE deployments, defining:
+The `remote-network` commands allow you to:
 
-- Physical locations and their associated subnets
-- IPsec tunnel assignments for secure connectivity
-- BGP routing configurations for dynamic route exchange
-- ECMP (Equal-Cost Multi-Path) settings for load balancing
-- Licensing models for the remote location
+- Create remote networks with IPsec tunnel and subnet configurations
+- Configure BGP routing for dynamic route exchange
+- Enable ECMP load balancing across multiple tunnels
+- Bulk import remote network configurations from YAML files
+- Export remote network configurations for backup or migration
+
+## Remote Network Components
+
+| Component | Description |
+| --- | --- |
+| **Region** | SASE deployment region for the remote network |
+| **SPN** | Service Provider Network association (required for FWAAS-AGGREGATE) |
+| **IPsec Tunnel** | Primary tunnel for secure connectivity (required when ECMP disabled) |
+| **ECMP** | Equal-Cost Multi-Path load balancing across up to 4 tunnels |
+| **BGP** | Dynamic routing with peer AS, IP addressing, and authentication |
+| **License Type** | Licensing model (default: FWAAS-AGGREGATE) |
 
 ## Set Remote Network
 
@@ -24,86 +35,89 @@ scm set sase remote-network [OPTIONS]
 
 ### Options
 
-| Option                          | Description                                     | Required |
-| ------------------------------- | ----------------------------------------------- | -------- |
-| `--name TEXT`                   | Name of the remote network                      | Yes      |
-| `--region TEXT`                 | Region for the remote network                   | Yes      |
-| `--license-type TEXT`           | License type (default: "FWAAS-AGGREGATE")       | No       |
-| `--description TEXT`            | Description of the remote network               | No       |
-| `--subnets LIST`                | List of subnets for the remote network          | No       |
-| `--spn-name TEXT`               | SPN name (required for FWAAS-AGGREGATE license) | No       |
-| `--ecmp-load-balancing TEXT`    | Enable or disable ECMP (default: "disable")     | No       |
-| `--ipsec-tunnel TEXT`           | IPsec tunnel (required when ECMP is disabled)   | No       |
-| `--secondary-ipsec-tunnel TEXT` | Secondary IPsec tunnel for redundancy           | No       |
-| `--bgp-enable`                  | Enable BGP                                      | No       |
-| `--bgp-peer-as TEXT`            | BGP peer AS number                              | No       |
-| `--bgp-peer-ip TEXT`            | BGP peer IP address                             | No       |
-| `--bgp-local-ip TEXT`           | BGP local IP address                            | No       |
-| `--bgp-secret TEXT`             | BGP authentication secret                       | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the remote network | Yes |
+| `--region TEXT` | Region for the remote network | Yes |
+| `--license-type TEXT` | License type (default: FWAAS-AGGREGATE) | No |
+| `--description TEXT` | Description of the remote network | No |
+| `--subnets LIST` | Comma-separated list of subnets | No |
+| `--spn-name TEXT` | SPN name (required for FWAAS-AGGREGATE license) | No |
+| `--ecmp-load-balancing TEXT` | Enable or disable ECMP (default: disable) | No |
+| `--ipsec-tunnel TEXT` | IPsec tunnel (required when ECMP is disabled) | No |
+| `--secondary-ipsec-tunnel TEXT` | Secondary IPsec tunnel for redundancy | No |
+| `--bgp-enable` | Enable BGP | No |
+| `--bgp-peer-as TEXT` | BGP peer AS number | No |
+| `--bgp-peer-ip TEXT` | BGP peer IP address | No |
+| `--bgp-local-ip TEXT` | BGP local IP address | No |
+| `--bgp-secret TEXT` | BGP authentication secret | No |
 
 ### Examples
 
 #### Create a Basic Remote Network
 
 ```bash
-$ scm set sase remote-network --name "branch-office-nyc" \
-  --region "us-east-1" \
-  --spn-name "us-east-spn" \
-  --ipsec-tunnel "ipsec-tunnel-nyc" \
-  --subnets "10.1.0.0/24,10.1.1.0/24" \
-  --description "New York branch office"
-Creating remote network 'branch-office-nyc'...
-Remote network created successfully.
+$ scm set sase remote-network \
+    --name branch-office-nyc \
+    --region us-east-1 \
+    --spn-name us-east-spn \
+    --ipsec-tunnel ipsec-tunnel-nyc \
+    --subnets "10.1.0.0/24,10.1.1.0/24" \
+    --description "New York branch office"
+---> 100%
+Created remote network: branch-office-nyc
 ```
 
 #### Create a Remote Network with BGP
 
 ```bash
-$ scm set sase remote-network --name "datacenter-west" \
-  --region "us-west-2" \
-  --license-type "FWAAS-AGGREGATE" \
-  --spn-name "us-west-spn" \
-  --ipsec-tunnel "ipsec-tunnel-dc-west" \
-  --subnets "172.16.0.0/16,172.17.0.0/16" \
-  --bgp-enable \
-  --bgp-peer-as "65001" \
-  --bgp-peer-ip "192.168.1.1" \
-  --bgp-local-ip "192.168.1.2" \
-  --bgp-secret "bgp-secret-west"
-Creating remote network 'datacenter-west'...
-Remote network created successfully.
+$ scm set sase remote-network \
+    --name datacenter-west \
+    --region us-west-2 \
+    --spn-name us-west-spn \
+    --ipsec-tunnel ipsec-tunnel-dc-west \
+    --subnets "172.16.0.0/16,172.17.0.0/16" \
+    --bgp-enable \
+    --bgp-peer-as "65001" \
+    --bgp-peer-ip "192.168.1.1" \
+    --bgp-local-ip "192.168.1.2" \
+    --bgp-secret "bgp-secret-west"
+---> 100%
+Created remote network: datacenter-west
 ```
 
 #### Create a Remote Network with ECMP Load Balancing
 
 ```bash
-$ scm set sase remote-network --name "hq-campus" \
-  --region "eu-central-1" \
-  --spn-name "eu-central-spn" \
-  --ecmp-load-balancing "enable" \
-  --subnets "10.0.0.0/8" \
-  --description "Headquarters campus network with ECMP"
-Creating remote network 'hq-campus'...
-Remote network created successfully.
+$ scm set sase remote-network \
+    --name hq-campus \
+    --region eu-central-1 \
+    --spn-name eu-central-spn \
+    --ecmp-load-balancing enable \
+    --subnets "10.0.0.0/8" \
+    --description "Headquarters campus with ECMP"
+---> 100%
+Created remote network: hq-campus
 ```
 
 #### Create a Remote Network with Redundant Tunnels
 
 ```bash
-$ scm set sase remote-network --name "critical-site" \
-  --region "ap-southeast-1" \
-  --spn-name "ap-southeast-spn" \
-  --ipsec-tunnel "ipsec-tunnel-primary" \
-  --secondary-ipsec-tunnel "ipsec-tunnel-secondary" \
-  --subnets "192.168.0.0/16" \
-  --description "Critical site with tunnel redundancy"
-Creating remote network 'critical-site'...
-Remote network created successfully.
+$ scm set sase remote-network \
+    --name critical-site \
+    --region ap-southeast-1 \
+    --spn-name ap-southeast-spn \
+    --ipsec-tunnel ipsec-tunnel-primary \
+    --secondary-ipsec-tunnel ipsec-tunnel-secondary \
+    --subnets "192.168.0.0/16" \
+    --description "Critical site with tunnel redundancy"
+---> 100%
+Created remote network: critical-site
 ```
 
 ## Delete Remote Network
 
-Delete a remote network configuration.
+Delete a remote network configuration from SCM.
 
 ### Syntax
 
@@ -113,21 +127,21 @@ scm delete sase remote-network [OPTIONS]
 
 ### Options
 
-| Option        | Description                          | Required |
-| ------------- | ------------------------------------ | -------- |
-| `--name TEXT` | Name of the remote network to delete | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the remote network to delete | Yes |
 
 ### Example
 
 ```bash
-$ scm delete sase remote-network --name "branch-office-nyc"
-Deleting remote network 'branch-office-nyc'...
-Remote network deleted successfully.
+$ scm delete sase remote-network --name branch-office-nyc
+---> 100%
+Deleted remote network: branch-office-nyc
 ```
 
 ## Load Remote Networks
 
-Create or update multiple remote networks from a YAML file.
+Load multiple remote network configurations from a YAML file.
 
 ### Syntax
 
@@ -137,14 +151,15 @@ scm load sase remote-network [OPTIONS]
 
 ### Options
 
-| Option        | Description                                             | Required |
-| ------------- | ------------------------------------------------------- | -------- |
-| `--file TEXT` | Path to YAML file containing remote network definitions | Yes      |
-| `--dry-run`   | Simulate execution without applying changes             | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing remote network definitions | Yes |
+| `--dry-run` | Simulate execution without applying changes | No |
 
-### Example YAML File
+### YAML File Format
 
 ```yaml
+---
 remote_networks:
   - name: branch-office-east
     folder: Remote Networks
@@ -155,7 +170,6 @@ remote_networks:
     subnets:
       - 10.1.0.0/24
       - 10.1.1.0/24
-      - 10.1.2.0/24
     ecmp_load_balancing: disable
     ipsec_tunnel: ipsec-tunnel-east
     bgp_enable: true
@@ -163,24 +177,6 @@ remote_networks:
     bgp_peer_ip_address: 192.168.1.1
     bgp_local_ip_address: 192.168.1.2
     bgp_secret: bgp-secret-east
-
-  - name: branch-office-west
-    folder: Remote Networks
-    region: us-west-2
-    license_type: FWAAS-AGGREGATE
-    description: "West coast branch office with redundancy"
-    spn_name: us-west-spn
-    subnets:
-      - 10.2.0.0/24
-      - 10.2.1.0/24
-    ecmp_load_balancing: disable
-    ipsec_tunnel: ipsec-tunnel-west-primary
-    secondary_ipsec_tunnel: ipsec-tunnel-west-secondary
-    bgp_enable: true
-    bgp_peer_as: "65002"
-    bgp_peer_ip_address: 192.168.2.1
-    bgp_local_ip_address: 192.168.2.2
-    bgp_originate_default_route: true
 
   - name: datacenter-central
     folder: Remote Networks
@@ -201,32 +197,33 @@ remote_networks:
         priority: 20
       - name: ipsec-tunnel-dc-4
         priority: 20
-
-  - name: retail-store-001
-    folder: Remote Networks
-    region: eu-west-1
-    license_type: FWAAS-AGGREGATE
-    description: "Retail location 001"
-    spn_name: eu-west-spn
-    subnets:
-      - 192.168.100.0/24
-    ecmp_load_balancing: disable
-    ipsec_tunnel: ipsec-tunnel-retail-001
 ```
 
-### Example Command
+### Examples
+
+#### Load Remote Networks
 
 ```bash
-$ scm load sase remote-network --file remote-networks.yaml
-Loading remote networks from 'remote-networks.yaml'...
-Applied remote network: branch-office-east
-Applied remote network: branch-office-west
-Applied remote network: datacenter-central
-Applied remote network: retail-store-001
-Loaded 4 remote network(s)
+$ scm load sase remote-network --file remote-networks.yml
+---> 100%
+✓ Loaded remote network: branch-office-east
+✓ Loaded remote network: datacenter-central
+
+Successfully loaded 2 out of 2 remote networks from 'remote-networks.yml'
 ```
 
-## Show Remote Networks
+#### Dry Run to Validate Configuration
+
+```bash
+$ scm load sase remote-network --file remote-networks.yml --dry-run
+---> 100%
+[DRY RUN] Would load remote network: branch-office-east
+[DRY RUN] Would load remote network: datacenter-central
+
+Dry run complete. 2 remote networks would be loaded.
+```
+
+## Show Remote Network
 
 Display remote network configurations.
 
@@ -238,281 +235,94 @@ scm show sase remote-network [OPTIONS]
 
 ### Options
 
-| Option        | Description                        | Required |
-| ------------- | ---------------------------------- | -------- |
-| `--name TEXT` | Name of the remote network to show | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the remote network to show | No |
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
 
 ### Examples
-
-#### List All Remote Networks
-
-```bash
-$ scm show sase remote-network
-Remote Networks:
-------------------------------------------------------------
-Name: branch-office-east
-  Folder: Remote Networks
-  Region: us-east-1
-  License Type: FWAAS-AGGREGATE
-  Subnets: 10.1.0.0/24, 10.1.1.0/24, 10.1.2.0/24
-  ECMP: disable
-  BGP: Enabled (AS 65001)
-  ID: 12345678-1234-1234-1234-123456789012
-------------------------------------------------------------
-Name: branch-office-west
-  Folder: Remote Networks
-  Region: us-west-2
-  License Type: FWAAS-AGGREGATE
-  Subnets: 10.2.0.0/24, 10.2.1.0/24
-  ECMP: disable
-  BGP: Enabled (AS 65002)
-  ID: 23456789-2345-2345-2345-234567890123
-------------------------------------------------------------
-Name: datacenter-central
-  Folder: Remote Networks
-  Region: us-central-1
-  License Type: FWAAS-AGGREGATE
-  Subnets: 172.16.0.0/12, 192.168.0.0/16
-  ECMP: enable
-  ID: 34567890-3456-3456-3456-345678901234
-------------------------------------------------------------
-```
 
 #### Show Specific Remote Network
 
 ```bash
 $ scm show sase remote-network --name datacenter-central
+---> 100%
 Remote Network: datacenter-central
-Folder: Remote Networks
-Region: us-central-1
-License Type: FWAAS-AGGREGATE
-Description: Central datacenter with ECMP
-Subnets: 172.16.0.0/12, 192.168.0.0/16
-SPN Name: us-central-spn
-ECMP Load Balancing: enable
-ECMP Tunnels:
-  Tunnel 1: ipsec-tunnel-dc-1
-  Tunnel 2: ipsec-tunnel-dc-2
-  Tunnel 3: ipsec-tunnel-dc-3
-  Tunnel 4: ipsec-tunnel-dc-4
-ID: 34567890-3456-3456-3456-345678901234
+  Folder: Remote Networks
+  Region: us-central-1
+  License Type: FWAAS-AGGREGATE
+  Description: Central datacenter with ECMP
+  Subnets: 172.16.0.0/12, 192.168.0.0/16
+  SPN Name: us-central-spn
+  ECMP Load Balancing: enable
+  ECMP Tunnels:
+    ipsec-tunnel-dc-1 (priority: 10)
+    ipsec-tunnel-dc-2 (priority: 10)
+    ipsec-tunnel-dc-3 (priority: 20)
+    ipsec-tunnel-dc-4 (priority: 20)
+```
+
+#### List All Remote Networks (Default Behavior)
+
+```bash
+$ scm show sase remote-network
+---> 100%
+Remote Networks:
+------------------------------------------------------------
+Name: branch-office-east
+  Region: us-east-1
+  Subnets: 10.1.0.0/24, 10.1.1.0/24
+  ECMP: disable
+  BGP: Enabled (AS 65001)
+------------------------------------------------------------
+Name: datacenter-central
+  Region: us-central-1
+  Subnets: 172.16.0.0/12, 192.168.0.0/16
+  ECMP: enable
+------------------------------------------------------------
 ```
 
 ## Backup Remote Networks
 
-Back up all remote networks to a YAML file.
+Backup all remote network configurations to a YAML file.
 
 ### Syntax
 
 ```bash
-scm backup sase remote-network
+scm backup sase remote-network [OPTIONS]
 ```
 
-### Example
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Custom output filename | No |
+
+### Examples
+
+#### Backup with Default Filename
 
 ```bash
 $ scm backup sase remote-network
-Successfully backed up 4 remote networks to remote-networks.yaml
+---> 100%
+Successfully backed up 4 remote networks to remote_network_20240115_120530.yaml
 ```
 
-## Advanced Configuration Examples
+#### Backup with Custom Filename
 
-### Remote Network with Full BGP Options
-
-```yaml
-remote_networks:
-  - name: advanced-bgp-site
-    folder: Remote Networks
-    region: us-east-1
-    license_type: FWAAS-AGGREGATE
-    spn_name: us-east-spn
-    subnets:
-      - 10.100.0.0/16
-      - 10.101.0.0/16
-      - 10.102.0.0/16
-    ecmp_load_balancing: disable
-    ipsec_tunnel: ipsec-tunnel-bgp
-    bgp_enable: true
-    bgp_peer_as: "65500"
-    bgp_peer_ip_address: 172.16.0.1
-    bgp_local_ip_address: 172.16.0.2
-    bgp_secret: strong-bgp-secret
-    bgp_peering_type: external
-    bgp_originate_default_route: true
-    bgp_summarize_mobile_user_routes: true
-    bgp_do_not_export_routes: false
-```
-
-### Remote Network with ECMP and Weighted Load Balancing
-
-```yaml
-remote_networks:
-  - name: datacenter-ecmp
-    folder: Remote Networks
-    region: ap-southeast-1
-    license_type: FWAAS-AGGREGATE
-    description: "Datacenter with weighted ECMP load balancing"
-    spn_name: ap-southeast-spn
-    subnets:
-      - 172.20.0.0/16
-      - 172.21.0.0/16
-      - 172.22.0.0/16
-      - 172.23.0.0/16
-    ecmp_load_balancing: enable
-    ecmp_tunnels:
-      - name: ipsec-tunnel-primary-1
-        priority: 10
-        weight: 50
-      - name: ipsec-tunnel-primary-2
-        priority: 10
-        weight: 50
-      - name: ipsec-tunnel-backup-1
-        priority: 20
-        weight: 30
-      - name: ipsec-tunnel-backup-2
-        priority: 20
-        weight: 70
-```
-
-### Multiple Remote Networks for Global Deployment
-
-```yaml
-remote_networks:
-  # North America
-  - name: na-hq-campus
-    folder: Remote Networks
-    region: us-east-1
-    license_type: FWAAS-AGGREGATE
-    description: "North America headquarters"
-    spn_name: na-east-spn
-    subnets:
-      - 10.0.0.0/16
-      - 10.1.0.0/16
-    ecmp_load_balancing: enable
-    ecmp_tunnels:
-      - name: na-hq-tunnel-1
-      - name: na-hq-tunnel-2
-
-  # Europe
-  - name: eu-office-london
-    folder: Remote Networks
-    region: eu-west-2
-    license_type: FWAAS-AGGREGATE
-    description: "European office - London"
-    spn_name: eu-west-spn
-    subnets:
-      - 10.20.0.0/16
-    ipsec_tunnel: eu-london-tunnel
-    bgp_enable: true
-    bgp_peer_as: "65100"
-    bgp_peer_ip_address: 192.168.100.1
-    bgp_local_ip_address: 192.168.100.2
-
-  # Asia Pacific
-  - name: apac-office-singapore
-    folder: Remote Networks
-    region: ap-southeast-1
-    license_type: FWAAS-AGGREGATE
-    description: "APAC office - Singapore"
-    spn_name: apac-spn
-    subnets:
-      - 10.30.0.0/16
-    ipsec_tunnel: apac-singapore-tunnel
-    secondary_ipsec_tunnel: apac-singapore-tunnel-backup
+```bash
+$ scm backup sase remote-network --file remote-networks-backup.yaml
+---> 100%
+Successfully backed up 4 remote networks to remote-networks-backup.yaml
 ```
 
 ## Best Practices
 
-1. **Naming Convention**: Use a consistent naming scheme that includes location and purpose (e.g., "region-city-type")
-
-2. **Subnet Planning**:
-
-   - Document all subnets to avoid overlaps
-   - Use hierarchical addressing for easier summarization
-   - Reserve address space for future growth
-
-3. **ECMP Configuration**:
-
-   - Use ECMP for locations requiring high bandwidth
-   - Configure up to 4 tunnels for load balancing
-   - Set appropriate priorities and weights
-
-4. **BGP Best Practices**:
-
-   - Use private AS numbers (64512-65535) for enterprise networks
-   - Enable route summarization to reduce routing table size
-   - Configure BGP authentication for security
-
-5. **High Availability**:
-
-   - Configure secondary tunnels for critical sites
-   - Use different ISPs for primary and secondary tunnels
-   - Test failover scenarios regularly
-
-6. **Regional Selection**:
-   - Choose the nearest region for optimal performance
-   - Consider data sovereignty requirements
-   - Plan for disaster recovery scenarios
-
-## Troubleshooting
-
-### Common Issues
-
-1. **License Type Errors**
-
-   - FWAAS-AGGREGATE requires spn_name to be specified
-   - Verify license entitlements in your tenant
-
-2. **ECMP Configuration Issues**
-
-   - ECMP requires ecmp_tunnels when enabled
-   - Maximum of 4 tunnels can be configured
-   - Cannot use ipsec_tunnel when ECMP is enabled
-
-3. **Tunnel Configuration Conflicts**
-
-   - When ECMP is disabled, ipsec_tunnel is required
-   - Ensure tunnel names exist before referencing them
-   - Check for tunnel capacity limits
-
-4. **BGP Connection Problems**
-   - Verify AS numbers don't conflict
-   - Ensure IP addresses are correctly configured
-   - Check BGP secrets match on both ends
-   - Confirm routing policies allow BGP
-
-### Debug Commands
-
-```bash
-# Show detailed remote network information
-scm show sase remote-network --name <network-name>
-
-# Verify IPsec tunnel configuration
-scm show network ipsec-tunnel --name <tunnel-name>
-
-# Test configuration with dry-run
-scm load sase remote-network --file config.yaml --dry-run
-
-# Check BGP routing status (requires appropriate permissions)
-scm show network bgp-routes --remote-network <network-name>
-```
-
-## Integration with Service Connections
-
-Remote networks work in conjunction with service connections to establish complete site-to-site connectivity:
-
-1. **Remote Network**: Defines the physical location and its properties
-2. **Service Connection**: Establishes the logical connection using IPsec tunnels
-
-Example workflow:
-
-```bash
-# 1. Create IPsec tunnel
-scm set network ipsec-tunnel --name "site-tunnel" ...
-
-# 2. Create remote network
-scm set sase remote-network --name "branch-site" --ipsec-tunnel "site-tunnel" ...
-
-# 3. Create service connection
-scm set sase service-connection --name "branch-connection" --ipsec-tunnel "site-tunnel" ...
-```
+1. **Use Consistent Naming**: Adopt a naming scheme that includes location and purpose (e.g., "region-city-type") for easy identification across large deployments.
+2. **Plan Subnets Carefully**: Document all subnets to avoid overlaps and reserve address space for future growth using hierarchical addressing.
+3. **Configure ECMP for Critical Sites**: Use ECMP load balancing with up to 4 tunnels for locations requiring high bandwidth and resilience.
+4. **Enable BGP with Authentication**: Use private AS numbers (64512-65535) and configure BGP authentication secrets for secure dynamic routing.
+5. **Deploy Redundant Tunnels**: Configure secondary IPsec tunnels for critical sites, ideally using different ISPs for primary and secondary paths.
+6. **Select Nearest Region**: Choose the closest SASE region for optimal performance, while considering data sovereignty and disaster recovery requirements.

--- a/docs/cli/deployment/service-connection.md
+++ b/docs/cli/deployment/service-connection.md
@@ -1,16 +1,16 @@
 # Service Connection
 
-Service connections define how your branch offices and remote locations connect to Prisma SASE, enabling secure connectivity through IPsec tunnels with optional BGP routing and QoS configurations. The `scm` CLI provides commands to create, update, delete, list, and load service connection configurations.
+Service connections define how branch offices and remote locations connect to Prisma SASE, enabling secure connectivity through IPsec tunnels with optional BGP routing and QoS configurations. The `scm` CLI provides commands to create, update, delete, bulk load, and back up service connection configurations.
 
 ## Overview
 
-Service connections are essential for establishing secure site-to-site connectivity in Prisma SASE deployments. They support:
+The `service-connection` commands allow you to:
 
-- Primary and backup IPsec tunnels for high availability
-- BGP routing for dynamic route exchange
-- QoS profiles for traffic prioritization
-- Source NAT for address translation
-- Multiple subnet support for complex networks
+- Create service connections with IPsec tunnels and subnet configurations
+- Configure BGP routing for dynamic route exchange
+- Enable QoS profiles for traffic prioritization and source NAT
+- Bulk import service connection configurations from YAML files
+- Export service connection configurations for backup or migration
 
 ## Set Service Connection
 
@@ -24,71 +24,74 @@ scm set sase service-connection [OPTIONS]
 
 ### Options
 
-| Option                   | Description                                | Required |
-| ------------------------ | ------------------------------------------ | -------- |
-| `--name TEXT`            | Name of the service connection             | Yes      |
-| `--ipsec-tunnel TEXT`    | IPsec tunnel for the service connection    | Yes      |
-| `--region TEXT`          | Region for the service connection          | Yes      |
-| `--onboarding-type TEXT` | Onboarding type (default: "classic")       | No       |
-| `--backup-sc TEXT`       | Backup service connection name             | No       |
-| `--nat-pool TEXT`        | NAT pool for the service connection        | No       |
-| `--source-nat`           | Enable source NAT                          | No       |
-| `--subnets LIST`         | List of subnets for the service connection | No       |
-| `--bgp-enable`           | Enable BGP                                 | No       |
-| `--bgp-peer-as TEXT`     | BGP peer AS number                         | No       |
-| `--bgp-peer-ip TEXT`     | BGP peer IP address                        | No       |
-| `--bgp-local-ip TEXT`    | BGP local IP address                       | No       |
-| `--bgp-secret TEXT`      | BGP authentication secret                  | No       |
-| `--qos-enable`           | Enable QoS                                 | No       |
-| `--qos-profile TEXT`     | QoS profile name                           | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the service connection | Yes |
+| `--ipsec-tunnel TEXT` | IPsec tunnel for the service connection | Yes |
+| `--region TEXT` | Region for the service connection | Yes |
+| `--onboarding-type TEXT` | Onboarding type (default: classic) | No |
+| `--backup-sc TEXT` | Backup service connection name | No |
+| `--nat-pool TEXT` | NAT pool for the service connection | No |
+| `--source-nat` | Enable source NAT | No |
+| `--subnets LIST` | Comma-separated list of subnets | No |
+| `--bgp-enable` | Enable BGP | No |
+| `--bgp-peer-as TEXT` | BGP peer AS number | No |
+| `--bgp-peer-ip TEXT` | BGP peer IP address | No |
+| `--bgp-local-ip TEXT` | BGP local IP address | No |
+| `--bgp-secret TEXT` | BGP authentication secret | No |
+| `--qos-enable` | Enable QoS | No |
+| `--qos-profile TEXT` | QoS profile name | No |
 
 ### Examples
 
 #### Create a Basic Service Connection
 
 ```bash
-$ scm set sase service-connection --name "branch-office-1" \
-  --ipsec-tunnel "ipsec-tunnel-branch-1" \
-  --region "us-east-1" \
-  --subnets "10.1.0.0/24,10.1.1.0/24"
-Creating service connection 'branch-office-1'...
-Service connection created successfully.
+$ scm set sase service-connection \
+    --name branch-office-1 \
+    --ipsec-tunnel ipsec-tunnel-branch-1 \
+    --region us-east-1 \
+    --subnets "10.1.0.0/24,10.1.1.0/24"
+---> 100%
+Created service connection: branch-office-1
 ```
 
 #### Create a Service Connection with BGP
 
 ```bash
-$ scm set sase service-connection --name "hq-connection" \
-  --ipsec-tunnel "ipsec-tunnel-hq" \
-  --region "us-west-2" \
-  --subnets "172.16.0.0/16" \
-  --bgp-enable \
-  --bgp-peer-as "65001" \
-  --bgp-peer-ip "192.168.1.1" \
-  --bgp-local-ip "192.168.1.2" \
-  --bgp-secret "mysecret123"
-Creating service connection 'hq-connection'...
-Service connection created successfully.
+$ scm set sase service-connection \
+    --name hq-connection \
+    --ipsec-tunnel ipsec-tunnel-hq \
+    --region us-west-2 \
+    --subnets "172.16.0.0/16" \
+    --bgp-enable \
+    --bgp-peer-as "65001" \
+    --bgp-peer-ip "192.168.1.1" \
+    --bgp-local-ip "192.168.1.2" \
+    --bgp-secret "mysecret123"
+---> 100%
+Created service connection: hq-connection
 ```
 
 #### Create a Service Connection with High Availability
 
 ```bash
-$ scm set sase service-connection --name "critical-site" \
-  --ipsec-tunnel "ipsec-tunnel-primary" \
-  --region "eu-central-1" \
-  --backup-sc "backup-connection" \
-  --subnets "10.10.0.0/16" \
-  --source-nat \
-  --qos-enable \
-  --qos-profile "business-critical"
-Creating service connection 'critical-site'...
-Service connection created successfully.
+$ scm set sase service-connection \
+    --name critical-site \
+    --ipsec-tunnel ipsec-tunnel-primary \
+    --region eu-central-1 \
+    --backup-sc backup-connection \
+    --subnets "10.10.0.0/16" \
+    --source-nat \
+    --qos-enable \
+    --qos-profile business-critical
+---> 100%
+Created service connection: critical-site
 ```
 
 ## Delete Service Connection
 
-Delete a service connection configuration.
+Delete a service connection configuration from SCM.
 
 ### Syntax
 
@@ -98,21 +101,21 @@ scm delete sase service-connection [OPTIONS]
 
 ### Options
 
-| Option        | Description                              | Required |
-| ------------- | ---------------------------------------- | -------- |
-| `--name TEXT` | Name of the service connection to delete | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the service connection to delete | Yes |
 
 ### Example
 
 ```bash
-$ scm delete sase service-connection --name "branch-office-1"
-Deleting service connection 'branch-office-1'...
-Service connection deleted successfully.
+$ scm delete sase service-connection --name branch-office-1
+---> 100%
+Deleted service connection: branch-office-1
 ```
 
 ## Load Service Connections
 
-Create or update multiple service connections from a YAML file.
+Load multiple service connection configurations from a YAML file.
 
 ### Syntax
 
@@ -122,14 +125,15 @@ scm load sase service-connection [OPTIONS]
 
 ### Options
 
-| Option        | Description                                                 | Required |
-| ------------- | ----------------------------------------------------------- | -------- |
-| `--file TEXT` | Path to YAML file containing service connection definitions | Yes      |
-| `--dry-run`   | Simulate execution without applying changes                 | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing service connection definitions | Yes |
+| `--dry-run` | Simulate execution without applying changes | No |
 
-### Example YAML File
+### YAML File Format
 
 ```yaml
+---
 service_connections:
   - name: branch-office-east
     ipsec_tunnel: ipsec-tunnel-east
@@ -155,32 +159,33 @@ service_connections:
     nat_pool: nat-pool-west
     qos_enable: true
     qos_profile: standard-qos
-
-  - name: retail-store-001
-    ipsec_tunnel: ipsec-tunnel-retail-001
-    region: eu-west-1
-    subnets:
-      - 192.168.1.0/24
-    bgp_enable: true
-    bgp_peer_as: "65100"
-    bgp_peer_ip_address: 10.0.0.1
-    bgp_local_ip_address: 10.0.0.2
-    bgp_originate_default_route: true
-    bgp_summarize_mobile_user_routes: true
 ```
 
-### Example Command
+### Examples
+
+#### Load Service Connections
 
 ```bash
-$ scm load sase service-connection --file service-connections.yaml
-Loading service connections from 'service-connections.yaml'...
-Applied service connection: branch-office-east
-Applied service connection: branch-office-west
-Applied service connection: retail-store-001
-Loaded 3 service connection(s)
+$ scm load sase service-connection --file service-connections.yml
+---> 100%
+✓ Loaded service connection: branch-office-east
+✓ Loaded service connection: branch-office-west
+
+Successfully loaded 2 out of 2 service connections from 'service-connections.yml'
 ```
 
-## Show Service Connections
+#### Dry Run to Validate Configuration
+
+```bash
+$ scm load sase service-connection --file service-connections.yml --dry-run
+---> 100%
+[DRY RUN] Would load service connection: branch-office-east
+[DRY RUN] Would load service connection: branch-office-west
+
+Dry run complete. 2 service connections would be loaded.
+```
+
+## Show Service Connection
 
 Display service connection configurations.
 
@@ -192,187 +197,97 @@ scm show sase service-connection [OPTIONS]
 
 ### Options
 
-| Option        | Description                            | Required |
-| ------------- | -------------------------------------- | -------- |
-| `--name TEXT` | Name of the service connection to show | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the service connection to show | No |
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
 
 ### Examples
-
-#### List All Service Connections
-
-```bash
-$ scm show sase service-connection
-Service Connections:
-------------------------------------------------------------
-Name: branch-office-east
-  IPsec Tunnel: ipsec-tunnel-east
-  Region: us-east-1
-  Onboarding Type: classic
-  Subnets: 10.1.0.0/24, 10.1.1.0/24
-  BGP: Enabled (AS 65001)
-  ID: 12345678-1234-1234-1234-123456789012
-------------------------------------------------------------
-Name: branch-office-west
-  IPsec Tunnel: ipsec-tunnel-west
-  Region: us-west-2
-  Onboarding Type: classic
-  Subnets: 10.2.0.0/24, 10.2.1.0/24
-  QoS: Enabled
-  ID: 23456789-2345-2345-2345-234567890123
-------------------------------------------------------------
-Name: retail-store-001
-  IPsec Tunnel: ipsec-tunnel-retail-001
-  Region: eu-west-1
-  Onboarding Type: classic
-  Subnets: 192.168.1.0/24
-  BGP: Enabled (AS 65100)
-  ID: 34567890-3456-3456-3456-345678901234
-------------------------------------------------------------
-```
 
 #### Show Specific Service Connection
 
 ```bash
 $ scm show sase service-connection --name branch-office-east
+---> 100%
 Service Connection: branch-office-east
-Folder: Service Connections
-IPsec Tunnel: ipsec-tunnel-east
-Region: us-east-1
-Onboarding Type: classic
-Subnets: 10.1.0.0/24, 10.1.1.0/24
-BGP Settings:
-  Enabled: True
-  Peer AS: 65001
-  Peer IP: 192.168.1.1
-  Local IP: 192.168.1.2
-ID: 12345678-1234-1234-1234-123456789012
+  IPsec Tunnel: ipsec-tunnel-east
+  Region: us-east-1
+  Onboarding Type: classic
+  Subnets: 10.1.0.0/24, 10.1.1.0/24
+  BGP Settings:
+    Enabled: true
+    Peer AS: 65001
+    Peer IP: 192.168.1.1
+    Local IP: 192.168.1.2
+```
+
+#### List All Service Connections (Default Behavior)
+
+```bash
+$ scm show sase service-connection
+---> 100%
+Service Connections:
+------------------------------------------------------------
+Name: branch-office-east
+  IPsec Tunnel: ipsec-tunnel-east
+  Region: us-east-1
+  Subnets: 10.1.0.0/24, 10.1.1.0/24
+  BGP: Enabled (AS 65001)
+------------------------------------------------------------
+Name: branch-office-west
+  IPsec Tunnel: ipsec-tunnel-west
+  Region: us-west-2
+  Subnets: 10.2.0.0/24, 10.2.1.0/24
+  QoS: Enabled
+------------------------------------------------------------
 ```
 
 ## Backup Service Connections
 
-Back up all service connections to a YAML file.
+Backup all service connection configurations to a YAML file.
 
 ### Syntax
 
 ```bash
-scm backup sase service-connection
+scm backup sase service-connection [OPTIONS]
 ```
 
-### Example
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Custom output filename | No |
+
+### Examples
+
+#### Backup with Default Filename
 
 ```bash
 $ scm backup sase service-connection
-Successfully backed up 3 service connections to service-connections.yaml
+---> 100%
+Successfully backed up 3 service connections to service_connection_20240115_120530.yaml
 ```
 
-## Advanced Configuration Examples
+#### Backup with Custom Filename
 
-### Service Connection with Full BGP Options
-
-```yaml
-service_connections:
-  - name: advanced-bgp-connection
-    ipsec_tunnel: ipsec-tunnel-bgp
-    region: us-central-1
-    subnets:
-      - 10.100.0.0/16
-      - 10.101.0.0/16
-    bgp_enable: true
-    bgp_peer_as: "65500"
-    bgp_peer_ip_address: 172.16.0.1
-    bgp_local_ip_address: 172.16.0.2
-    bgp_secret: strong-bgp-secret
-    bgp_originate_default_route: true
-    bgp_summarize_mobile_user_routes: true
-    bgp_do_not_export_routes: false
-    bgp_fast_failover: true
-```
-
-### Service Connection with NAT and QoS
-
-```yaml
-service_connections:
-  - name: nat-qos-connection
-    ipsec_tunnel: ipsec-tunnel-nat
-    region: ap-southeast-1
-    subnets:
-      - 10.20.0.0/24
-      - 10.20.1.0/24
-      - 10.20.2.0/24
-    source_nat: true
-    nat_pool: branch-nat-pool
-    qos_enable: true
-    qos_profile: premium-bandwidth
-    backup_SC: nat-qos-backup
-```
-
-### Service Connection with IPv6 Support
-
-```yaml
-service_connections:
-  - name: dual-stack-connection
-    ipsec_tunnel: ipsec-tunnel-v6
-    region: eu-west-2
-    subnets:
-      - 10.30.0.0/24
-      - 2001:db8:1::/64
-    bgp_enable: true
-    bgp_peer_as: "65600"
-    bgp_peer_ip_address: 192.168.10.1
-    bgp_local_ip_address: 192.168.10.2
-    bgp_peer_ipv6_address: "2001:db8::1"
-    bgp_local_ipv6_address: "2001:db8::2"
+```bash
+$ scm backup sase service-connection --file sc-backup.yaml
+---> 100%
+Successfully backed up 3 service connections to sc-backup.yaml
 ```
 
 ## Best Practices
 
-1. **Naming Convention**: Use descriptive names that identify the location or purpose (e.g., "branch-office-nyc", "retail-store-001")
+1. **Use Descriptive Names**: Name service connections to clearly identify the location or purpose (e.g., "branch-office-nyc", "retail-store-001").
+2. **Configure Backup Connections**: Set up backup service connections for critical sites to ensure continuous connectivity during primary tunnel failures.
+3. **Enable BGP for Complex Networks**: Use BGP dynamic routing when connecting sites with multiple subnets or complex routing requirements.
+4. **Secure BGP Secrets**: Store BGP authentication secrets securely and rotate them regularly to maintain routing security.
+5. **Apply QoS Profiles**: Assign appropriate QoS profiles to prioritize business-critical traffic over less important flows.
+6. **Plan Subnets Carefully**: Document subnet allocations across all service connections to avoid overlaps and ensure proper routing.
 
-2. **High Availability**: Configure backup service connections for critical sites to ensure continuous connectivity
+## Related Topics
 
-3. **BGP Configuration**: Use BGP for dynamic routing when connecting sites with multiple subnets or complex routing requirements
-
-4. **Security**: Store BGP secrets securely and rotate them regularly
-
-5. **QoS Profiles**: Apply appropriate QoS profiles to prioritize business-critical traffic
-
-6. **Subnet Planning**: Carefully plan and document subnet allocations to avoid overlaps
-
-7. **Regional Placement**: Choose regions closest to your physical locations for optimal performance
-
-## Troubleshooting
-
-### Common Issues
-
-1. **IPsec Tunnel Not Found**
-
-   - Ensure the referenced IPsec tunnel exists before creating the service connection
-   - Verify the tunnel name is spelled correctly
-
-2. **BGP Configuration Errors**
-
-   - Verify peer AS numbers match your network configuration
-   - Ensure IP addresses are correctly configured on both ends
-   - Check that BGP secrets match on both peers
-
-3. **Subnet Conflicts**
-
-   - Check for overlapping subnets with other service connections
-   - Ensure subnets don't conflict with Prisma SASE infrastructure ranges
-
-4. **Regional Availability**
-   - Verify the selected region is available for your tenant
-   - Check service connection capacity limits for the region
-
-### Debug Commands
-
-```bash
-# Show detailed service connection information
-scm show sase service-connection --name <connection-name>
-
-# Test configuration with dry-run
-scm load sase service-connection --file config.yaml --dry-run
-
-# Check IPsec tunnel status (requires appropriate permissions)
-scm show network ipsec-tunnel --name <tunnel-name>
-```
+- [Remote Network](remote-network.md)
+- [BGP Routing](bgp-routing.md)


### PR DESCRIPTION
## Summary

- Rewrote all 6 deployment CLI reference pages (`bandwidth`, `bgp-routing`, `internal-dns-server`, `network-location`, `remote-network`, `service-connection`) to conform to the docs-style skill
- Each operation (Set, Delete, Load, Show, Backup) gets its own H2 with Syntax, Options, Examples subsections
- Standardized output formatting (`---> 100%`, Unicode `✓`), option tables (3-col with backtick type hints), admonitions (4-space indent), and Best Practices (numbered, bold lead phrases)
- Classified pages by type: Full (remote-network, service-connection, internal-dns-server), Minimal (bandwidth, bgp-routing), Read-Only (network-location)

Closes #117

## Test plan

- [ ] Verify `make docs-build` passes with no warnings
- [ ] Spot-check rendered pages for correct heading hierarchy and code block formatting
- [ ] Confirm no HTML span tags remain in output examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)