### PR TITLE
docs: standardize Identity CLI reference pages

### DIFF
--- a/docs/cli/identity/authentication-profile.md
+++ b/docs/cli/identity/authentication-profile.md
@@ -1,8 +1,22 @@
 # Authentication Profile
 
-Authentication profiles define how users authenticate, supporting LDAP, RADIUS, Kerberos, SAML, and other methods.
+Authentication profiles define how users authenticate to Palo Alto Networks Strata Cloud Manager, supporting LDAP, RADIUS, Kerberos, SAML, and other methods. The `scm` CLI provides commands to create, update, delete, and bulk manage authentication profiles.
+
+## Overview
+
+The `authentication-profile` commands allow you to:
+
+- Create authentication profiles with various authentication methods
+- Update existing profile configurations including lockout and MFA settings
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set Authentication Profile
+
+Create or update an authentication profile.
+
+### Syntax
 
 ```bash
 scm set identity authentication-profile [OPTIONS]
@@ -12,32 +26,266 @@ scm set identity authentication-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder scope | No* |
-| `--snippet TEXT` | Snippet scope | No* |
-| `--device TEXT` | Device scope | No* |
 | `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--method TEXT` | Authentication method as JSON | No |
 | `--user-domain TEXT` | User domain | No |
 | `--username-modifier TEXT` | Username modifier pattern | No |
 | `--lockout TEXT` | Lockout configuration as JSON | No |
 | `--allow-list TEXT` | Allow list entries | No |
-| `--multi-factor-auth TEXT` | Multi-factor auth config as JSON | No |
-| `--single-sign-on TEXT` | SSO config as JSON | No |
+| `--multi-factor-auth TEXT` | Multi-factor auth configuration as JSON | No |
+| `--single-sign-on TEXT` | SSO configuration as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create LDAP Authentication Profile
+
+```bash
+$ scm set identity authentication-profile \
+    --folder Texas \
+    --name corp-ldap-auth \
+    --method '{"ldap": {"server_profile": "corp-ldap", "login_attribute": "sAMAccountName"}}' \
+    --user-domain "example.com"
+---> 100%
+Created authentication-profile: corp-ldap-auth in folder Texas
+```
+
+#### Create RADIUS Authentication Profile with Lockout
+
+```bash
+$ scm set identity authentication-profile \
+    --folder Texas \
+    --name corp-radius-auth \
+    --method '{"radius": {"server_profile": "corp-radius"}}' \
+    --lockout '{"failed_attempts": 5, "lockout_time": 30}'
+---> 100%
+Created authentication-profile: corp-radius-auth in folder Texas
+```
+
+#### Create SAML Profile with MFA
+
+```bash
+$ scm set identity authentication-profile \
+    --folder Texas \
+    --name corp-saml-mfa \
+    --method '{"saml_idp": {"server_profile": "corp-saml"}}' \
+    --multi-factor-auth '{"mfa_enable": true, "factors": ["okta-otp"]}' \
+    --single-sign-on '{"realm": "example.com"}'
+---> 100%
+Created authentication-profile: corp-saml-mfa in folder Texas
+```
+
+## Delete Authentication Profile
+
+Delete an authentication profile from SCM.
+
+### Syntax
+
+```bash
+scm delete identity authentication-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set identity authentication-profile --folder Texas --name my-auth \
-    --method '{"ldap": {"server_profile": "corp-ldap", "login_attribute": "sAMAccountName"}}'
+$ scm delete identity authentication-profile \
+    --folder Texas \
+    --name corp-ldap-auth
+---> 100%
+Deleted authentication-profile: corp-ldap-auth from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load Authentication Profile
+
+Load multiple authentication profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show identity authentication-profile --folder Texas
-scm delete identity authentication-profile --folder Texas --name my-auth
-scm load identity authentication-profile --file auth-profiles.yaml
-scm backup identity authentication-profile --folder Texas
+scm load identity authentication-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location override | No |
+| `--snippet TEXT` | Snippet location override | No |
+| `--device TEXT` | Device location override | No |
+| `--dry-run` | Preview changes without applying | No |
+
+### YAML File Format
+
+```yaml
+---
+authentication_profiles:
+  - name: corp-ldap-auth
+    folder: Texas
+    method:
+      ldap:
+        server_profile: corp-ldap
+        login_attribute: sAMAccountName
+    user_domain: example.com
+
+  - name: corp-radius-auth
+    folder: Texas
+    method:
+      radius:
+        server_profile: corp-radius
+    lockout:
+      failed_attempts: 5
+      lockout_time: 30
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load identity authentication-profile --file auth-profiles.yml
+---> 100%
+✓ Loaded authentication-profile: corp-ldap-auth
+✓ Loaded authentication-profile: corp-radius-auth
+
+Successfully loaded 2 out of 2 authentication-profiles from 'auth-profiles.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load identity authentication-profile \
+    --file auth-profiles.yml \
+    --folder Austin
+---> 100%
+✓ Loaded authentication-profile: corp-ldap-auth
+✓ Loaded authentication-profile: corp-radius-auth
+
+Successfully loaded 2 out of 2 authentication-profiles from 'auth-profiles.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all authentication
+    profiles will be loaded into the specified container, ignoring the container specified in
+    the YAML file.
+
+## Show Authentication Profile
+
+Display authentication profile objects.
+
+### Syntax
+
+```bash
+scm show identity authentication-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | No |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Authentication Profile
+
+```bash
+$ scm show identity authentication-profile \
+    --folder Texas \
+    --name corp-ldap-auth
+---> 100%
+Authentication Profile: corp-ldap-auth
+  Location: Folder 'Texas'
+  Method: LDAP
+  Server Profile: corp-ldap
+  User Domain: example.com
+```
+
+#### List All Authentication Profiles (Default Behavior)
+
+```bash
+$ scm show identity authentication-profile --folder Texas
+---> 100%
+Authentication Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: corp-ldap-auth
+  Method: LDAP
+  Server Profile: corp-ldap
+------------------------------------------------------------
+Name: corp-radius-auth
+  Method: RADIUS
+  Server Profile: corp-radius
+------------------------------------------------------------
+```
+
+## Backup Authentication Profiles
+
+Backup all authentication profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup identity authentication-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup identity authentication-profile --folder Texas
+---> 100%
+Successfully backed up 5 authentication-profiles to authentication_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup identity authentication-profile \
+    --folder Texas \
+    --file texas-auth-profiles.yaml
+---> 100%
+Successfully backed up 5 authentication-profiles to texas-auth-profiles.yaml
+```
+
+## Best Practices
+
+1. **Use Descriptive Names**: Name profiles by their authentication method and purpose (e.g., `corp-ldap-auth`, `vpn-radius-auth`) for easy identification.
+2. **Configure Lockout Policies**: Set failed attempt thresholds and lockout durations to protect against brute-force attacks.
+3. **Enable Multi-Factor Authentication**: Add MFA factors to critical authentication profiles for enhanced security.
+4. **Backup Before Changes**: Export existing profiles before making modifications to enable quick rollback if needed.
+5. **Use YAML for Bulk Operations**: Manage multiple authentication profiles through YAML files to ensure consistency and repeatability.

--- a/docs/cli/identity/kerberos-server-profile.md
+++ b/docs/cli/identity/kerberos-server-profile.md
@@ -1,8 +1,22 @@
 # Kerberos Server Profile
 
-Kerberos server profiles configure KDC (Key Distribution Center) servers for Kerberos authentication.
+Kerberos server profiles configure KDC (Key Distribution Center) server connections for Kerberos authentication in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, and bulk manage Kerberos server profiles.
+
+## Overview
+
+The `kerberos-server-profile` commands allow you to:
+
+- Create Kerberos server profiles with KDC server configurations
+- Update existing profile server lists and settings
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set Kerberos Server Profile
+
+Create or update a Kerberos server profile.
+
+### Syntax
 
 ```bash
 scm set identity kerberos-server-profile [OPTIONS]
@@ -12,27 +26,242 @@ scm set identity kerberos-server-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder scope | No* |
-| `--snippet TEXT` | Snippet scope | No* |
-| `--device TEXT` | Device scope | No* |
 | `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--servers TEXT` | Server list as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create Kerberos Server Profile
+
+```bash
+$ scm set identity kerberos-server-profile \
+    --folder Texas \
+    --name corp-kerberos \
+    --servers '[{"name": "kdc1", "host": "kdc1.example.com", "port": 88}]'
+---> 100%
+Created kerberos-server-profile: corp-kerberos in folder Texas
+```
+
+#### Create Profile with Multiple KDC Servers
+
+```bash
+$ scm set identity kerberos-server-profile \
+    --folder Texas \
+    --name corp-kerberos-ha \
+    --servers '[{"name": "kdc1", "host": "kdc1.example.com", "port": 88}, {"name": "kdc2", "host": "kdc2.example.com", "port": 88}]'
+---> 100%
+Created kerberos-server-profile: corp-kerberos-ha in folder Texas
+```
+
+## Delete Kerberos Server Profile
+
+Delete a Kerberos server profile from SCM.
+
+### Syntax
+
+```bash
+scm delete identity kerberos-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set identity kerberos-server-profile --folder Texas --name corp-kerberos \
-    --servers '[{"name": "kdc1", "host": "kdc1.example.com", "port": 88}]'
+$ scm delete identity kerberos-server-profile \
+    --folder Texas \
+    --name corp-kerberos
+---> 100%
+Deleted kerberos-server-profile: corp-kerberos from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load Kerberos Server Profile
+
+Load multiple Kerberos server profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show identity kerberos-server-profile --folder Texas --list
-scm show identity kerberos-server-profile --folder Texas --name corp-kerberos
-scm delete identity kerberos-server-profile --folder Texas --name corp-kerberos
-scm load identity kerberos-server-profile --file kerberos.yaml
-scm backup identity kerberos-server-profile --folder Texas
+scm load identity kerberos-server-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location override | No |
+| `--snippet TEXT` | Snippet location override | No |
+| `--device TEXT` | Device location override | No |
+| `--dry-run` | Preview changes without applying | No |
+
+### YAML File Format
+
+```yaml
+---
+kerberos_server_profiles:
+  - name: corp-kerberos
+    folder: Texas
+    servers:
+      - name: kdc1
+        host: kdc1.example.com
+        port: 88
+
+  - name: branch-kerberos
+    folder: Texas
+    servers:
+      - name: kdc-branch1
+        host: kdc-branch1.example.com
+        port: 88
+      - name: kdc-branch2
+        host: kdc-branch2.example.com
+        port: 88
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load identity kerberos-server-profile --file kerberos.yml
+---> 100%
+✓ Loaded kerberos-server-profile: corp-kerberos
+✓ Loaded kerberos-server-profile: branch-kerberos
+
+Successfully loaded 2 out of 2 kerberos-server-profiles from 'kerberos.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load identity kerberos-server-profile \
+    --file kerberos.yml \
+    --folder Austin
+---> 100%
+✓ Loaded kerberos-server-profile: corp-kerberos
+✓ Loaded kerberos-server-profile: branch-kerberos
+
+Successfully loaded 2 out of 2 kerberos-server-profiles from 'kerberos.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all Kerberos server
+    profiles will be loaded into the specified container, ignoring the container specified in
+    the YAML file.
+
+## Show Kerberos Server Profile
+
+Display Kerberos server profile objects.
+
+### Syntax
+
+```bash
+scm show identity kerberos-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | No |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Kerberos Server Profile
+
+```bash
+$ scm show identity kerberos-server-profile \
+    --folder Texas \
+    --name corp-kerberos
+---> 100%
+Kerberos Server Profile: corp-kerberos
+  Location: Folder 'Texas'
+  Servers:
+    - kdc1 (kdc1.example.com:88)
+```
+
+#### List All Kerberos Server Profiles (Default Behavior)
+
+```bash
+$ scm show identity kerberos-server-profile --folder Texas
+---> 100%
+Kerberos Server Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: corp-kerberos
+  Servers: kdc1 (kdc1.example.com:88)
+------------------------------------------------------------
+Name: branch-kerberos
+  Servers: kdc-branch1 (kdc-branch1.example.com:88), kdc-branch2 (kdc-branch2.example.com:88)
+------------------------------------------------------------
+```
+
+## Backup Kerberos Server Profiles
+
+Backup all Kerberos server profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup identity kerberos-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup identity kerberos-server-profile --folder Texas
+---> 100%
+Successfully backed up 3 kerberos-server-profiles to kerberos_server_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup identity kerberos-server-profile \
+    --folder Texas \
+    --file texas-kerberos.yaml
+---> 100%
+Successfully backed up 3 kerberos-server-profiles to texas-kerberos.yaml
+```
+
+## Best Practices
+
+1. **Use Descriptive Profile Names**: Name profiles by environment or location (e.g., `corp-kerberos`, `branch-kerberos`) for easy identification.
+2. **Configure Multiple KDC Servers**: Add redundant KDC servers to ensure high availability for Kerberos authentication.
+3. **Use Standard Ports**: Use port 88 (the Kerberos default) unless your environment requires a non-standard configuration.
+4. **Backup Before Changes**: Export existing profiles before making modifications to enable quick rollback if needed.
+5. **Use YAML for Bulk Operations**: Manage multiple Kerberos server profiles through YAML files to ensure consistency across environments.

--- a/docs/cli/identity/ldap-server-profile.md
+++ b/docs/cli/identity/ldap-server-profile.md
@@ -1,8 +1,31 @@
 # LDAP Server Profile
 
-LDAP server profiles configure directory server connections for user authentication and group lookups.
+LDAP server profiles configure directory server connections for user authentication and group lookups in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, and bulk manage LDAP server profiles.
+
+## Overview
+
+The `ldap-server-profile` commands allow you to:
+
+- Create LDAP server profiles with directory server configurations
+- Update existing profile settings including bind credentials and SSL options
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
+
+## LDAP Types
+
+| Type | Description |
+| --- | --- |
+| `active-directory` | Microsoft Active Directory |
+| `e-directory` | Novell eDirectory |
+| `sun` | Sun/Oracle Directory Server |
+| `other` | Other LDAP-compliant directory |
 
 ## Set LDAP Server Profile
+
+Create or update an LDAP server profile.
+
+### Syntax
 
 ```bash
 scm set identity ldap-server-profile [OPTIONS]
@@ -12,10 +35,10 @@ scm set identity ldap-server-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder scope | No* |
-| `--snippet TEXT` | Snippet scope | No* |
-| `--device TEXT` | Device scope | No* |
 | `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--servers TEXT` | Server list as JSON | No |
 | `--base TEXT` | Base distinguished name | No |
 | `--bind-dn TEXT` | Bind distinguished name | No |
@@ -25,20 +48,265 @@ scm set identity ldap-server-profile [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
+### Examples
+
+#### Create Active Directory Profile
+
+```bash
+$ scm set identity ldap-server-profile \
+    --folder Texas \
+    --name corp-ldap \
+    --servers '[{"name": "ldap1", "address": "ldap.example.com", "port": 389}]' \
+    --base "dc=example,dc=com" \
+    --ldap-type active-directory
+---> 100%
+Created ldap-server-profile: corp-ldap in folder Texas
+```
+
+#### Create LDAP Profile with SSL and Bind Credentials
+
+```bash
+$ scm set identity ldap-server-profile \
+    --folder Texas \
+    --name secure-ldap \
+    --servers '[{"name": "ldaps1", "address": "ldaps.example.com", "port": 636}]' \
+    --base "dc=example,dc=com" \
+    --bind-dn "cn=admin,dc=example,dc=com" \
+    --bind-password "s3cret" \
+    --ldap-type active-directory \
+    --ssl
+---> 100%
+Created ldap-server-profile: secure-ldap in folder Texas
+```
+
+#### Create Profile with Multiple Servers
+
+```bash
+$ scm set identity ldap-server-profile \
+    --folder Texas \
+    --name corp-ldap-ha \
+    --servers '[{"name": "ldap1", "address": "ldap1.example.com", "port": 389}, {"name": "ldap2", "address": "ldap2.example.com", "port": 389}]' \
+    --base "dc=example,dc=com" \
+    --ldap-type active-directory
+---> 100%
+Created ldap-server-profile: corp-ldap-ha in folder Texas
+```
+
+## Delete LDAP Server Profile
+
+Delete an LDAP server profile from SCM.
+
+### Syntax
+
+```bash
+scm delete identity ldap-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
 ### Example
 
 ```bash
-$ scm set identity ldap-server-profile --folder Texas --name corp-ldap \
-    --servers '[{"name": "ldap1", "address": "ldap.example.com", "port": 389}]' \
-    --base "dc=example,dc=com" --ldap-type active-directory
+$ scm delete identity ldap-server-profile \
+    --folder Texas \
+    --name corp-ldap
+---> 100%
+Deleted ldap-server-profile: corp-ldap from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load LDAP Server Profile
+
+Load multiple LDAP server profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show identity ldap-server-profile --folder Texas --list
-scm show identity ldap-server-profile --folder Texas --name corp-ldap
-scm delete identity ldap-server-profile --folder Texas --name corp-ldap
-scm load identity ldap-server-profile --file ldap.yaml
-scm backup identity ldap-server-profile --folder Texas
+scm load identity ldap-server-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location override | No |
+| `--snippet TEXT` | Snippet location override | No |
+| `--device TEXT` | Device location override | No |
+| `--dry-run` | Preview changes without applying | No |
+
+### YAML File Format
+
+```yaml
+---
+ldap_server_profiles:
+  - name: corp-ldap
+    folder: Texas
+    servers:
+      - name: ldap1
+        address: ldap.example.com
+        port: 389
+    base: "dc=example,dc=com"
+    ldap_type: active-directory
+
+  - name: secure-ldap
+    folder: Texas
+    servers:
+      - name: ldaps1
+        address: ldaps.example.com
+        port: 636
+    base: "dc=example,dc=com"
+    bind_dn: "cn=admin,dc=example,dc=com"
+    bind_password: "s3cret"
+    ldap_type: active-directory
+    ssl: true
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load identity ldap-server-profile --file ldap.yml
+---> 100%
+✓ Loaded ldap-server-profile: corp-ldap
+✓ Loaded ldap-server-profile: secure-ldap
+
+Successfully loaded 2 out of 2 ldap-server-profiles from 'ldap.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load identity ldap-server-profile \
+    --file ldap.yml \
+    --folder Austin
+---> 100%
+✓ Loaded ldap-server-profile: corp-ldap
+✓ Loaded ldap-server-profile: secure-ldap
+
+Successfully loaded 2 out of 2 ldap-server-profiles from 'ldap.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all LDAP server
+    profiles will be loaded into the specified container, ignoring the container specified in
+    the YAML file.
+
+## Show LDAP Server Profile
+
+Display LDAP server profile objects.
+
+### Syntax
+
+```bash
+scm show identity ldap-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | No |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific LDAP Server Profile
+
+```bash
+$ scm show identity ldap-server-profile \
+    --folder Texas \
+    --name corp-ldap
+---> 100%
+LDAP Server Profile: corp-ldap
+  Location: Folder 'Texas'
+  LDAP Type: active-directory
+  Base DN: dc=example,dc=com
+  SSL: No
+  Servers:
+    - ldap1 (ldap.example.com:389)
+```
+
+#### List All LDAP Server Profiles (Default Behavior)
+
+```bash
+$ scm show identity ldap-server-profile --folder Texas
+---> 100%
+LDAP Server Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: corp-ldap
+  LDAP Type: active-directory
+  Servers: ldap1 (ldap.example.com:389)
+------------------------------------------------------------
+Name: secure-ldap
+  LDAP Type: active-directory
+  SSL: Yes
+  Servers: ldaps1 (ldaps.example.com:636)
+------------------------------------------------------------
+```
+
+## Backup LDAP Server Profiles
+
+Backup all LDAP server profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup identity ldap-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup identity ldap-server-profile --folder Texas
+---> 100%
+Successfully backed up 4 ldap-server-profiles to ldap_server_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup identity ldap-server-profile \
+    --folder Texas \
+    --file texas-ldap.yaml
+---> 100%
+Successfully backed up 4 ldap-server-profiles to texas-ldap.yaml
+```
+
+## Best Practices
+
+1. **Use SSL for Production**: Always enable SSL (port 636) for LDAP connections in production environments to protect credentials in transit.
+2. **Configure Multiple Servers**: Add redundant LDAP servers to ensure high availability for authentication services.
+3. **Use Service Accounts for Bind**: Create dedicated service accounts with minimal privileges for LDAP bind operations rather than using admin credentials.
+4. **Choose the Correct LDAP Type**: Select the appropriate directory type (active-directory, e-directory, sun, other) to ensure proper attribute mapping.
+5. **Backup Before Changes**: Export existing profiles before making modifications to enable quick rollback if needed.
+6. **Protect Bind Credentials**: Store bind passwords securely and rotate them regularly according to your organization's security policy.

--- a/docs/cli/identity/radius-server-profile.md
+++ b/docs/cli/identity/radius-server-profile.md
@@ -1,8 +1,22 @@
 # RADIUS Server Profile
 
-RADIUS server profiles configure RADIUS servers for authentication, authorization, and accounting (AAA).
+RADIUS server profiles configure RADIUS servers for authentication, authorization, and accounting (AAA) in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, and bulk manage RADIUS server profiles.
+
+## Overview
+
+The `radius-server-profile` commands allow you to:
+
+- Create RADIUS server profiles with server and protocol configurations
+- Update existing profile settings including timeout and retry parameters
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set RADIUS Server Profile
+
+Create or update a RADIUS server profile.
+
+### Syntax
 
 ```bash
 scm set identity radius-server-profile [OPTIONS]
@@ -12,31 +26,275 @@ scm set identity radius-server-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder scope | No* |
-| `--snippet TEXT` | Snippet scope | No* |
-| `--device TEXT` | Device scope | No* |
 | `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--servers TEXT` | Server list as JSON | No |
-| `--protocol TEXT` | Protocol config as JSON | No |
+| `--protocol TEXT` | Protocol configuration as JSON | No |
 | `--timeout INT` | Timeout in seconds (1-120) | No |
 | `--retries INT` | Number of retries (1-5) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create RADIUS Server Profile
+
+```bash
+$ scm set identity radius-server-profile \
+    --folder Texas \
+    --name corp-radius \
+    --servers '[{"name": "rad1", "ip_address": "10.0.0.1", "port": 1812, "secret": "s3cret"}]' \
+    --protocol '{"CHAP": {}}' \
+    --timeout 5 \
+    --retries 3
+---> 100%
+Created radius-server-profile: corp-radius in folder Texas
+```
+
+#### Create Profile with Multiple Servers
+
+```bash
+$ scm set identity radius-server-profile \
+    --folder Texas \
+    --name corp-radius-ha \
+    --servers '[{"name": "rad1", "ip_address": "10.0.0.1", "port": 1812, "secret": "s3cret"}, {"name": "rad2", "ip_address": "10.0.0.2", "port": 1812, "secret": "s3cret"}]' \
+    --timeout 3 \
+    --retries 3
+---> 100%
+Created radius-server-profile: corp-radius-ha in folder Texas
+```
+
+#### Create Profile with PAP Protocol
+
+```bash
+$ scm set identity radius-server-profile \
+    --folder Texas \
+    --name vpn-radius \
+    --servers '[{"name": "rad-vpn", "ip_address": "10.0.1.1", "port": 1812, "secret": "vpn-s3cret"}]' \
+    --protocol '{"PAP": {}}' \
+    --timeout 10
+---> 100%
+Created radius-server-profile: vpn-radius in folder Texas
+```
+
+## Delete RADIUS Server Profile
+
+Delete a RADIUS server profile from SCM.
+
+### Syntax
+
+```bash
+scm delete identity radius-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set identity radius-server-profile --folder Texas --name corp-radius \
-    --servers '[{"name": "rad1", "ip_address": "10.0.0.1", "port": 1812, "secret": "s3cret"}]' \
-    --protocol '{"CHAP": {}}' --timeout 5 --retries 3
+$ scm delete identity radius-server-profile \
+    --folder Texas \
+    --name corp-radius
+---> 100%
+Deleted radius-server-profile: corp-radius from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load RADIUS Server Profile
+
+Load multiple RADIUS server profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show identity radius-server-profile --folder Texas --list
-scm show identity radius-server-profile --folder Texas --name corp-radius
-scm delete identity radius-server-profile --folder Texas --name corp-radius
-scm load identity radius-server-profile --file radius.yaml
-scm backup identity radius-server-profile --folder Texas
+scm load identity radius-server-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location override | No |
+| `--snippet TEXT` | Snippet location override | No |
+| `--device TEXT` | Device location override | No |
+| `--dry-run` | Preview changes without applying | No |
+
+### YAML File Format
+
+```yaml
+---
+radius_server_profiles:
+  - name: corp-radius
+    folder: Texas
+    servers:
+      - name: rad1
+        ip_address: "10.0.0.1"
+        port: 1812
+        secret: s3cret
+    protocol:
+      CHAP: {}
+    timeout: 5
+    retries: 3
+
+  - name: vpn-radius
+    folder: Texas
+    servers:
+      - name: rad-vpn
+        ip_address: "10.0.1.1"
+        port: 1812
+        secret: vpn-s3cret
+    protocol:
+      PAP: {}
+    timeout: 10
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load identity radius-server-profile --file radius.yml
+---> 100%
+✓ Loaded radius-server-profile: corp-radius
+✓ Loaded radius-server-profile: vpn-radius
+
+Successfully loaded 2 out of 2 radius-server-profiles from 'radius.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load identity radius-server-profile \
+    --file radius.yml \
+    --folder Austin
+---> 100%
+✓ Loaded radius-server-profile: corp-radius
+✓ Loaded radius-server-profile: vpn-radius
+
+Successfully loaded 2 out of 2 radius-server-profiles from 'radius.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all RADIUS server
+    profiles will be loaded into the specified container, ignoring the container specified in
+    the YAML file.
+
+## Show RADIUS Server Profile
+
+Display RADIUS server profile objects.
+
+### Syntax
+
+```bash
+scm show identity radius-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | No |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific RADIUS Server Profile
+
+```bash
+$ scm show identity radius-server-profile \
+    --folder Texas \
+    --name corp-radius
+---> 100%
+RADIUS Server Profile: corp-radius
+  Location: Folder 'Texas'
+  Protocol: CHAP
+  Timeout: 5s
+  Retries: 3
+  Servers:
+    - rad1 (10.0.0.1:1812)
+```
+
+#### List All RADIUS Server Profiles (Default Behavior)
+
+```bash
+$ scm show identity radius-server-profile --folder Texas
+---> 100%
+RADIUS Server Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: corp-radius
+  Protocol: CHAP
+  Servers: rad1 (10.0.0.1:1812)
+------------------------------------------------------------
+Name: vpn-radius
+  Protocol: PAP
+  Servers: rad-vpn (10.0.1.1:1812)
+------------------------------------------------------------
+```
+
+## Backup RADIUS Server Profiles
+
+Backup all RADIUS server profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup identity radius-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup identity radius-server-profile --folder Texas
+---> 100%
+Successfully backed up 3 radius-server-profiles to radius_server_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup identity radius-server-profile \
+    --folder Texas \
+    --file texas-radius.yaml
+---> 100%
+Successfully backed up 3 radius-server-profiles to texas-radius.yaml
+```
+
+## Best Practices
+
+1. **Use Strong Shared Secrets**: Configure strong, unique shared secrets for each RADIUS server to secure communication.
+2. **Configure Multiple Servers**: Add redundant RADIUS servers to ensure high availability for authentication services.
+3. **Tune Timeout and Retries**: Set appropriate timeout and retry values based on your network latency to avoid authentication delays.
+4. **Choose the Right Protocol**: Use CHAP for enhanced password security or PAP when compatibility with legacy systems is required.
+5. **Backup Before Changes**: Export existing profiles before making modifications to enable quick rollback if needed.
+6. **Use YAML for Bulk Operations**: Manage multiple RADIUS server profiles through YAML files to ensure consistency across environments.

--- a/docs/cli/identity/saml-server-profile.md
+++ b/docs/cli/identity/saml-server-profile.md
@@ -1,8 +1,22 @@
 # SAML Server Profile
 
-SAML server profiles configure SAML 2.0 Identity Provider connections for single sign-on authentication.
+SAML server profiles configure SAML 2.0 Identity Provider connections for single sign-on authentication in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, and bulk manage SAML server profiles.
+
+## Overview
+
+The `saml-server-profile` commands allow you to:
+
+- Create SAML server profiles with IdP connection settings
+- Update existing profile configurations including SSO and SLO bindings
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set SAML Server Profile
+
+Create or update a SAML server profile.
+
+### Syntax
 
 ```bash
 scm set identity saml-server-profile [OPTIONS]
@@ -12,35 +26,281 @@ scm set identity saml-server-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder scope | No* |
-| `--snippet TEXT` | Snippet scope | No* |
-| `--device TEXT` | Device scope | No* |
 | `--name TEXT` | Profile name | Yes |
-| `--entity-id TEXT` | Entity ID | Yes |
-| `--certificate TEXT` | Certificate name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--entity-id TEXT` | Entity ID of the IdP | Yes |
+| `--certificate TEXT` | Certificate name for IdP verification | Yes |
 | `--sso-url TEXT` | Single Sign-On URL | Yes |
 | `--sso-bindings TEXT` | SSO binding type (post, redirect) | Yes |
 | `--slo-bindings TEXT` | SLO binding type (post, redirect) | No |
 | `--max-clock-skew INT` | Maximum clock skew in seconds (1-900) | No |
-| `--validate-idp-certificate` | Validate IDP certificate | No |
-| `--want-auth-requests-signed` | Want auth requests signed | No |
+| `--validate-idp-certificate` | Validate IdP certificate | No |
+| `--want-auth-requests-signed` | Require signed authentication requests | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create Basic SAML Server Profile
+
+```bash
+$ scm set identity saml-server-profile \
+    --folder Texas \
+    --name corp-saml \
+    --entity-id "https://idp.example.com" \
+    --certificate idp-cert \
+    --sso-url "https://idp.example.com/sso" \
+    --sso-bindings post
+---> 100%
+Created saml-server-profile: corp-saml in folder Texas
+```
+
+#### Create SAML Profile with SLO and Certificate Validation
+
+```bash
+$ scm set identity saml-server-profile \
+    --folder Texas \
+    --name secure-saml \
+    --entity-id "https://idp.example.com" \
+    --certificate idp-cert \
+    --sso-url "https://idp.example.com/sso" \
+    --sso-bindings post \
+    --slo-bindings redirect \
+    --validate-idp-certificate \
+    --want-auth-requests-signed \
+    --max-clock-skew 60
+---> 100%
+Created saml-server-profile: secure-saml in folder Texas
+```
+
+#### Create SAML Profile with Redirect Binding
+
+```bash
+$ scm set identity saml-server-profile \
+    --folder Texas \
+    --name redirect-saml \
+    --entity-id "https://idp.example.com/redirect" \
+    --certificate idp-redirect-cert \
+    --sso-url "https://idp.example.com/sso/redirect" \
+    --sso-bindings redirect
+---> 100%
+Created saml-server-profile: redirect-saml in folder Texas
+```
+
+## Delete SAML Server Profile
+
+Delete a SAML server profile from SCM.
+
+### Syntax
+
+```bash
+scm delete identity saml-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set identity saml-server-profile --folder Texas --name corp-saml \
-    --entity-id "https://idp.example.com" --certificate idp-cert \
-    --sso-url "https://idp.example.com/sso" --sso-bindings post
+$ scm delete identity saml-server-profile \
+    --folder Texas \
+    --name corp-saml
+---> 100%
+Deleted saml-server-profile: corp-saml from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load SAML Server Profile
+
+Load multiple SAML server profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show identity saml-server-profile --folder Texas --list
-scm show identity saml-server-profile --folder Texas --name corp-saml
-scm delete identity saml-server-profile --folder Texas --name corp-saml
-scm load identity saml-server-profile --file saml.yaml
-scm backup identity saml-server-profile --folder Texas
+scm load identity saml-server-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location override | No |
+| `--snippet TEXT` | Snippet location override | No |
+| `--device TEXT` | Device location override | No |
+| `--dry-run` | Preview changes without applying | No |
+
+### YAML File Format
+
+```yaml
+---
+saml_server_profiles:
+  - name: corp-saml
+    folder: Texas
+    entity_id: "https://idp.example.com"
+    certificate: idp-cert
+    sso_url: "https://idp.example.com/sso"
+    sso_bindings: post
+
+  - name: secure-saml
+    folder: Texas
+    entity_id: "https://idp.example.com"
+    certificate: idp-cert
+    sso_url: "https://idp.example.com/sso"
+    sso_bindings: post
+    slo_bindings: redirect
+    validate_idp_certificate: true
+    want_auth_requests_signed: true
+    max_clock_skew: 60
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load identity saml-server-profile --file saml.yml
+---> 100%
+✓ Loaded saml-server-profile: corp-saml
+✓ Loaded saml-server-profile: secure-saml
+
+Successfully loaded 2 out of 2 saml-server-profiles from 'saml.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load identity saml-server-profile \
+    --file saml.yml \
+    --folder Austin
+---> 100%
+✓ Loaded saml-server-profile: corp-saml
+✓ Loaded saml-server-profile: secure-saml
+
+Successfully loaded 2 out of 2 saml-server-profiles from 'saml.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all SAML server
+    profiles will be loaded into the specified container, ignoring the container specified in
+    the YAML file.
+
+## Show SAML Server Profile
+
+Display SAML server profile objects.
+
+### Syntax
+
+```bash
+scm show identity saml-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | No |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific SAML Server Profile
+
+```bash
+$ scm show identity saml-server-profile \
+    --folder Texas \
+    --name corp-saml
+---> 100%
+SAML Server Profile: corp-saml
+  Location: Folder 'Texas'
+  Entity ID: https://idp.example.com
+  SSO URL: https://idp.example.com/sso
+  SSO Bindings: post
+  Certificate: idp-cert
+```
+
+#### List All SAML Server Profiles (Default Behavior)
+
+```bash
+$ scm show identity saml-server-profile --folder Texas
+---> 100%
+SAML Server Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: corp-saml
+  Entity ID: https://idp.example.com
+  SSO Bindings: post
+------------------------------------------------------------
+Name: secure-saml
+  Entity ID: https://idp.example.com
+  SSO Bindings: post
+  SLO Bindings: redirect
+  Validate IdP Certificate: Yes
+------------------------------------------------------------
+```
+
+## Backup SAML Server Profiles
+
+Backup all SAML server profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup identity saml-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup identity saml-server-profile --folder Texas
+---> 100%
+Successfully backed up 3 saml-server-profiles to saml_server_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup identity saml-server-profile \
+    --folder Texas \
+    --file texas-saml.yaml
+---> 100%
+Successfully backed up 3 saml-server-profiles to texas-saml.yaml
+```
+
+## Best Practices
+
+1. **Validate IdP Certificates**: Enable certificate validation in production to prevent man-in-the-middle attacks on SAML assertions.
+2. **Sign Authentication Requests**: Use the `--want-auth-requests-signed` flag for enhanced security in sensitive environments.
+3. **Configure Clock Skew Tolerance**: Set an appropriate `--max-clock-skew` value to accommodate time differences between SP and IdP while minimizing replay attack windows.
+4. **Use POST Bindings for Security**: Prefer POST bindings over redirect bindings as POST transmits SAML data in the request body rather than URL parameters.
+5. **Backup Before Changes**: Export existing profiles before making modifications to enable quick rollback if needed.
+6. **Configure SLO**: Set up Single Logout bindings to ensure users are properly logged out across all SAML-integrated services.

--- a/docs/cli/identity/tacacs-server-profile.md
+++ b/docs/cli/identity/tacacs-server-profile.md
@@ -1,8 +1,22 @@
 # TACACS+ Server Profile
 
-TACACS+ server profiles configure TACACS+ servers for authentication, authorization, and accounting.
+TACACS+ server profiles configure TACACS+ servers for authentication, authorization, and accounting in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, and bulk manage TACACS+ server profiles.
+
+## Overview
+
+The `tacacs-server-profile` commands allow you to:
+
+- Create TACACS+ server profiles with server and protocol configurations
+- Update existing profile settings including timeout and connection options
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set TACACS+ Server Profile
+
+Create or update a TACACS+ server profile.
+
+### Syntax
 
 ```bash
 scm set identity tacacs-server-profile [OPTIONS]
@@ -12,10 +26,10 @@ scm set identity tacacs-server-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder scope | No* |
-| `--snippet TEXT` | Snippet scope | No* |
-| `--device TEXT` | Device scope | No* |
 | `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--servers TEXT` | Server list as JSON | No |
 | `--protocol TEXT` | Protocol type (CHAP, PAP) | No |
 | `--timeout INT` | Timeout in seconds (1-30) | No |
@@ -23,20 +37,261 @@ scm set identity tacacs-server-profile [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
+### Examples
+
+#### Create TACACS+ Server Profile
+
+```bash
+$ scm set identity tacacs-server-profile \
+    --folder Texas \
+    --name corp-tacacs \
+    --servers '[{"name": "tac1", "address": "10.0.0.1", "port": 49, "secret": "s3cret"}]' \
+    --protocol CHAP \
+    --timeout 5
+---> 100%
+Created tacacs-server-profile: corp-tacacs in folder Texas
+```
+
+#### Create Profile with Multiple Servers and Single Connection
+
+```bash
+$ scm set identity tacacs-server-profile \
+    --folder Texas \
+    --name corp-tacacs-ha \
+    --servers '[{"name": "tac1", "address": "10.0.0.1", "port": 49, "secret": "s3cret"}, {"name": "tac2", "address": "10.0.0.2", "port": 49, "secret": "s3cret"}]' \
+    --protocol CHAP \
+    --timeout 3 \
+    --use-single-connection
+---> 100%
+Created tacacs-server-profile: corp-tacacs-ha in folder Texas
+```
+
+#### Create Profile with PAP Protocol
+
+```bash
+$ scm set identity tacacs-server-profile \
+    --folder Texas \
+    --name legacy-tacacs \
+    --servers '[{"name": "tac-legacy", "address": "10.0.1.1", "port": 49, "secret": "legacy-s3cret"}]' \
+    --protocol PAP \
+    --timeout 10
+---> 100%
+Created tacacs-server-profile: legacy-tacacs in folder Texas
+```
+
+## Delete TACACS+ Server Profile
+
+Delete a TACACS+ server profile from SCM.
+
+### Syntax
+
+```bash
+scm delete identity tacacs-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
 ### Example
 
 ```bash
-$ scm set identity tacacs-server-profile --folder Texas --name corp-tacacs \
-    --servers '[{"name": "tac1", "address": "10.0.0.1", "port": 49, "secret": "s3cret"}]' \
-    --protocol CHAP --timeout 5
+$ scm delete identity tacacs-server-profile \
+    --folder Texas \
+    --name corp-tacacs
+---> 100%
+Deleted tacacs-server-profile: corp-tacacs from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load TACACS+ Server Profile
+
+Load multiple TACACS+ server profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show identity tacacs-server-profile --folder Texas --list
-scm show identity tacacs-server-profile --folder Texas --name corp-tacacs
-scm delete identity tacacs-server-profile --folder Texas --name corp-tacacs
-scm load identity tacacs-server-profile --file tacacs.yaml
-scm backup identity tacacs-server-profile --folder Texas
+scm load identity tacacs-server-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location override | No |
+| `--snippet TEXT` | Snippet location override | No |
+| `--device TEXT` | Device location override | No |
+| `--dry-run` | Preview changes without applying | No |
+
+### YAML File Format
+
+```yaml
+---
+tacacs_server_profiles:
+  - name: corp-tacacs
+    folder: Texas
+    servers:
+      - name: tac1
+        address: "10.0.0.1"
+        port: 49
+        secret: s3cret
+    protocol: CHAP
+    timeout: 5
+
+  - name: legacy-tacacs
+    folder: Texas
+    servers:
+      - name: tac-legacy
+        address: "10.0.1.1"
+        port: 49
+        secret: legacy-s3cret
+    protocol: PAP
+    timeout: 10
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load identity tacacs-server-profile --file tacacs.yml
+---> 100%
+✓ Loaded tacacs-server-profile: corp-tacacs
+✓ Loaded tacacs-server-profile: legacy-tacacs
+
+Successfully loaded 2 out of 2 tacacs-server-profiles from 'tacacs.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load identity tacacs-server-profile \
+    --file tacacs.yml \
+    --folder Austin
+---> 100%
+✓ Loaded tacacs-server-profile: corp-tacacs
+✓ Loaded tacacs-server-profile: legacy-tacacs
+
+Successfully loaded 2 out of 2 tacacs-server-profiles from 'tacacs.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all TACACS+ server
+    profiles will be loaded into the specified container, ignoring the container specified in
+    the YAML file.
+
+## Show TACACS+ Server Profile
+
+Display TACACS+ server profile objects.
+
+### Syntax
+
+```bash
+scm show identity tacacs-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | No |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific TACACS+ Server Profile
+
+```bash
+$ scm show identity tacacs-server-profile \
+    --folder Texas \
+    --name corp-tacacs
+---> 100%
+TACACS+ Server Profile: corp-tacacs
+  Location: Folder 'Texas'
+  Protocol: CHAP
+  Timeout: 5s
+  Single Connection: No
+  Servers:
+    - tac1 (10.0.0.1:49)
+```
+
+#### List All TACACS+ Server Profiles (Default Behavior)
+
+```bash
+$ scm show identity tacacs-server-profile --folder Texas
+---> 100%
+TACACS+ Server Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: corp-tacacs
+  Protocol: CHAP
+  Servers: tac1 (10.0.0.1:49)
+------------------------------------------------------------
+Name: legacy-tacacs
+  Protocol: PAP
+  Servers: tac-legacy (10.0.1.1:49)
+------------------------------------------------------------
+```
+
+## Backup TACACS+ Server Profiles
+
+Backup all TACACS+ server profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup identity tacacs-server-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup identity tacacs-server-profile --folder Texas
+---> 100%
+Successfully backed up 3 tacacs-server-profiles to tacacs_server_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup identity tacacs-server-profile \
+    --folder Texas \
+    --file texas-tacacs.yaml
+---> 100%
+Successfully backed up 3 tacacs-server-profiles to texas-tacacs.yaml
+```
+
+## Best Practices
+
+1. **Use Strong Shared Secrets**: Configure strong, unique shared secrets for each TACACS+ server to secure communication.
+2. **Configure Multiple Servers**: Add redundant TACACS+ servers to ensure high availability for authentication services.
+3. **Prefer CHAP over PAP**: Use CHAP for enhanced password security as PAP transmits passwords in cleartext.
+4. **Enable Single Connection**: Use `--use-single-connection` to maintain a persistent TCP connection for improved performance when supported by your TACACS+ server.
+5. **Tune Timeout Values**: Set appropriate timeout values (1-30 seconds) based on your network latency to balance responsiveness and reliability.
+6. **Backup Before Changes**: Export existing profiles before making modifications to enable quick rollback if needed.


### PR DESCRIPTION
## Summary
- Expanded all 6 identity CLI reference pages (authentication-profile, kerberos-server-profile, ldap-server-profile, radius-server-profile, saml-server-profile, tacacs-server-profile) from minimal stubs into full docs-style pages
- Each collapsed "Show / Delete / Load / Backup" section is now expanded into separate H2 sections with Syntax, Options, and Examples subsections
- All pages follow canonical section order: Set, Delete, Load, Show, Backup, Best Practices

Closes #119

## Test plan
- [ ] Verify `make docs-build` passes
- [ ] Verify `make docs-serve` renders all 6 pages correctly
- [ ] Spot-check admonitions, code blocks, and option tables render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)