### PR TITLE
docs: standardize Operations CLI pages (Jobs, Commit, Insights)

### DIFF
--- a/docs/cli/commit.md
+++ b/docs/cli/commit.md
@@ -1,6 +1,6 @@
 # Commit
 
-Push pending configuration changes to Strata Cloud Manager.
+Push pending configuration changes to Strata Cloud Manager. The `scm commit` command initiates a commit job for one or more folders, optionally waiting for completion.
 
 ## Syntax
 
@@ -16,22 +16,72 @@ scm commit [OPTIONS]
 | `--description TEXT` | Description of the commit | Yes |
 | `--sync` | Wait synchronously for the commit to complete | No |
 | `--timeout INT` | Timeout in seconds when using --sync (default: 300) | No |
+| `--admin TEXT` | Admin user for commit (required for bearer token auth) | No |
 
 ## Examples
 
+#### Basic Commit
+
 ```bash
-# Basic commit
-$ scm commit --folder Texas --description "Update address objects"
+$ scm commit \
+    --folder Texas \
+    --description "Update address objects"
+---> 100%
+Commit successful!
+Job ID: 12345
+```
 
-# Multi-folder commit
-$ scm commit --folder Texas --folder California --description "Multi-folder update"
+#### Multi-Folder Commit
 
-# Synchronous commit (waits for completion)
-$ scm commit --folder Texas --description "Deploy changes" --sync
+```bash
+$ scm commit \
+    --folder Texas \
+    --folder California \
+    --description "Multi-folder update"
+---> 100%
+Commit successful!
+Job ID: 12346
+```
 
-# Synchronous with custom timeout
-$ scm commit --folder Texas --description "Deploy changes" --sync --timeout 600
+#### Synchronous Commit
+
+```bash
+$ scm commit \
+    --folder Texas \
+    --description "Deploy changes" \
+    --sync
+---> 100%
+Commit successful!
+Job ID: 12347
+Status: FIN
+```
+
+#### Synchronous Commit with Custom Timeout
+
+```bash
+$ scm commit \
+    --folder Texas \
+    --description "Deploy changes" \
+    --sync \
+    --timeout 600
+---> 100%
+Commit successful!
+Job ID: 12348
+Status: FIN
+```
+
+#### Commit with Bearer Token Auth
+
+```bash
+$ scm commit \
+    --folder Texas \
+    --description "Deploy changes" \
+    --admin user@domain.com
+---> 100%
+Commit successful!
+Job ID: 12349
 ```
 
 !!! tip
-    After an async commit, use `scm jobs status --id <JOB_ID>` to check progress or `scm jobs wait --id <JOB_ID>` to wait for completion.
+    After an async commit, use `scm jobs status --id <JOB_ID>` to check progress
+    or `scm jobs wait --id <JOB_ID>` to wait for completion.

--- a/docs/cli/insights.md
+++ b/docs/cli/insights.md
@@ -5,11 +5,12 @@ The `scm insights` commands provide access to monitoring and telemetry data from
 ## Overview
 
 The insights commands allow you to:
-- View security and system alerts
+
+- View security and system alerts with severity filtering
 - Monitor mobile user connections and activity
-- Track location-based metrics
-- Analyze remote network performance
-- Check service connection health
+- Track location-based metrics and capacity
+- Analyze remote network connectivity and performance
+- Check service connection health status
 - Monitor tunnel status and statistics
 
 ## Prerequisites
@@ -24,165 +25,407 @@ The insights commands allow you to:
 
 View and export security and system alerts from your Prisma Access environment.
 
-#### List all alerts
+| Option | Description | Required |
+| --- | --- | --- |
+| `--list` | List all alerts | No\* |
+| `--id TEXT` | Get a specific alert by ID | No\* |
+| `--real-time` | Monitor alerts in real-time (continuous polling) | No\* |
+| `--severity TEXT` | Filter alerts by severity (Critical, High, Medium, Low) | No |
+| `--start DATETIME` | Filter alerts starting from this time (ISO format) | No |
+| `--end DATETIME` | Filter alerts up to this time (ISO format) | No |
+| `--folder TEXT` | Filter alerts by folder | No |
+| `--max-results INT` | Maximum number of results to return (default: 10) | No |
+| `--export TEXT` | Export format (json, csv) | No |
+| `--output TEXT` | Output file path for export | No |
+| `--mock` | Run in mock mode | No |
+
+\* One of --list, --id, or --real-time is required.
+
+#### List All Alerts
+
 ```bash
-scm insights alerts --list
+$ scm insights alerts --list
+---> 100%
+- id: alert-001
+  name: Critical CPU Usage
+  severity: critical
+  status: active
+  timestamp: '2026-03-08T10:30:00Z'
 ```
 
-#### Filter alerts by severity
+#### Filter Alerts by Severity
+
 ```bash
-scm insights alerts --list --severity critical
-scm insights alerts --list --severity high,medium
+$ scm insights alerts --list --severity critical
+---> 100%
+- id: alert-001
+  name: Critical CPU Usage
+  severity: critical
+  status: active
 ```
 
-#### Filter alerts by time range
-```bash
-# Last 7 days
-scm insights alerts --list --start 7
+#### Filter Alerts by Time Range
 
-# Specific date range
-scm insights alerts --list --start 2024-01-01T00:00:00 --end 2024-01-31T23:59:59
+```bash
+$ scm insights alerts --list \
+    --start "2026-03-01T00:00:00" \
+    --end "2026-03-08T23:59:59"
+---> 100%
+- id: alert-001
+  name: Critical CPU Usage
+  severity: critical
 ```
 
-#### Get a specific alert
+#### Get a Specific Alert
+
 ```bash
-scm insights alerts --id alert-001
+$ scm insights alerts --id alert-001
+---> 100%
+id: alert-001
+name: Critical CPU Usage
+severity: critical
+status: active
+timestamp: '2026-03-08T10:30:00Z'
+description: CPU usage exceeded 95% threshold
+impacted_resources:
+  - fw-01
+  - fw-02
 ```
 
-#### Export alerts
-```bash
-# Export to JSON
-scm insights alerts --list --export json --output alerts.json
+#### Export Alerts to JSON
 
-# Export to CSV
-scm insights alerts --list --export csv --output alerts.csv
+```bash
+$ scm insights alerts --list \
+    --export json \
+    --output alerts.json
+---> 100%
+Data exported to alerts.json
+```
+
+#### Export Alerts to CSV
+
+```bash
+$ scm insights alerts --list \
+    --export csv \
+    --output alerts.csv
+---> 100%
+Data exported to alerts.csv
 ```
 
 ### Mobile Users
 
 Monitor mobile user connections and activity.
 
-#### List all mobile users
+| Option | Description | Required |
+| --- | --- | --- |
+| `--list` | List all mobile users | No\* |
+| `--id TEXT` | Get a specific mobile user by ID | No\* |
+| `--status TEXT` | Filter by status (connected, disconnected) | No |
+| `--location TEXT` | Filter by location | No |
+| `--folder TEXT` | Filter by folder | No |
+| `--max-results INT` | Maximum number of results to return (default: 100) | No |
+| `--export TEXT` | Export format (json, csv) | No |
+| `--output TEXT` | Output file path for export | No |
+| `--mock` | Run in mock mode | No |
+
+\* One of --list or --id is required.
+
+#### List All Mobile Users
+
 ```bash
-scm insights mobile-users --list
+$ scm insights mobile-users --list
+---> 100%
+- id: user-001
+  username: jsmith@example.com
+  status: connected
+  location: New York
 ```
 
-#### Filter by connection status
+#### Filter by Connection Status
+
 ```bash
-scm insights mobile-users --list --status connected
-scm insights mobile-users --list --status disconnected
+$ scm insights mobile-users --list --status connected
+---> 100%
+- id: user-001
+  username: jsmith@example.com
+  status: connected
+  location: New York
 ```
 
-#### Filter by location
+#### Filter by Location
+
 ```bash
-scm insights mobile-users --list --location "New York"
+$ scm insights mobile-users --list --location "New York"
+---> 100%
+- id: user-001
+  username: jsmith@example.com
+  status: connected
+  location: New York
 ```
 
-#### Get a specific user
+#### Get a Specific User
+
 ```bash
-scm insights mobile-users --id user-001
+$ scm insights mobile-users --id user-001
+---> 100%
+id: user-001
+username: jsmith@example.com
+status: connected
+location: New York
 ```
 
 ### Locations
 
 View location-based metrics and capacity information.
 
-#### List all locations
+| Option | Description | Required |
+| --- | --- | --- |
+| `--list` | List all locations | No\* |
+| `--id TEXT` | Get a specific location by ID | No\* |
+| `--region TEXT` | Filter by geographic region | No |
+| `--folder TEXT` | Filter by folder | No |
+| `--max-results INT` | Maximum number of results to return (default: 100) | No |
+| `--export TEXT` | Export format (json, csv) | No |
+| `--output TEXT` | Output file path for export | No |
+| `--mock` | Run in mock mode | No |
+
+\* One of --list or --id is required.
+
+#### List All Locations
+
 ```bash
-scm insights locations --list
+$ scm insights locations --list
+---> 100%
+- id: loc-001
+  name: US East
+  region: us-east
+  status: active
 ```
 
-#### Filter by region
+#### Filter by Region
+
 ```bash
-scm insights locations --list --region us-east
+$ scm insights locations --list --region us-east
+---> 100%
+- id: loc-001
+  name: US East
+  region: us-east
+  status: active
 ```
 
-#### Get location details
+#### Get Location Details
+
 ```bash
-scm insights locations --id loc-001
+$ scm insights locations --id loc-001
+---> 100%
+id: loc-001
+name: US East
+region: us-east
+status: active
+capacity: 85%
 ```
 
 ### Remote Networks
 
 Monitor remote network connectivity and performance.
 
-#### List all remote networks
+| Option | Description | Required |
+| --- | --- | --- |
+| `--list` | List all remote networks | No\* |
+| `--id TEXT` | Get a specific remote network by ID | No\* |
+| `--connectivity TEXT` | Filter by connectivity status (connected, disconnected, degraded) | No |
+| `--metrics` | Include performance metrics | No |
+| `--folder TEXT` | Filter by folder | No |
+| `--max-results INT` | Maximum number of results to return (default: 100) | No |
+| `--export TEXT` | Export format (json, csv) | No |
+| `--output TEXT` | Output file path for export | No |
+| `--mock` | Run in mock mode | No |
+
+\* One of --list or --id is required.
+
+#### List All Remote Networks
+
 ```bash
-scm insights remote-networks --list
+$ scm insights remote-networks --list
+---> 100%
+- id: rn-001
+  name: Branch-Office-1
+  connectivity: connected
+  site: Dallas
 ```
 
-#### Filter by connectivity status
+#### Filter by Connectivity Status
+
 ```bash
-scm insights remote-networks --list --connectivity degraded
+$ scm insights remote-networks --list --connectivity degraded
+---> 100%
+- id: rn-003
+  name: Branch-Office-3
+  connectivity: degraded
+  site: Austin
 ```
 
-#### Include performance metrics
+#### Include Performance Metrics
+
 ```bash
-scm insights remote-networks --list --metrics
+$ scm insights remote-networks --list --metrics
+---> 100%
+- id: rn-001
+  name: Branch-Office-1
+  connectivity: connected
+  latency_ms: 12
+  throughput_mbps: 450
 ```
 
-#### Get specific network details
+#### Get Specific Network Details
+
 ```bash
-scm insights remote-networks --id rn-001 --metrics
+$ scm insights remote-networks --id rn-001 --metrics
+---> 100%
+id: rn-001
+name: Branch-Office-1
+connectivity: connected
+latency_ms: 12
+throughput_mbps: 450
+packet_loss: 0.01%
 ```
 
 ### Service Connections
 
 Monitor cloud service connections and their health status.
 
-#### List all service connections
+| Option | Description | Required |
+| --- | --- | --- |
+| `--list` | List all service connections | No\* |
+| `--id TEXT` | Get a specific service connection by ID | No\* |
+| `--health TEXT` | Filter by health status (healthy, unhealthy, degraded) | No |
+| `--metrics` | Include performance metrics (latency, throughput) | No |
+| `--folder TEXT` | Filter by folder | No |
+| `--max-results INT` | Maximum number of results to return (default: 100) | No |
+| `--export TEXT` | Export format (json, csv) | No |
+| `--output TEXT` | Output file path for export | No |
+| `--mock` | Run in mock mode | No |
+
+\* One of --list or --id is required.
+
+#### List All Service Connections
+
 ```bash
-scm insights service-connections --list
+$ scm insights service-connections --list
+---> 100%
+- id: sc-001
+  name: AWS-US-East
+  health: healthy
+  type: aws
 ```
 
-#### Filter by health status
+#### Filter by Health Status
+
 ```bash
-scm insights service-connections --list --health unhealthy
+$ scm insights service-connections --list --health unhealthy
+---> 100%
+- id: sc-003
+  name: Azure-EU-West
+  health: unhealthy
+  type: azure
 ```
 
-#### Include performance metrics
+#### Include Performance Metrics
+
 ```bash
-scm insights service-connections --list --metrics
+$ scm insights service-connections --list --metrics
+---> 100%
+- id: sc-001
+  name: AWS-US-East
+  health: healthy
+  latency_ms: 8
+  throughput_mbps: 920
 ```
 
 ### Tunnels
 
 Monitor IPSec and SSL tunnel status and performance.
 
-#### List all tunnels
+| Option | Description | Required |
+| --- | --- | --- |
+| `--list` | List all tunnels | No\* |
+| `--id TEXT` | Get a specific tunnel by ID | No\* |
+| `--status TEXT` | Filter by tunnel status (up, down) | No |
+| `--stats` | Include performance statistics | No |
+| `--start DATETIME` | Filter historical data from this time (ISO format) | No |
+| `--end DATETIME` | Filter historical data up to this time (ISO format) | No |
+| `--folder TEXT` | Filter by folder | No |
+| `--max-results INT` | Maximum number of results to return (default: 100) | No |
+| `--export TEXT` | Export format (json, csv) | No |
+| `--output TEXT` | Output file path for export | No |
+| `--mock` | Run in mock mode | No |
+
+\* One of --list or --id is required.
+
+#### List All Tunnels
+
 ```bash
-scm insights tunnels --list
+$ scm insights tunnels --list
+---> 100%
+- id: tunnel-001
+  name: HQ-to-Branch1
+  status: up
+  type: ipsec
 ```
 
-#### Filter by status
+#### Filter by Status
+
 ```bash
-scm insights tunnels --list --status down
+$ scm insights tunnels --list --status down
+---> 100%
+- id: tunnel-003
+  name: HQ-to-Branch3
+  status: down
+  type: ipsec
 ```
 
-#### Include statistics
+#### Include Statistics
+
 ```bash
-scm insights tunnels --list --stats
+$ scm insights tunnels --list --stats
+---> 100%
+- id: tunnel-001
+  name: HQ-to-Branch1
+  status: up
+  bytes_in: 1234567890
+  bytes_out: 987654321
 ```
 
-#### Get historical data
+#### Get Historical Data
+
 ```bash
-scm insights tunnels --list --start 2024-01-01T00:00:00 --end 2024-01-31T23:59:59
+$ scm insights tunnels --list \
+    --start "2026-03-01T00:00:00" \
+    --end "2026-03-08T23:59:59"
+---> 100%
+- id: tunnel-001
+  name: HQ-to-Branch1
+  status: up
 ```
 
 ## Common Options
 
 All insights commands support these common options:
 
-- `--folder`: Filter by folder
-- `--max-results`: Limit the number of results (default: 100)
-- `--export`: Export format (json or csv)
-- `--output`: Output file path for exports
-- `--mock`: Run in mock mode for testing
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Filter by folder | No |
+| `--max-results INT` | Limit the number of results (default varies by command) | No |
+| `--export TEXT` | Export format (json or csv) | No |
+| `--output TEXT` | Output file path for exports | No |
+| `--mock` | Run in mock mode for testing | No |
 
 ## Export Formats
 
 ### JSON Export
+
 Exports data in JSON format with full field details:
+
 ```json
 [
   {
@@ -190,7 +433,7 @@ Exports data in JSON format with full field details:
     "name": "Critical CPU Usage",
     "severity": "critical",
     "status": "active",
-    "timestamp": "2024-01-20T10:30:00Z",
+    "timestamp": "2026-03-08T10:30:00Z",
     "description": "CPU usage exceeded 95% threshold",
     "impacted_resources": ["fw-01", "fw-02"]
   }
@@ -198,27 +441,19 @@ Exports data in JSON format with full field details:
 ```
 
 ### CSV Export
+
 Exports data in CSV format with flattened fields:
+
 ```csv
 id,name,severity,status,timestamp,description
-alert-001,Critical CPU Usage,critical,active,2024-01-20T10:30:00Z,CPU usage exceeded 95% threshold
+alert-001,Critical CPU Usage,critical,active,2026-03-08T10:30:00Z,CPU usage exceeded 95% threshold
 ```
-
-## Mock Mode
-
-All insights commands support mock mode for testing and development:
-
-```bash
-# Force mock mode by clearing credentials
-SCM_CLIENT_ID="" SCM_CLIENT_SECRET="" SCM_TSG_ID="" scm insights alerts --list
-```
-
-This returns realistic sample data without making actual API calls.
 
 ## Notes
 
 - The insights APIs require appropriate permissions in your Strata Cloud Manager tenant
 - Some metrics and statistics may have a delay of several minutes
-- Export operations respect the --max-results limit
-- Time filters accept both relative days (e.g., 7 for last 7 days) and ISO timestamps
-- The insights functionality requires the pan-scm-sdk to have the insights services implemented
+- Export operations respect the `--max-results` limit
+- Time filters accept ISO timestamps (e.g., `2026-03-01T00:00:00`)
+- Alerts default to the last 7 days when no `--start` time is specified
+- All commands support `--mock` for testing without API credentials

--- a/docs/cli/jobs.md
+++ b/docs/cli/jobs.md
@@ -1,10 +1,12 @@
 # Jobs
 
-Jobs track the status of configuration operations in Strata Cloud Manager.
+Jobs track the status of configuration operations in Strata Cloud Manager. The `scm jobs` commands allow you to list recent jobs, check the status of a specific job, and wait for a job to complete.
 
 ## List Jobs
 
-Display recent SCM configuration jobs.
+Display recent SCM configuration jobs in a tabular format.
+
+### Syntax
 
 ```bash
 scm jobs list [OPTIONS]
@@ -16,45 +18,140 @@ scm jobs list [OPTIONS]
 | --- | --- | --- |
 | `--max-results INT` | Maximum number of jobs to display (default: 25) | No |
 
-### Example
+### Examples
+
+#### List Recent Jobs
 
 ```bash
 $ scm jobs list
+---> 100%
+                         SCM Jobs
+┌────────┬───────────┬────────┬──────────────────┬────────────┬────────────┐
+│ Job ID │ Type      │ Status │ Description      │ Start Time │ End Time   │
+├────────┼───────────┼────────┼──────────────────┼────────────┼────────────┤
+│ 12345  │ CommitAll │ FIN    │ Deploy changes   │ 2026-03-08 │ 2026-03-08 │
+│ 12344  │ CommitAll │ FIN    │ Update objects   │ 2026-03-07 │ 2026-03-07 │
+└────────┴───────────┴────────┴──────────────────┴────────────┴────────────┘
+
+Showing 2 of 2 jobs
+```
+
+#### List with Custom Result Limit
+
+```bash
 $ scm jobs list --max-results 50
+---> 100%
+                         SCM Jobs
+┌────────┬───────────┬────────┬──────────────────┬────────────┬────────────┐
+│ Job ID │ Type      │ Status │ Description      │ Start Time │ End Time   │
+├────────┼───────────┼────────┼──────────────────┼────────────┼────────────┤
+│ 12345  │ CommitAll │ FIN    │ Deploy changes   │ 2026-03-08 │ 2026-03-08 │
+│ ...    │ ...       │ ...    │ ...              │ ...        │ ...        │
+└────────┴───────────┴────────┴──────────────────┴────────────┴────────────┘
+
+Showing 50 of 120 jobs
 ```
 
 ## Job Status
 
-Get the status of a specific job.
+Get the detailed status of a specific job by its ID.
+
+### Syntax
 
 ```bash
-scm jobs status --id JOB_ID
-```
-
-### Example
-
-```bash
-$ scm jobs status --id 12345
-```
-
-## Wait for Job
-
-Wait for a job to complete, polling until finished or timeout.
-
-```bash
-scm jobs wait --id JOB_ID [OPTIONS]
+scm jobs status [OPTIONS]
 ```
 
 ### Options
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--id TEXT` | Job ID | Yes |
+| `--id TEXT` | Job ID to query | Yes |
+
+### Examples
+
+#### Check a Completed Job
+
+```bash
+$ scm jobs status --id 12345
+---> 100%
+
+Job Details for ID: 12345
+--------------------------------------------------
+  id: 12345
+  type_str: CommitAll
+  status_str: FIN
+  description: Deploy changes
+  start_ts: 2026-03-08T10:30:00Z
+  end_ts: 2026-03-08T10:31:15Z
+```
+
+#### Check a Pending Job
+
+```bash
+$ scm jobs status --id 12350
+---> 100%
+
+Job Details for ID: 12350
+--------------------------------------------------
+  id: 12350
+  type_str: CommitAll
+  status_str: PEND
+  description: Update security rules
+  start_ts: 2026-03-08T11:00:00Z
+```
+
+## Wait for Job
+
+Wait for a job to complete by polling its status until finished or timeout is reached.
+
+### Syntax
+
+```bash
+scm jobs wait [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--id TEXT` | Job ID to wait for | Yes |
 | `--timeout INT` | Timeout in seconds (default: 300) | No |
 
-### Example
+### Examples
+
+#### Wait for Job Completion
 
 ```bash
 $ scm jobs wait --id 12345
-$ scm jobs wait --id 12345 --timeout 600
+Waiting for job 12345 to complete (timeout: 300s)...
+---> 100%
+
+Job 12345 completed with status: FIN
+--------------------------------------------------
+  id: 12345
+  type_str: CommitAll
+  status_str: FIN
+  description: Deploy changes
+  start_ts: 2026-03-08T10:30:00Z
+  end_ts: 2026-03-08T10:31:15Z
 ```
+
+#### Wait with Custom Timeout
+
+```bash
+$ scm jobs wait --id 12345 --timeout 600
+Waiting for job 12345 to complete (timeout: 600s)...
+---> 100%
+
+Job 12345 completed with status: FIN
+--------------------------------------------------
+  id: 12345
+  type_str: CommitAll
+  status_str: FIN
+  description: Deploy changes
+```
+
+!!! tip
+    Use `scm jobs wait` after an async commit to block until the configuration
+    is fully deployed. Combine with `--timeout` for long-running operations.


### PR DESCRIPTION
## Summary
- Standardize `docs/cli/commit.md`, `docs/cli/jobs.md`, `docs/cli/insights.md` to the docs-style skill conventions (CLI Special category)
- Add proper option tables with 3-column format, backtick option names with type hints, and Required column
- Add realistic output examples with `---> 100%` progress indicators and proper formatting
- Add missing `--admin` option to commit docs, full options tables for all insights subcommands

## Test plan
- [ ] Verify `make docs-build` passes
- [ ] Verify `make docs-serve` renders all three pages correctly
- [ ] Spot-check option tables match actual CLI options in source code

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)