### PR TITLE
docs: standardize Security CLI reference pages

### DIFF
--- a/docs/cli/security/anti-spyware-profile.md
+++ b/docs/cli/security/anti-spyware-profile.md
@@ -1,8 +1,22 @@
 # Anti-Spyware Profile
 
-Anti-spyware profiles define threat detection and prevention rules for spyware, command-and-control traffic, and other malicious activity.
+Anti-spyware profiles define threat detection and prevention rules for spyware, command-and-control traffic, and other malicious activity. The `scm` CLI provides commands to create, update, delete, and load anti-spyware profiles.
+
+## Overview
+
+The `anti-spyware-profile` commands allow you to:
+
+- Create anti-spyware profiles with threat blocking rules
+- Update existing profile configurations
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set Anti-Spyware Profile
+
+Create or update an anti-spyware profile.
+
+### Syntax
 
 ```bash
 scm set security anti-spyware-profile [OPTIONS]
@@ -12,9 +26,9 @@ scm set security anti-spyware-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name | Yes |
 | `--description TEXT` | Profile description | No |
 | `--cloud-inline-analysis / --no-cloud-inline-analysis` | Enable cloud inline analysis | No |
@@ -24,38 +38,237 @@ scm set security anti-spyware-profile [OPTIONS]
 
 ### Examples
 
+#### Create Basic Profile
+
 ```bash
-# Create basic profile
 $ scm set security anti-spyware-profile \
-    --folder Texas --name strict-security \
+    --folder Texas \
+    --name strict-security \
     --description "Block critical threats"
-
-# Create profile blocking critical and high severity
-$ scm set security anti-spyware-profile \
-    --folder Texas --name block-threats \
-    --block-critical-high --cloud-inline-analysis
-
-# Create profile in snippet
-$ scm set security anti-spyware-profile \
-    --snippet Security-Best-Practice --name standard-protection
+---> 100%
+Created anti-spyware profile: strict-security in folder Texas
 ```
 
-## Show Anti-Spyware Profile
+#### Create Profile Blocking Critical and High Severity
 
 ```bash
-scm show security anti-spyware-profile --folder Texas
-scm show security anti-spyware-profile --folder Texas --name strict-security
+$ scm set security anti-spyware-profile \
+    --folder Texas \
+    --name block-threats \
+    --block-critical-high \
+    --cloud-inline-analysis
+---> 100%
+Created anti-spyware profile: block-threats in folder Texas
+```
+
+#### Create Profile in Snippet
+
+```bash
+$ scm set security anti-spyware-profile \
+    --snippet Security-Best-Practice \
+    --name standard-protection
+---> 100%
+Created anti-spyware profile: standard-protection in snippet Security-Best-Practice
 ```
 
 ## Delete Anti-Spyware Profile
 
-```bash
-scm delete security anti-spyware-profile --folder Texas --name strict-security
-```
+Delete an anti-spyware profile from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load security anti-spyware-profile --file anti-spyware.yaml --folder Texas
-scm backup security anti-spyware-profile --folder Texas
+scm delete security anti-spyware-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete security anti-spyware-profile \
+    --folder Texas \
+    --name strict-security
+---> 100%
+Deleted anti-spyware profile: strict-security from folder Texas
+```
+
+## Load Anti-Spyware Profile
+
+Load multiple anti-spyware profiles from a YAML file.
+
+### Syntax
+
+```bash
+scm load security anti-spyware-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing profile definitions | Yes |
+| `--folder TEXT` | Override folder location for all profiles | No |
+| `--snippet TEXT` | Override snippet location for all profiles | No |
+| `--device TEXT` | Override device location for all profiles | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+anti_spyware_profiles:
+  - name: strict-security
+    folder: Texas
+    description: "Block critical threats"
+    cloud_inline_analysis: true
+
+  - name: standard-protection
+    folder: Texas
+    description: "Standard spyware protection"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security anti-spyware-profile \
+    --file anti-spyware.yaml
+---> 100%
+✓ Loaded anti-spyware profile: strict-security
+✓ Loaded anti-spyware profile: standard-protection
+
+Successfully loaded 2 out of 2 anti-spyware profiles from 'anti-spyware.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security anti-spyware-profile \
+    --file anti-spyware.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded anti-spyware profile: strict-security
+✓ Loaded anti-spyware profile: standard-protection
+
+Successfully loaded 2 out of 2 anti-spyware profiles from 'anti-spyware.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Anti-Spyware Profile
+
+Display anti-spyware profile objects.
+
+### Syntax
+
+```bash
+scm show security anti-spyware-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Profile
+
+```bash
+$ scm show security anti-spyware-profile \
+    --folder Texas \
+    --name strict-security
+---> 100%
+Anti-Spyware Profile: strict-security
+  Location: Folder 'Texas'
+  Description: Block critical threats
+  Cloud Inline Analysis: true
+```
+
+#### List All Profiles (Default Behavior)
+
+```bash
+$ scm show security anti-spyware-profile --folder Texas
+---> 100%
+Anti-Spyware Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: strict-security
+  Description: Block critical threats
+  Cloud Inline Analysis: true
+------------------------------------------------------------
+Name: standard-protection
+  Description: Standard spyware protection
+------------------------------------------------------------
+```
+
+## Backup Anti-Spyware Profiles
+
+Backup all anti-spyware profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security anti-spyware-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup profiles from | No\* |
+| `--snippet TEXT` | Snippet to backup profiles from | No\* |
+| `--device TEXT` | Device to backup profiles from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security anti-spyware-profile --folder Texas
+---> 100%
+Successfully backed up 5 anti-spyware profiles to anti_spyware_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security anti-spyware-profile \
+    --folder Texas \
+    --file texas-anti-spyware.yaml
+---> 100%
+Successfully backed up 5 anti-spyware profiles to texas-anti-spyware.yaml
+```
+
+## Best Practices
+
+1. **Block Critical and High Severity**: Use `--block-critical-high` to create profiles that automatically block the most dangerous threats.
+2. **Enable Cloud Analysis**: Turn on `--cloud-inline-analysis` for real-time cloud-based threat detection on critical traffic paths.
+3. **Use Descriptive Names**: Name profiles to reflect their purpose and severity level (e.g., `strict-security`, `standard-protection`).
+4. **Backup Before Changes**: Always backup existing profiles before making bulk modifications via load commands.
+5. **Test in Non-Production**: Create and validate profiles in a test folder before applying to production environments.

--- a/docs/cli/security/app-override-rule.md
+++ b/docs/cli/security/app-override-rule.md
@@ -1,8 +1,23 @@
 # App Override Rule
 
-App override rules force the firewall to identify specific traffic as a particular application, bypassing the App-ID engine.
+App override rules force the firewall to identify specific traffic as a particular application, bypassing the App-ID engine. The `scm` CLI provides commands to create, update, delete, move, and load app override rules.
+
+## Overview
+
+The `app-override-rule` commands allow you to:
+
+- Create app override rules with protocol, port, and application mappings
+- Update existing rule configurations
+- Delete rules that are no longer needed
+- Move rules to control processing order
+- Bulk import rules from YAML files
+- Export rules for backup or migration
 
 ## Set App Override Rule
+
+Create or update an app override rule.
+
+### Syntax
 
 ```bash
 scm set security app-override-rule [OPTIONS]
@@ -12,9 +27,9 @@ scm set security app-override-rule [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Rule name | Yes |
 | `--application TEXT` | Application to override | Yes |
 | `--port TEXT` | Port(s) for the rule | Yes |
@@ -28,18 +43,297 @@ scm set security app-override-rule [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
+### Examples
+
+#### Create Basic Override Rule
+
+```bash
+$ scm set security app-override-rule \
+    --folder Texas \
+    --name override-https \
+    --application ssl \
+    --port 8443 \
+    --protocol tcp
+---> 100%
+Created app override rule: override-https in folder Texas
+```
+
+#### Create Override with Zones
+
+```bash
+$ scm set security app-override-rule \
+    --folder Texas \
+    --name custom-app-override \
+    --application web-browsing \
+    --port 9090 \
+    --protocol tcp \
+    --source-zones trust \
+    --destination-zones untrust \
+    --description "Override custom web app on port 9090"
+---> 100%
+Created app override rule: custom-app-override in folder Texas
+```
+
+## Move App Override Rule
+
+Change the position of an app override rule. Rules are processed in order from top to bottom.
+
+### Syntax
+
+```bash
+scm set security app-override-rule --move [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder containing the rules | No\* |
+| `--snippet TEXT` | Snippet containing the rules | No\* |
+| `--device TEXT` | Device containing the rules | No\* |
+| `--name TEXT` | Name of the rule to move | Yes |
+| `--location TEXT` | Where to move the rule (top, bottom, before, after) | Yes |
+| `--reference TEXT` | Reference rule name (required with before/after) | No\*\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+\*\* Required when `--location` is `before` or `after`.
+
+### Examples
+
+#### Move Rule to Top
+
+```bash
+$ scm set security app-override-rule --move \
+    --folder Texas \
+    --name override-https \
+    --location top
+---> 100%
+Moved app override rule: override-https to top in folder Texas
+```
+
+#### Move Rule After Another Rule
+
+```bash
+$ scm set security app-override-rule --move \
+    --folder Texas \
+    --name custom-app-override \
+    --location after \
+    --reference override-https
+---> 100%
+Moved app override rule: custom-app-override after override-https in folder Texas
+```
+
+## Delete App Override Rule
+
+Delete an app override rule from SCM.
+
+### Syntax
+
+```bash
+scm delete security app-override-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Rule name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
 ### Example
 
 ```bash
-$ scm set security app-override-rule --folder Texas --name override-https \
-    --application ssl --port 8443 --protocol tcp
+$ scm delete security app-override-rule \
+    --folder Texas \
+    --name override-https
+---> 100%
+Deleted app override rule: override-https from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load App Override Rule
+
+Load multiple app override rules from a YAML file.
+
+### Syntax
 
 ```bash
-scm show security app-override-rule --folder Texas
-scm delete security app-override-rule --folder Texas --name override-https
-scm load security app-override-rule --file app-overrides.yaml --folder Texas
-scm backup security app-override-rule --folder Texas
+scm load security app-override-rule [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing rule definitions | Yes |
+| `--folder TEXT` | Override folder location for all rules | No |
+| `--snippet TEXT` | Override snippet location for all rules | No |
+| `--device TEXT` | Override device location for all rules | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+app_override_rules:
+  - name: override-https
+    folder: Texas
+    application: ssl
+    port: "8443"
+    protocol: tcp
+
+  - name: custom-app-override
+    folder: Texas
+    application: web-browsing
+    port: "9090"
+    protocol: tcp
+    source_zones:
+      - trust
+    destination_zones:
+      - untrust
+    description: "Override custom web app on port 9090"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security app-override-rule \
+    --file app-overrides.yaml
+---> 100%
+✓ Loaded app override rule: override-https
+✓ Loaded app override rule: custom-app-override
+
+Successfully loaded 2 out of 2 app override rules from 'app-overrides.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security app-override-rule \
+    --file app-overrides.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded app override rule: override-https
+✓ Loaded app override rule: custom-app-override
+
+Successfully loaded 2 out of 2 app override rules from 'app-overrides.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all rules
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show App Override Rule
+
+Display app override rule objects.
+
+### Syntax
+
+```bash
+scm show security app-override-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Rule name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Rule
+
+```bash
+$ scm show security app-override-rule \
+    --folder Texas \
+    --name override-https
+---> 100%
+App Override Rule: override-https
+  Location: Folder 'Texas'
+  Application: ssl
+  Port: 8443
+  Protocol: tcp
+```
+
+#### List All Rules (Default Behavior)
+
+```bash
+$ scm show security app-override-rule --folder Texas
+---> 100%
+App Override Rules in folder 'Texas':
+------------------------------------------------------------
+Name: override-https
+  Application: ssl
+  Port: 8443
+  Protocol: tcp
+------------------------------------------------------------
+Name: custom-app-override
+  Application: web-browsing
+  Port: 9090
+  Protocol: tcp
+------------------------------------------------------------
+```
+
+## Backup App Override Rules
+
+Backup all app override rule objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security app-override-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup rules from | No\* |
+| `--snippet TEXT` | Snippet to backup rules from | No\* |
+| `--device TEXT` | Device to backup rules from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security app-override-rule --folder Texas
+---> 100%
+Successfully backed up 8 app override rules to app_override_rule_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security app-override-rule \
+    --folder Texas \
+    --file texas-app-overrides.yaml
+---> 100%
+Successfully backed up 8 app override rules to texas-app-overrides.yaml
+```
+
+## Best Practices
+
+1. **Use Sparingly**: Only create app override rules when App-ID cannot correctly identify an application; prefer proper App-ID identification when possible.
+2. **Be Specific with Ports**: Define exact ports rather than broad ranges to minimize the scope of the override.
+3. **Specify Zones**: Include source and destination zones to limit the override to specific traffic paths.
+4. **Order Rules Carefully**: Place more specific override rules above general ones since rules are processed top to bottom.
+5. **Backup Before Changes**: Always backup existing rules before making bulk modifications via load commands.

--- a/docs/cli/security/authentication-rule.md
+++ b/docs/cli/security/authentication-rule.md
@@ -1,8 +1,23 @@
 # Authentication Rule
 
-Authentication rules enforce user authentication before allowing access to network resources.
+Authentication rules enforce user authentication before allowing access to network resources. The `scm` CLI provides commands to create, update, delete, move, and load authentication rules.
+
+## Overview
+
+The `authentication-rule` commands allow you to:
+
+- Create authentication rules with zone, service, and category matching
+- Update existing rule configurations and authentication enforcement profiles
+- Delete rules that are no longer needed
+- Move rules to control processing order
+- Bulk import rules from YAML files
+- Export rules for backup or migration
 
 ## Set Authentication Rule
+
+Create or update an authentication rule.
+
+### Syntax
 
 ```bash
 scm set security authentication-rule [OPTIONS]
@@ -12,9 +27,9 @@ scm set security authentication-rule [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Rule name | Yes |
 | `--rulebase TEXT` | Rulebase (pre, post, default) | No |
 | `--description TEXT` | Description | No |
@@ -28,19 +43,302 @@ scm set security authentication-rule [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
+### Examples
+
+#### Create Basic Authentication Rule
+
+```bash
+$ scm set security authentication-rule \
+    --folder Texas \
+    --name auth-web \
+    --source-zones trust \
+    --destination-zones untrust \
+    --authentication-enforcement my-auth-profile
+---> 100%
+Created authentication rule: auth-web in folder Texas
+```
+
+#### Create Rule with Service and Category
+
+```bash
+$ scm set security authentication-rule \
+    --folder Texas \
+    --name auth-sensitive \
+    --source-zones trust \
+    --destination-zones dmz \
+    --service "service-https" \
+    --category "financial-services" \
+    --authentication-enforcement strict-auth \
+    --description "Authenticate before accessing sensitive resources"
+---> 100%
+Created authentication rule: auth-sensitive in folder Texas
+```
+
+## Move Authentication Rule
+
+Change the position of an authentication rule. Rules are processed in order from top to bottom.
+
+### Syntax
+
+```bash
+scm set security authentication-rule --move [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder containing the rules | No\* |
+| `--snippet TEXT` | Snippet containing the rules | No\* |
+| `--device TEXT` | Device containing the rules | No\* |
+| `--name TEXT` | Name of the rule to move | Yes |
+| `--location TEXT` | Where to move the rule (top, bottom, before, after) | Yes |
+| `--reference TEXT` | Reference rule name (required with before/after) | No\*\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+\*\* Required when `--location` is `before` or `after`.
+
+### Examples
+
+#### Move Rule to Top
+
+```bash
+$ scm set security authentication-rule --move \
+    --folder Texas \
+    --name auth-sensitive \
+    --location top
+---> 100%
+Moved authentication rule: auth-sensitive to top in folder Texas
+```
+
+#### Move Rule Before Another Rule
+
+```bash
+$ scm set security authentication-rule --move \
+    --folder Texas \
+    --name auth-web \
+    --location before \
+    --reference auth-sensitive
+---> 100%
+Moved authentication rule: auth-web before auth-sensitive in folder Texas
+```
+
+## Delete Authentication Rule
+
+Delete an authentication rule from SCM.
+
+### Syntax
+
+```bash
+scm delete security authentication-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Rule name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
 ### Example
 
 ```bash
-$ scm set security authentication-rule --folder Texas --name auth-web \
-    --source-zones trust --destination-zones untrust \
-    --authentication-enforcement my-auth-profile
+$ scm delete security authentication-rule \
+    --folder Texas \
+    --name auth-web
+---> 100%
+Deleted authentication rule: auth-web from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load Authentication Rule
+
+Load multiple authentication rules from a YAML file.
+
+### Syntax
 
 ```bash
-scm show security authentication-rule --folder Texas
-scm delete security authentication-rule --folder Texas --name auth-web
-scm load security authentication-rule --file auth-rules.yaml --folder Texas
-scm backup security authentication-rule --folder Texas
+scm load security authentication-rule [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing rule definitions | Yes |
+| `--folder TEXT` | Override folder location for all rules | No |
+| `--snippet TEXT` | Override snippet location for all rules | No |
+| `--device TEXT` | Override device location for all rules | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+authentication_rules:
+  - name: auth-web
+    folder: Texas
+    description: "Authenticate web traffic"
+    source_zones:
+      - trust
+    destination_zones:
+      - untrust
+    authentication_enforcement: my-auth-profile
+
+  - name: auth-sensitive
+    folder: Texas
+    description: "Authenticate before accessing sensitive resources"
+    source_zones:
+      - trust
+    destination_zones:
+      - dmz
+    service:
+      - service-https
+    category:
+      - financial-services
+    authentication_enforcement: strict-auth
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security authentication-rule \
+    --file auth-rules.yaml
+---> 100%
+✓ Loaded authentication rule: auth-web
+✓ Loaded authentication rule: auth-sensitive
+
+Successfully loaded 2 out of 2 authentication rules from 'auth-rules.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security authentication-rule \
+    --file auth-rules.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded authentication rule: auth-web
+✓ Loaded authentication rule: auth-sensitive
+
+Successfully loaded 2 out of 2 authentication rules from 'auth-rules.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all rules
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Authentication Rule
+
+Display authentication rule objects.
+
+### Syntax
+
+```bash
+scm show security authentication-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Rule name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Rule
+
+```bash
+$ scm show security authentication-rule \
+    --folder Texas \
+    --name auth-web
+---> 100%
+Authentication Rule: auth-web
+  Location: Folder 'Texas'
+  Source Zones: trust
+  Destination Zones: untrust
+  Authentication Enforcement: my-auth-profile
+```
+
+#### List All Rules (Default Behavior)
+
+```bash
+$ scm show security authentication-rule --folder Texas
+---> 100%
+Authentication Rules in folder 'Texas':
+------------------------------------------------------------
+Name: auth-web
+  Source Zones: trust
+  Destination Zones: untrust
+  Authentication Enforcement: my-auth-profile
+------------------------------------------------------------
+Name: auth-sensitive
+  Source Zones: trust
+  Destination Zones: dmz
+  Authentication Enforcement: strict-auth
+------------------------------------------------------------
+```
+
+## Backup Authentication Rules
+
+Backup all authentication rule objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security authentication-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup rules from | No\* |
+| `--snippet TEXT` | Snippet to backup rules from | No\* |
+| `--device TEXT` | Device to backup rules from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security authentication-rule --folder Texas
+---> 100%
+Successfully backed up 6 authentication rules to authentication_rule_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security authentication-rule \
+    --folder Texas \
+    --file texas-auth-rules.yaml
+---> 100%
+Successfully backed up 6 authentication rules to texas-auth-rules.yaml
+```
+
+## Best Practices
+
+1. **Match Specific Traffic**: Define source zones, destination zones, and services to target authentication requirements to specific traffic flows.
+2. **Order Rules Carefully**: Place more specific authentication rules above general ones since rules are processed top to bottom.
+3. **Use Authentication Enforcement Profiles**: Reference pre-configured authentication profiles to ensure consistent authentication behavior.
+4. **Use Category Matching**: Combine URL categories with authentication rules for context-aware authentication requirements.
+5. **Backup Before Changes**: Always backup existing rules before making bulk modifications via load commands.

--- a/docs/cli/security/decryption-profile.md
+++ b/docs/cli/security/decryption-profile.md
@@ -1,8 +1,32 @@
 # Decryption Profile
 
-Decryption profiles configure SSL/TLS inspection settings for three proxy types: SSL Forward Proxy (outbound), SSL Inbound Proxy (inbound), and SSL No Proxy (bypass).
+Decryption profiles configure SSL/TLS inspection settings for three proxy types: SSL Forward Proxy (outbound), SSL Inbound Proxy (inbound), and SSL No Proxy (bypass). The `scm` CLI provides commands to create, update, delete, and load decryption profiles.
+
+## Overview
+
+The `decryption-profile` commands allow you to:
+
+- Create decryption profiles with SSL/TLS proxy configurations
+- Update existing profile settings including protocol versions and cipher suites
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
+
+## Proxy Types
+
+Decryption profiles support three proxy types:
+
+| Proxy Type | Direction | Description |
+| --- | --- | --- |
+| SSL Forward Proxy | Outbound | Decrypt outbound SSL/TLS traffic for inspection |
+| SSL Inbound Proxy | Inbound | Decrypt inbound SSL/TLS traffic to internal servers |
+| SSL No Proxy | Bypass | Define certificate handling without decryption |
 
 ## Set Decryption Profile
+
+Create or update a decryption profile.
+
+### Syntax
 
 ```bash
 scm set security decryption-profile [OPTIONS]
@@ -12,9 +36,9 @@ scm set security decryption-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name | Yes |
 | `--description TEXT` | Profile description | No |
 | `--ssl-forward-proxy TEXT` | SSL forward proxy settings as JSON | No |
@@ -26,26 +50,244 @@ scm set security decryption-profile [OPTIONS]
 
 ### Examples
 
-```bash
-# Create SSL forward proxy profile
-$ scm set security decryption-profile --folder Texas --name ssl-forward \
-    --ssl-forward-proxy '{"block_expired_certificate": true, "block_untrusted_issuer": true}'
+#### Create SSL Forward Proxy Profile
 
-# Create profile with protocol settings
-$ scm set security decryption-profile --folder Texas --name custom-decrypt \
+```bash
+$ scm set security decryption-profile \
+    --folder Texas \
+    --name ssl-forward \
+    --ssl-forward-proxy '{"block_expired_certificate": true, "block_untrusted_issuer": true}'
+---> 100%
+Created decryption profile: ssl-forward in folder Texas
+```
+
+#### Create Profile with Protocol Settings
+
+```bash
+$ scm set security decryption-profile \
+    --folder Texas \
+    --name custom-decrypt \
     --ssl-forward-proxy '{"block_expired_certificate": true}' \
     --ssl-protocol-settings '{"min_version": "tls1-2", "max_version": "tls1-3"}'
-
-# Create no-decrypt profile
-$ scm set security decryption-profile --folder Texas --name no-decrypt \
-    --ssl-no-proxy '{"block_expired_certificate": false}'
+---> 100%
+Created decryption profile: custom-decrypt in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create No-Decrypt Profile
 
 ```bash
-scm show security decryption-profile --folder Texas
-scm delete security decryption-profile --folder Texas --name ssl-forward
-scm load security decryption-profile --file decrypt-profiles.yaml --folder Texas
-scm backup security decryption-profile --folder Texas
+$ scm set security decryption-profile \
+    --folder Texas \
+    --name no-decrypt \
+    --ssl-no-proxy '{"block_expired_certificate": false}'
+---> 100%
+Created decryption profile: no-decrypt in folder Texas
 ```
+
+## Delete Decryption Profile
+
+Delete a decryption profile from SCM.
+
+### Syntax
+
+```bash
+scm delete security decryption-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete security decryption-profile \
+    --folder Texas \
+    --name ssl-forward
+---> 100%
+Deleted decryption profile: ssl-forward from folder Texas
+```
+
+## Load Decryption Profile
+
+Load multiple decryption profiles from a YAML file.
+
+### Syntax
+
+```bash
+scm load security decryption-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing profile definitions | Yes |
+| `--folder TEXT` | Override folder location for all profiles | No |
+| `--snippet TEXT` | Override snippet location for all profiles | No |
+| `--device TEXT` | Override device location for all profiles | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+decryption_profiles:
+  - name: ssl-forward
+    folder: Texas
+    ssl_forward_proxy:
+      block_expired_certificate: true
+      block_untrusted_issuer: true
+
+  - name: custom-decrypt
+    folder: Texas
+    ssl_forward_proxy:
+      block_expired_certificate: true
+    ssl_protocol_settings:
+      min_version: "tls1-2"
+      max_version: "tls1-3"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security decryption-profile \
+    --file decrypt-profiles.yaml
+---> 100%
+✓ Loaded decryption profile: ssl-forward
+✓ Loaded decryption profile: custom-decrypt
+
+Successfully loaded 2 out of 2 decryption profiles from 'decrypt-profiles.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security decryption-profile \
+    --file decrypt-profiles.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded decryption profile: ssl-forward
+✓ Loaded decryption profile: custom-decrypt
+
+Successfully loaded 2 out of 2 decryption profiles from 'decrypt-profiles.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Decryption Profile
+
+Display decryption profile objects.
+
+### Syntax
+
+```bash
+scm show security decryption-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Profile
+
+```bash
+$ scm show security decryption-profile \
+    --folder Texas \
+    --name ssl-forward
+---> 100%
+Decryption Profile: ssl-forward
+  Location: Folder 'Texas'
+  SSL Forward Proxy:
+    Block Expired Certificate: true
+    Block Untrusted Issuer: true
+```
+
+#### List All Profiles (Default Behavior)
+
+```bash
+$ scm show security decryption-profile --folder Texas
+---> 100%
+Decryption Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: ssl-forward
+  SSL Forward Proxy: configured
+------------------------------------------------------------
+Name: custom-decrypt
+  SSL Forward Proxy: configured
+  SSL Protocol Settings: TLS 1.2 - TLS 1.3
+------------------------------------------------------------
+```
+
+## Backup Decryption Profiles
+
+Backup all decryption profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security decryption-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup profiles from | No\* |
+| `--snippet TEXT` | Snippet to backup profiles from | No\* |
+| `--device TEXT` | Device to backup profiles from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security decryption-profile --folder Texas
+---> 100%
+Successfully backed up 3 decryption profiles to decryption_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security decryption-profile \
+    --folder Texas \
+    --file texas-decrypt-profiles.yaml
+---> 100%
+Successfully backed up 3 decryption profiles to texas-decrypt-profiles.yaml
+```
+
+## Best Practices
+
+1. **Enforce TLS 1.2 Minimum**: Use `--ssl-protocol-settings` to set `min_version` to `tls1-2` to prevent downgrade attacks.
+2. **Block Expired Certificates**: Enable `block_expired_certificate` in forward proxy settings to prevent connections to servers with invalid certificates.
+3. **Separate Profiles by Use Case**: Create distinct profiles for forward proxy, inbound proxy, and no-proxy scenarios rather than combining settings.
+4. **Use JSON Input Carefully**: Validate JSON strings before passing them to `--ssl-forward-proxy` and related options to avoid configuration errors.
+5. **Backup Before Changes**: Always backup existing profiles before making bulk modifications via load commands.

--- a/docs/cli/security/decryption-rule.md
+++ b/docs/cli/security/decryption-rule.md
@@ -1,8 +1,23 @@
 # Decryption Rule
 
-Decryption rules define which traffic should be decrypted for inspection or bypassed.
+Decryption rules define which traffic should be decrypted for inspection or bypassed. The `scm` CLI provides commands to create, update, delete, move, and load decryption rules.
+
+## Overview
+
+The `decryption-rule` commands allow you to:
+
+- Create decryption rules with decrypt or no-decrypt actions
+- Update existing rule configurations including SSL proxy type settings
+- Delete rules that are no longer needed
+- Move rules to control processing order
+- Bulk import rules from YAML files
+- Export rules for backup or migration
 
 ## Set Decryption Rule
+
+Create or update a decryption rule.
+
+### Syntax
 
 ```bash
 scm set security decryption-rule [OPTIONS]
@@ -12,9 +27,9 @@ scm set security decryption-rule [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Rule name | Yes |
 | `--action TEXT` | Action (decrypt or no-decrypt) | Yes |
 | `--rulebase TEXT` | Rulebase (pre, post, default) | No |
@@ -30,21 +45,299 @@ scm set security decryption-rule [OPTIONS]
 
 ### Examples
 
-```bash
-# Create no-decrypt rule
-$ scm set security decryption-rule --folder Texas --name no-decrypt-internal \
-    --action no-decrypt --source-zones trust --destination-zones trust
-
-# Create decrypt rule with SSL forward proxy
-$ scm set security decryption-rule --folder Texas --name decrypt-outbound \
-    --action decrypt --type '{"ssl_forward_proxy": {}}'
-```
-
-## Show / Delete / Load / Backup
+#### Create No-Decrypt Rule
 
 ```bash
-scm show security decryption-rule --folder Texas
-scm delete security decryption-rule --folder Texas --name no-decrypt-internal
-scm load security decryption-rule --file decrypt-rules.yaml --folder Texas
-scm backup security decryption-rule --folder Texas
+$ scm set security decryption-rule \
+    --folder Texas \
+    --name no-decrypt-internal \
+    --action no-decrypt \
+    --source-zones trust \
+    --destination-zones trust
+---> 100%
+Created decryption rule: no-decrypt-internal in folder Texas
 ```
+
+#### Create Decrypt Rule with SSL Forward Proxy
+
+```bash
+$ scm set security decryption-rule \
+    --folder Texas \
+    --name decrypt-outbound \
+    --action decrypt \
+    --type '{"ssl_forward_proxy": {}}' \
+    --profile ssl-forward-profile \
+    --source-zones trust \
+    --destination-zones untrust
+---> 100%
+Created decryption rule: decrypt-outbound in folder Texas
+```
+
+## Move Decryption Rule
+
+Change the position of a decryption rule. Rules are processed in order from top to bottom.
+
+### Syntax
+
+```bash
+scm set security decryption-rule --move [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder containing the rules | No\* |
+| `--snippet TEXT` | Snippet containing the rules | No\* |
+| `--device TEXT` | Device containing the rules | No\* |
+| `--name TEXT` | Name of the rule to move | Yes |
+| `--location TEXT` | Where to move the rule (top, bottom, before, after) | Yes |
+| `--reference TEXT` | Reference rule name (required with before/after) | No\*\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+\*\* Required when `--location` is `before` or `after`.
+
+### Examples
+
+#### Move Rule to Top
+
+```bash
+$ scm set security decryption-rule --move \
+    --folder Texas \
+    --name no-decrypt-internal \
+    --location top
+---> 100%
+Moved decryption rule: no-decrypt-internal to top in folder Texas
+```
+
+#### Move Rule After Another Rule
+
+```bash
+$ scm set security decryption-rule --move \
+    --folder Texas \
+    --name decrypt-outbound \
+    --location after \
+    --reference no-decrypt-internal
+---> 100%
+Moved decryption rule: decrypt-outbound after no-decrypt-internal in folder Texas
+```
+
+## Delete Decryption Rule
+
+Delete a decryption rule from SCM.
+
+### Syntax
+
+```bash
+scm delete security decryption-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Rule name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete security decryption-rule \
+    --folder Texas \
+    --name no-decrypt-internal
+---> 100%
+Deleted decryption rule: no-decrypt-internal from folder Texas
+```
+
+## Load Decryption Rule
+
+Load multiple decryption rules from a YAML file.
+
+### Syntax
+
+```bash
+scm load security decryption-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing rule definitions | Yes |
+| `--folder TEXT` | Override folder location for all rules | No |
+| `--snippet TEXT` | Override snippet location for all rules | No |
+| `--device TEXT` | Override device location for all rules | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+decryption_rules:
+  - name: no-decrypt-internal
+    folder: Texas
+    description: "Skip decryption for internal traffic"
+    action: no-decrypt
+    source_zones:
+      - trust
+    destination_zones:
+      - trust
+
+  - name: decrypt-outbound
+    folder: Texas
+    description: "Decrypt outbound traffic"
+    action: decrypt
+    type:
+      ssl_forward_proxy: {}
+    profile: ssl-forward-profile
+    source_zones:
+      - trust
+    destination_zones:
+      - untrust
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security decryption-rule \
+    --file decrypt-rules.yaml
+---> 100%
+✓ Loaded decryption rule: no-decrypt-internal
+✓ Loaded decryption rule: decrypt-outbound
+
+Successfully loaded 2 out of 2 decryption rules from 'decrypt-rules.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security decryption-rule \
+    --file decrypt-rules.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded decryption rule: no-decrypt-internal
+✓ Loaded decryption rule: decrypt-outbound
+
+Successfully loaded 2 out of 2 decryption rules from 'decrypt-rules.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all rules
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Decryption Rule
+
+Display decryption rule objects.
+
+### Syntax
+
+```bash
+scm show security decryption-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Rule name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Rule
+
+```bash
+$ scm show security decryption-rule \
+    --folder Texas \
+    --name decrypt-outbound
+---> 100%
+Decryption Rule: decrypt-outbound
+  Location: Folder 'Texas'
+  Action: decrypt
+  Type: SSL Forward Proxy
+  Profile: ssl-forward-profile
+  Source Zones: trust
+  Destination Zones: untrust
+```
+
+#### List All Rules (Default Behavior)
+
+```bash
+$ scm show security decryption-rule --folder Texas
+---> 100%
+Decryption Rules in folder 'Texas':
+------------------------------------------------------------
+Name: no-decrypt-internal
+  Action: no-decrypt
+  Source Zones: trust
+  Destination Zones: trust
+------------------------------------------------------------
+Name: decrypt-outbound
+  Action: decrypt
+  Type: SSL Forward Proxy
+------------------------------------------------------------
+```
+
+## Backup Decryption Rules
+
+Backup all decryption rule objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security decryption-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup rules from | No\* |
+| `--snippet TEXT` | Snippet to backup rules from | No\* |
+| `--device TEXT` | Device to backup rules from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security decryption-rule --folder Texas
+---> 100%
+Successfully backed up 5 decryption rules to decryption_rule_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security decryption-rule \
+    --folder Texas \
+    --file texas-decrypt-rules.yaml
+---> 100%
+Successfully backed up 5 decryption rules to texas-decrypt-rules.yaml
+```
+
+## Best Practices
+
+1. **Exclude Internal Traffic**: Create no-decrypt rules for internal zone-to-zone traffic to reduce unnecessary processing overhead.
+2. **Order No-Decrypt First**: Place no-decrypt bypass rules above decrypt rules so trusted traffic is excluded before decryption processing begins.
+3. **Attach Decryption Profiles**: Always associate a decryption profile with decrypt rules to control SSL/TLS protocol settings and certificate handling.
+4. **Use SSL Forward Proxy for Outbound**: Configure `ssl_forward_proxy` type for outbound traffic decryption to internal users browsing external sites.
+5. **Backup Before Changes**: Always backup existing rules before making bulk modifications via load commands.

--- a/docs/cli/security/dns-security-profile.md
+++ b/docs/cli/security/dns-security-profile.md
@@ -1,8 +1,22 @@
 # DNS Security Profile
 
-DNS security profiles protect against DNS-based threats including malware domains, command-and-control, and DNS tunneling.
+DNS security profiles protect against DNS-based threats including malware domains, command-and-control traffic, and DNS tunneling. The `scm` CLI provides commands to create, update, delete, and load DNS security profiles.
+
+## Overview
+
+The `dns-security-profile` commands allow you to:
+
+- Create DNS security profiles with botnet domain protections
+- Update existing profile configurations including sinkhole settings
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set DNS Security Profile
+
+Create or update a DNS security profile.
+
+### Syntax
 
 ```bash
 scm set security dns-security-profile [OPTIONS]
@@ -12,9 +26,9 @@ scm set security dns-security-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name | Yes |
 | `--description TEXT` | Profile description | No |
 | `--botnet-domains TEXT` | Botnet domains settings as JSON | No |
@@ -23,21 +37,231 @@ scm set security dns-security-profile [OPTIONS]
 
 ### Examples
 
+#### Create Profile with Sinkhole
+
 ```bash
-# Create DNS security profile with sinkhole
-$ scm set security dns-security-profile --folder Texas --name dns-sec-default \
+$ scm set security dns-security-profile \
+    --folder Texas \
+    --name dns-sec-default \
     --botnet-domains '{"dns_security_categories": [{"name": "pan-dns-sec-malware", "action": "sinkhole"}]}'
-
-# Create profile with whitelist
-$ scm set security dns-security-profile --folder Texas --name dns-sec-custom \
-    --botnet-domains '{"whitelist": [{"name": "example.com"}]}'
+---> 100%
+Created DNS security profile: dns-sec-default in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create Profile with Whitelist
 
 ```bash
-scm show security dns-security-profile --folder Texas
-scm delete security dns-security-profile --folder Texas --name dns-sec-default
-scm load security dns-security-profile --file dns-security.yaml --folder Texas
-scm backup security dns-security-profile --folder Texas
+$ scm set security dns-security-profile \
+    --folder Texas \
+    --name dns-sec-custom \
+    --botnet-domains '{"whitelist": [{"name": "example.com"}]}'
+---> 100%
+Created DNS security profile: dns-sec-custom in folder Texas
 ```
+
+## Delete DNS Security Profile
+
+Delete a DNS security profile from SCM.
+
+### Syntax
+
+```bash
+scm delete security dns-security-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete security dns-security-profile \
+    --folder Texas \
+    --name dns-sec-default
+---> 100%
+Deleted DNS security profile: dns-sec-default from folder Texas
+```
+
+## Load DNS Security Profile
+
+Load multiple DNS security profiles from a YAML file.
+
+### Syntax
+
+```bash
+scm load security dns-security-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing profile definitions | Yes |
+| `--folder TEXT` | Override folder location for all profiles | No |
+| `--snippet TEXT` | Override snippet location for all profiles | No |
+| `--device TEXT` | Override device location for all profiles | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+dns_security_profiles:
+  - name: dns-sec-default
+    folder: Texas
+    description: "Default DNS security profile"
+    botnet_domains:
+      dns_security_categories:
+        - name: pan-dns-sec-malware
+          action: sinkhole
+
+  - name: dns-sec-custom
+    folder: Texas
+    description: "Custom DNS security with whitelist"
+    botnet_domains:
+      whitelist:
+        - name: example.com
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security dns-security-profile \
+    --file dns-security.yaml
+---> 100%
+✓ Loaded DNS security profile: dns-sec-default
+✓ Loaded DNS security profile: dns-sec-custom
+
+Successfully loaded 2 out of 2 DNS security profiles from 'dns-security.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security dns-security-profile \
+    --file dns-security.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded DNS security profile: dns-sec-default
+✓ Loaded DNS security profile: dns-sec-custom
+
+Successfully loaded 2 out of 2 DNS security profiles from 'dns-security.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show DNS Security Profile
+
+Display DNS security profile objects.
+
+### Syntax
+
+```bash
+scm show security dns-security-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Profile
+
+```bash
+$ scm show security dns-security-profile \
+    --folder Texas \
+    --name dns-sec-default
+---> 100%
+DNS Security Profile: dns-sec-default
+  Location: Folder 'Texas'
+  Description: Default DNS security profile
+  Botnet Domains: configured
+```
+
+#### List All Profiles (Default Behavior)
+
+```bash
+$ scm show security dns-security-profile --folder Texas
+---> 100%
+DNS Security Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: dns-sec-default
+  Description: Default DNS security profile
+------------------------------------------------------------
+Name: dns-sec-custom
+  Description: Custom DNS security with whitelist
+------------------------------------------------------------
+```
+
+## Backup DNS Security Profiles
+
+Backup all DNS security profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security dns-security-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup profiles from | No\* |
+| `--snippet TEXT` | Snippet to backup profiles from | No\* |
+| `--device TEXT` | Device to backup profiles from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security dns-security-profile --folder Texas
+---> 100%
+Successfully backed up 4 DNS security profiles to dns_security_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security dns-security-profile \
+    --folder Texas \
+    --file texas-dns-security.yaml
+---> 100%
+Successfully backed up 4 DNS security profiles to texas-dns-security.yaml
+```
+
+## Best Practices
+
+1. **Sinkhole Malware Domains**: Configure `dns_security_categories` with sinkhole actions to redirect malware DNS queries to a safe IP.
+2. **Whitelist Trusted Domains**: Add legitimate domains to the whitelist to prevent false positives for business-critical services.
+3. **Use Descriptive Names**: Name profiles to reflect their protection scope (e.g., `dns-sec-strict`, `dns-sec-custom`).
+4. **Backup Before Changes**: Always backup existing profiles before making bulk modifications via load commands.
+5. **Layer with Other Profiles**: Combine DNS security profiles with anti-spyware and URL filtering for comprehensive threat protection.

--- a/docs/cli/security/rules.md
+++ b/docs/cli/security/rules.md
@@ -1,15 +1,29 @@
 # Security Rules
 
-Security rules define policies that control traffic flow between zones. The `scm` CLI provides commands to create, update, delete, and load security rules.
+Security rules define policies that control traffic flow between zones. The `scm` CLI provides commands to create, update, delete, move, and load security rules.
+
+## Overview
+
+The `rule` commands allow you to:
+
+- Create security rules with source/destination zones, addresses, and applications
+- Update existing rule configurations and security profiles
+- Delete rules that are no longer needed
+- Move rules to control processing order
+- Bulk import rules from YAML files
+- Export rules for backup or migration
 
 ## Rule Components
 
 Security rules consist of several components:
 
-- **Source and Destination**: Define where traffic is coming from and going to
-- **Applications and Services**: Specify what type of traffic is allowed
-- **Actions**: Determine what happens to matching traffic
-- **Profiles**: Apply security profiles to traffic
+| Component | Description |
+| --- | --- |
+| Source/Destination | Zones, addresses, and users that define traffic endpoints |
+| Applications | Applications to match (e.g., web-browsing, ssl) |
+| Services | Services to match (e.g., application-default) |
+| Action | What happens to matching traffic (allow, deny, drop) |
+| Profiles | Security profiles applied to allowed traffic |
 
 ## Set Security Rule
 
@@ -23,82 +37,71 @@ scm set security rule [OPTIONS]
 
 ### Options
 
-| Option                         | Description                               | Required |
-| ------------------------------ | ----------------------------------------- | -------- |
-| `--folder TEXT`                | Folder for the security rule              | Yes      |
-| `--name TEXT`                  | Name of the security rule                 | Yes      |
-| `--description TEXT`           | Description for the rule                  | No       |
-| `--source-zones LIST`          | Source security zones                     | Yes      |
-| `--destination-zones LIST`     | Destination security zones                | Yes      |
-| `--source-addresses LIST`      | Source address or address groups          | Yes      |
-| `--destination-addresses LIST` | Destination address or address groups     | Yes      |
-| `--applications LIST`          | Applications to match                     | Yes      |
-| `--services LIST`              | Services to match                         | Yes      |
-| `--action TEXT`                | Action to take (allow, deny, drop)        | Yes      |
-| `--log-start BOOLEAN`          | Log at session start                      | No       |
-| `--log-end BOOLEAN`            | Log at session end                        | No       |
-| `--disabled BOOLEAN`           | Whether rule is disabled                  | No       |
-| `--tags LIST`                  | List of tags to apply to the rule         | No       |
-| `--profile-group TEXT`         | Security profile group to apply           | No       |
-| `--anti-virus TEXT`            | Anti-virus profile to apply               | No       |
-| `--anti-spyware TEXT`          | Anti-spyware profile to apply             | No       |
-| `--vulnerability TEXT`         | Vulnerability protection profile to apply | No       |
-| `--url-filtering TEXT`         | URL filtering profile to apply            | No       |
-| `--file-blocking TEXT`         | File blocking profile to apply            | No       |
-| `--data-filtering TEXT`        | Data filtering profile to apply           | No       |
-| `--wildfire-analysis TEXT`     | WildFire analysis profile to apply        | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder for the security rule | Yes |
+| `--name TEXT` | Name of the security rule | Yes |
+| `--description TEXT` | Description for the rule | No |
+| `--source-zones LIST` | Source security zones | Yes |
+| `--destination-zones LIST` | Destination security zones | Yes |
+| `--source-addresses LIST` | Source address or address groups | Yes |
+| `--destination-addresses LIST` | Destination address or address groups | Yes |
+| `--applications LIST` | Applications to match | Yes |
+| `--services LIST` | Services to match | Yes |
+| `--action TEXT` | Action to take (allow, deny, drop) | Yes |
+| `--log-start BOOLEAN` | Log at session start | No |
+| `--log-end BOOLEAN` | Log at session end | No |
+| `--disabled BOOLEAN` | Whether rule is disabled | No |
+| `--tags LIST` | List of tags to apply to the rule | No |
+| `--profile-group TEXT` | Security profile group to apply | No |
+| `--anti-virus TEXT` | Anti-virus profile to apply | No |
+| `--anti-spyware TEXT` | Anti-spyware profile to apply | No |
+| `--vulnerability TEXT` | Vulnerability protection profile to apply | No |
+| `--url-filtering TEXT` | URL filtering profile to apply | No |
+| `--file-blocking TEXT` | File blocking profile to apply | No |
+| `--data-filtering TEXT` | Data filtering profile to apply | No |
+| `--wildfire-analysis TEXT` | WildFire analysis profile to apply | No |
 
 ### Examples
 
 #### Create an Allow Rule
 
 ```bash
-$ scm set security rule --folder Shared --name "Allow-Internal-Web" \
-  --source-zones Trust --destination-zones DMZ \
-  --source-addresses "any" --destination-addresses "web-servers" \
-  --applications web-browsing --services application-default \
-  --action allow --log-end true
-Creating security rule 'Allow-Internal-Web' in folder 'Shared'...
-Security rule created successfully.
+$ scm set security rule \
+    --folder Shared \
+    --name "Allow-Internal-Web" \
+    --source-zones Trust \
+    --destination-zones DMZ \
+    --source-addresses "any" \
+    --destination-addresses "web-servers" \
+    --applications web-browsing \
+    --services application-default \
+    --action allow \
+    --log-end true
+---> 100%
+Created security rule: Allow-Internal-Web in folder Shared
 ```
 
 #### Create a Block Rule with Security Profiles
 
 ```bash
-$ scm set security rule --folder Shared --name "Block-Malicious-Web" \
-  --source-zones Untrust --destination-zones DMZ \
-  --source-addresses "any" --destination-addresses "any" \
-  --applications any --services application-default \
-  --action deny --log-start true --log-end true \
-  --anti-virus "default-av" --anti-spyware "default-as" \
-  --url-filtering "strict-url-filtering"
-Creating security rule 'Block-Malicious-Web' in folder 'Shared'...
-Security rule created successfully.
-```
-
-## Delete Security Rule
-
-Delete a security rule.
-
-### Syntax
-
-```bash
-scm delete security rule [OPTIONS]
-```
-
-### Options
-
-| Option          | Description                         | Required |
-| --------------- | ----------------------------------- | -------- |
-| `--folder TEXT` | Folder containing the security rule | Yes      |
-| `--name TEXT`   | Name of the security rule to delete | Yes      |
-
-### Example
-
-```bash
-$ scm delete security rule --folder Shared --name "Allow-Internal-Web"
-Deleting security rule 'Allow-Internal-Web' from folder 'Shared'...
-Security rule deleted successfully.
+$ scm set security rule \
+    --folder Shared \
+    --name "Block-Malicious-Web" \
+    --source-zones Untrust \
+    --destination-zones DMZ \
+    --source-addresses "any" \
+    --destination-addresses "any" \
+    --applications any \
+    --services application-default \
+    --action deny \
+    --log-start true \
+    --log-end true \
+    --anti-virus "default-av" \
+    --anti-spyware "default-as" \
+    --url-filtering "strict-url-filtering"
+---> 100%
+Created security rule: Block-Malicious-Web in folder Shared
 ```
 
 ## Move Security Rule
@@ -113,34 +116,70 @@ scm set security rule --move [OPTIONS]
 
 ### Options
 
-| Option             | Description                                         | Required         |
-| ------------------ | --------------------------------------------------- | ---------------- |
-| `--folder TEXT`    | Folder containing the security rules                | Yes              |
-| `--name TEXT`      | Name of the security rule to move                   | Yes              |
-| `--location TEXT`  | Where to move the rule (top, bottom, before, after) | Yes              |
-| `--reference TEXT` | Reference rule name (required with before/after)    | For before/after |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder containing the security rules | Yes |
+| `--name TEXT` | Name of the security rule to move | Yes |
+| `--location TEXT` | Where to move the rule (top, bottom, before, after) | Yes |
+| `--reference TEXT` | Reference rule name (required with before/after) | No\*\* |
+
+\*\* Required when `--location` is `before` or `after`.
 
 ### Examples
 
 #### Move Rule to Top
 
 ```bash
-$ scm set security rule --move --folder Shared --name "Block-Malicious-Web" --location top
-Moving security rule 'Block-Malicious-Web' to top in folder 'Shared'...
-Security rule moved successfully.
+$ scm set security rule --move \
+    --folder Shared \
+    --name "Block-Malicious-Web" \
+    --location top
+---> 100%
+Moved security rule: Block-Malicious-Web to top in folder Shared
 ```
 
 #### Move Rule After Another Rule
 
 ```bash
-$ scm set security rule --move --folder Shared --name "Allow-Internal-Web" --location after --reference "Allow-Internal-DNS"
-Moving security rule 'Allow-Internal-Web' after 'Allow-Internal-DNS' in folder 'Shared'...
-Security rule moved successfully.
+$ scm set security rule --move \
+    --folder Shared \
+    --name "Allow-Internal-Web" \
+    --location after \
+    --reference "Allow-Internal-DNS"
+---> 100%
+Moved security rule: Allow-Internal-Web after Allow-Internal-DNS in folder Shared
+```
+
+## Delete Security Rule
+
+Delete a security rule from SCM.
+
+### Syntax
+
+```bash
+scm delete security rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder containing the security rule | Yes |
+| `--name TEXT` | Name of the security rule to delete | Yes |
+
+### Example
+
+```bash
+$ scm delete security rule \
+    --folder Shared \
+    --name "Allow-Internal-Web"
+---> 100%
+Deleted security rule: Allow-Internal-Web from folder Shared
 ```
 
 ## Load Security Rules
 
-Create or update multiple security rules from a YAML file.
+Load multiple security rules from a YAML file.
 
 ### Syntax
 
@@ -150,16 +189,21 @@ scm load security rule [OPTIONS]
 
 ### Options
 
-| Option          | Description                                            | Required |
-| --------------- | ------------------------------------------------------ | -------- |
-| `--folder TEXT` | Folder for the security rules                          | Yes      |
-| `--file TEXT`   | Path to YAML file containing security rule definitions | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing security rule definitions | Yes |
+| `--folder TEXT` | Override folder location for all rules | No |
+| `--snippet TEXT` | Override snippet location for all rules | No |
+| `--device TEXT` | Override device location for all rules | No |
+| `--dry-run` | Preview changes without applying them | No |
 
-### Example YAML File
+### YAML File Format
 
 ```yaml
+---
 security_rules:
   - name: Allow-Internal-Web
+    folder: Shared
     description: "Allow internal users to access web servers"
     source_zones:
       - Trust
@@ -180,6 +224,7 @@ security_rules:
       - internal-access
 
   - name: Block-Malicious-Web
+    folder: Shared
     description: "Block malicious web traffic"
     source_zones:
       - Untrust
@@ -204,38 +249,139 @@ security_rules:
       - blocking
 ```
 
-### Example Command
+### Examples
+
+#### Load with Original Locations
 
 ```bash
-$ scm load security rule --folder Shared --file security-rules.yaml
-Loading security rules from 'security-rules.yaml' into folder 'Shared'...
-Created 2 security rules successfully.
+$ scm load security rule --file security-rules.yaml
+---> 100%
+✓ Loaded security rule: Allow-Internal-Web
+✓ Loaded security rule: Block-Malicious-Web
+
+Successfully loaded 2 out of 2 security rules from 'security-rules.yaml'
 ```
 
-## List Security Rules
+#### Load with Folder Override
 
-List all security rules in a folder.
+```bash
+$ scm load security rule \
+    --file security-rules.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded security rule: Allow-Internal-Web
+✓ Loaded security rule: Block-Malicious-Web
+
+Successfully loaded 2 out of 2 security rules from 'security-rules.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all rules
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Security Rule
+
+Display security rule objects.
 
 ### Syntax
 
 ```bash
-scm set security rule --list [OPTIONS]
+scm show security rule [OPTIONS]
 ```
 
 ### Options
 
-| Option          | Description                        | Required |
-| --------------- | ---------------------------------- | -------- |
-| `--folder TEXT` | Folder to list security rules from | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | Yes |
+| `--name TEXT` | Rule name to display | No |
 
-### Example
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Rule
 
 ```bash
-$ scm set security rule --list --folder Shared
-Listing security rules in folder 'Shared'...
-
-| Name | Source Zones | Dest Zones | Source | Destination | Apps | Services | Action | Profiles |
-|------|-------------|------------|--------|-------------|------|----------|--------|----------|
-| Allow-Internal-Web | Trust | DMZ | any | web-servers | web-browsing,ssl | app-default | allow | - |
-| Block-Malicious-Web | Untrust | DMZ | any | any | any | app-default | deny | AV,AS,URL |
+$ scm show security rule \
+    --folder Shared \
+    --name "Allow-Internal-Web"
+---> 100%
+Security Rule: Allow-Internal-Web
+  Location: Folder 'Shared'
+  Source Zones: Trust
+  Destination Zones: DMZ
+  Source Addresses: any
+  Destination Addresses: web-servers
+  Applications: web-browsing
+  Services: application-default
+  Action: allow
+  Log End: true
 ```
+
+#### List All Rules (Default Behavior)
+
+```bash
+$ scm show security rule --folder Shared
+---> 100%
+Security Rules in folder 'Shared':
+------------------------------------------------------------
+Name: Allow-Internal-Web
+  Source Zones: Trust
+  Destination Zones: DMZ
+  Action: allow
+------------------------------------------------------------
+Name: Block-Malicious-Web
+  Source Zones: Untrust
+  Destination Zones: DMZ
+  Action: deny
+------------------------------------------------------------
+```
+
+## Backup Security Rules
+
+Backup all security rule objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup rules from | Yes |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security rule --folder Shared
+---> 100%
+Successfully backed up 15 security rules to security_rule_folder_shared_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security rule \
+    --folder Shared \
+    --file shared-security-rules.yaml
+---> 100%
+Successfully backed up 15 security rules to shared-security-rules.yaml
+```
+
+## Best Practices
+
+1. **Order Rules Carefully**: Place more specific rules above general rules since rules are processed top to bottom; use the Move command to control order.
+2. **Apply Security Profiles**: Attach anti-virus, anti-spyware, vulnerability protection, and URL filtering profiles to allow rules for defense in depth.
+3. **Enable Logging**: Use `--log-end true` on all rules for visibility; add `--log-start true` for deny rules to capture blocked traffic.
+4. **Use Descriptive Names**: Name rules to clearly indicate their purpose (e.g., `Allow-Internal-Web`, `Block-Malicious-Traffic`).
+5. **Tag Rules for Organization**: Apply tags to group related rules by function, department, or compliance requirement.
+6. **Backup Before Changes**: Always backup existing rules before making bulk modifications via load commands.

--- a/docs/cli/security/url-access-profile.md
+++ b/docs/cli/security/url-access-profile.md
@@ -1,8 +1,22 @@
 # URL Access Profile
 
-URL access profiles define URL filtering policies that control access to websites by category.
+URL access profiles define URL filtering policies that control access to websites by category. The `scm` CLI provides commands to create, update, delete, and load URL access profiles.
+
+## Overview
+
+The `url-access-profile` commands allow you to:
+
+- Create URL access profiles with category-based filtering actions
+- Update existing profile configurations including safe search and credential enforcement
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set URL Access Profile
+
+Create or update a URL access profile.
+
+### Syntax
 
 ```bash
 scm set security url-access-profile [OPTIONS]
@@ -12,9 +26,9 @@ scm set security url-access-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name | Yes |
 | `--description TEXT` | Description | No |
 | `--block TEXT` | URL categories to block (can specify multiple) | No |
@@ -26,18 +40,244 @@ scm set security url-access-profile [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
+### Examples
+
+#### Create Profile with Blocked Categories
+
+```bash
+$ scm set security url-access-profile \
+    --folder Texas \
+    --name strict-url \
+    --block adult \
+    --block malware \
+    --alert hacking
+---> 100%
+Created URL access profile: strict-url in folder Texas
+```
+
+#### Create Profile with Safe Search
+
+```bash
+$ scm set security url-access-profile \
+    --folder Texas \
+    --name safe-browsing \
+    --block adult \
+    --block gambling \
+    --safe-search \
+    --cloud-inline-cat
+---> 100%
+Created URL access profile: safe-browsing in folder Texas
+```
+
+## Delete URL Access Profile
+
+Delete a URL access profile from SCM.
+
+### Syntax
+
+```bash
+scm delete security url-access-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
 ### Example
 
 ```bash
-$ scm set security url-access-profile --folder Texas --name strict-url \
-    --block adult --block malware --alert hacking
+$ scm delete security url-access-profile \
+    --folder Texas \
+    --name strict-url
+---> 100%
+Deleted URL access profile: strict-url from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load URL Access Profile
+
+Load multiple URL access profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show security url-access-profile --folder Texas
-scm delete security url-access-profile --folder Texas --name strict-url
-scm load security url-access-profile --file url-profiles.yaml --folder Texas
-scm backup security url-access-profile --folder Texas
+scm load security url-access-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing profile definitions | Yes |
+| `--folder TEXT` | Override folder location for all profiles | No |
+| `--snippet TEXT` | Override snippet location for all profiles | No |
+| `--device TEXT` | Override device location for all profiles | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+url_access_profiles:
+  - name: strict-url
+    folder: Texas
+    description: "Strict URL filtering"
+    block:
+      - adult
+      - malware
+    alert:
+      - hacking
+
+  - name: safe-browsing
+    folder: Texas
+    description: "Safe browsing with search enforcement"
+    block:
+      - adult
+      - gambling
+    safe_search: true
+    cloud_inline_cat: true
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security url-access-profile \
+    --file url-profiles.yaml
+---> 100%
+✓ Loaded URL access profile: strict-url
+✓ Loaded URL access profile: safe-browsing
+
+Successfully loaded 2 out of 2 URL access profiles from 'url-profiles.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security url-access-profile \
+    --file url-profiles.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded URL access profile: strict-url
+✓ Loaded URL access profile: safe-browsing
+
+Successfully loaded 2 out of 2 URL access profiles from 'url-profiles.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show URL Access Profile
+
+Display URL access profile objects.
+
+### Syntax
+
+```bash
+scm show security url-access-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Profile
+
+```bash
+$ scm show security url-access-profile \
+    --folder Texas \
+    --name strict-url
+---> 100%
+URL Access Profile: strict-url
+  Location: Folder 'Texas'
+  Description: Strict URL filtering
+  Block: adult, malware
+  Alert: hacking
+```
+
+#### List All Profiles (Default Behavior)
+
+```bash
+$ scm show security url-access-profile --folder Texas
+---> 100%
+URL Access Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: strict-url
+  Description: Strict URL filtering
+  Block: adult, malware
+------------------------------------------------------------
+Name: safe-browsing
+  Description: Safe browsing with search enforcement
+  Safe Search: enabled
+------------------------------------------------------------
+```
+
+## Backup URL Access Profiles
+
+Backup all URL access profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security url-access-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup profiles from | No\* |
+| `--snippet TEXT` | Snippet to backup profiles from | No\* |
+| `--device TEXT` | Device to backup profiles from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security url-access-profile --folder Texas
+---> 100%
+Successfully backed up 4 URL access profiles to url_access_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security url-access-profile \
+    --folder Texas \
+    --file texas-url-profiles.yaml
+---> 100%
+Successfully backed up 4 URL access profiles to texas-url-profiles.yaml
+```
+
+## Best Practices
+
+1. **Block High-Risk Categories**: Always block categories like malware, phishing, and command-and-control to protect against threats.
+2. **Use Alert for Monitoring**: Set categories to alert mode initially to monitor user behavior before enforcing blocks.
+3. **Enable Safe Search**: Use `--safe-search` to enforce safe search on search engines for compliance and content filtering.
+4. **Enable Cloud Categorization**: Use `--cloud-inline-cat` for real-time URL categorization of newly discovered websites.
+5. **Backup Before Changes**: Always backup existing profiles before making bulk modifications via load commands.

--- a/docs/cli/security/url-category.md
+++ b/docs/cli/security/url-category.md
@@ -1,8 +1,29 @@
 # URL Category
 
-Custom URL categories define lists of URLs or URL category matches for use in security policies and URL filtering profiles.
+Custom URL categories define lists of URLs or URL category matches for use in security policies and URL filtering profiles. The `scm` CLI provides commands to create, update, delete, and load custom URL categories.
+
+## Overview
+
+The `url-category` commands allow you to:
+
+- Create custom URL categories with URL lists or category matches
+- Update existing category configurations
+- Delete categories that are no longer needed
+- Bulk import categories from YAML files
+- Export categories for backup or migration
+
+## Category Types
+
+| Type | Description |
+| --- | --- |
+| URL List | Define explicit URLs or URL patterns to match |
+| Category Match | Match against predefined URL category names |
 
 ## Set URL Category
+
+Create or update a custom URL category.
+
+### Syntax
 
 ```bash
 scm set security url-category [OPTIONS]
@@ -12,9 +33,9 @@ scm set security url-category [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Category name | Yes |
 | `--description TEXT` | Description | No |
 | `--type TEXT` | Type: "URL List" or "Category Match" (default: URL List) | No |
@@ -24,21 +45,237 @@ scm set security url-category [OPTIONS]
 
 ### Examples
 
-```bash
-# Create URL list category
-$ scm set security url-category --folder Texas --name custom-block \
-    --url malware.example.com --url phishing.test.org
-
-# Create category match type
-$ scm set security url-category --folder Texas --name match-category \
-    --type "Category Match" --url gambling --url adult
-```
-
-## Show / Delete / Load / Backup
+#### Create URL List Category
 
 ```bash
-scm show security url-category --folder Texas
-scm delete security url-category --folder Texas --name custom-block
-scm load security url-category --file url-categories.yaml --folder Texas
-scm backup security url-category --folder Texas
+$ scm set security url-category \
+    --folder Texas \
+    --name custom-block \
+    --url malware.example.com \
+    --url phishing.test.org
+---> 100%
+Created URL category: custom-block in folder Texas
 ```
+
+#### Create Category Match Type
+
+```bash
+$ scm set security url-category \
+    --folder Texas \
+    --name match-category \
+    --type "Category Match" \
+    --url gambling \
+    --url adult
+---> 100%
+Created URL category: match-category in folder Texas
+```
+
+## Delete URL Category
+
+Delete a custom URL category from SCM.
+
+### Syntax
+
+```bash
+scm delete security url-category [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Category name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete security url-category \
+    --folder Texas \
+    --name custom-block
+---> 100%
+Deleted URL category: custom-block from folder Texas
+```
+
+## Load URL Category
+
+Load multiple custom URL categories from a YAML file.
+
+### Syntax
+
+```bash
+scm load security url-category [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing category definitions | Yes |
+| `--folder TEXT` | Override folder location for all categories | No |
+| `--snippet TEXT` | Override snippet location for all categories | No |
+| `--device TEXT` | Override device location for all categories | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+url_categories:
+  - name: custom-block
+    folder: Texas
+    description: "Blocked URL list"
+    type: "URL List"
+    url:
+      - malware.example.com
+      - phishing.test.org
+
+  - name: match-category
+    folder: Texas
+    description: "Category match filter"
+    type: "Category Match"
+    url:
+      - gambling
+      - adult
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security url-category \
+    --file url-categories.yaml
+---> 100%
+✓ Loaded URL category: custom-block
+✓ Loaded URL category: match-category
+
+Successfully loaded 2 out of 2 URL categories from 'url-categories.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security url-category \
+    --file url-categories.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded URL category: custom-block
+✓ Loaded URL category: match-category
+
+Successfully loaded 2 out of 2 URL categories from 'url-categories.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all categories
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show URL Category
+
+Display custom URL category objects.
+
+### Syntax
+
+```bash
+scm show security url-category [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Category name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Category
+
+```bash
+$ scm show security url-category \
+    --folder Texas \
+    --name custom-block
+---> 100%
+URL Category: custom-block
+  Location: Folder 'Texas'
+  Type: URL List
+  URLs: malware.example.com, phishing.test.org
+```
+
+#### List All Categories (Default Behavior)
+
+```bash
+$ scm show security url-category --folder Texas
+---> 100%
+URL Categories in folder 'Texas':
+------------------------------------------------------------
+Name: custom-block
+  Type: URL List
+  URLs: 2 entries
+------------------------------------------------------------
+Name: match-category
+  Type: Category Match
+  URLs: gambling, adult
+------------------------------------------------------------
+```
+
+## Backup URL Categories
+
+Backup all custom URL category objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security url-category [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup categories from | No\* |
+| `--snippet TEXT` | Snippet to backup categories from | No\* |
+| `--device TEXT` | Device to backup categories from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security url-category --folder Texas
+---> 100%
+Successfully backed up 6 URL categories to url_category_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security url-category \
+    --folder Texas \
+    --file texas-url-categories.yaml
+---> 100%
+Successfully backed up 6 URL categories to texas-url-categories.yaml
+```
+
+## Best Practices
+
+1. **Use URL Lists for Specific Sites**: Create URL List categories for explicit domain blocking or allowing of known sites.
+2. **Use Category Match for Broad Filtering**: Use Category Match type to reference predefined categories in custom policies.
+3. **Descriptive Names**: Name categories to clearly indicate their purpose (e.g., `blocked-malware-sites`, `allowed-business-apps`).
+4. **Reference in URL Access Profiles**: Combine custom URL categories with URL access profiles for granular filtering control.
+5. **Backup Before Changes**: Always backup existing categories before making bulk modifications via load commands.

--- a/docs/cli/security/vulnerability-protection-profile.md
+++ b/docs/cli/security/vulnerability-protection-profile.md
@@ -1,8 +1,22 @@
 # Vulnerability Protection Profile
 
-Vulnerability protection profiles define rules for detecting and preventing exploitation of known vulnerabilities.
+Vulnerability protection profiles define rules for detecting and preventing exploitation of known vulnerabilities. The `scm` CLI provides commands to create, update, delete, and load vulnerability protection profiles.
+
+## Overview
+
+The `vulnerability-protection-profile` commands allow you to:
+
+- Create vulnerability protection profiles with severity-based blocking rules
+- Update existing profile configurations
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set Vulnerability Protection Profile
+
+Create or update a vulnerability protection profile.
+
+### Syntax
 
 ```bash
 scm set security vulnerability-protection-profile [OPTIONS]
@@ -12,9 +26,9 @@ scm set security vulnerability-protection-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name | Yes |
 | `--description TEXT` | Profile description | No |
 | `--block-critical-high` | Add default rule to block critical and high severity vulnerabilities | No |
@@ -23,23 +37,223 @@ scm set security vulnerability-protection-profile [OPTIONS]
 
 ### Examples
 
+#### Create Basic Profile
+
 ```bash
-# Create basic profile
 $ scm set security vulnerability-protection-profile \
-    --folder Texas --name strict-vuln \
+    --folder Texas \
+    --name strict-vuln \
     --description "Block critical vulnerabilities"
-
-# Create profile with block critical/high rule
-$ scm set security vulnerability-protection-profile \
-    --folder Texas --name vuln-protection \
-    --block-critical-high
+---> 100%
+Created vulnerability protection profile: strict-vuln in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create Profile with Block Critical/High Rule
 
 ```bash
-scm show security vulnerability-protection-profile --folder Texas
-scm delete security vulnerability-protection-profile --folder Texas --name strict-vuln
-scm load security vulnerability-protection-profile --file vuln-profiles.yaml --folder Texas
-scm backup security vulnerability-protection-profile --folder Texas
+$ scm set security vulnerability-protection-profile \
+    --folder Texas \
+    --name vuln-protection \
+    --block-critical-high
+---> 100%
+Created vulnerability protection profile: vuln-protection in folder Texas
 ```
+
+## Delete Vulnerability Protection Profile
+
+Delete a vulnerability protection profile from SCM.
+
+### Syntax
+
+```bash
+scm delete security vulnerability-protection-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete security vulnerability-protection-profile \
+    --folder Texas \
+    --name strict-vuln
+---> 100%
+Deleted vulnerability protection profile: strict-vuln from folder Texas
+```
+
+## Load Vulnerability Protection Profile
+
+Load multiple vulnerability protection profiles from a YAML file.
+
+### Syntax
+
+```bash
+scm load security vulnerability-protection-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing profile definitions | Yes |
+| `--folder TEXT` | Override folder location for all profiles | No |
+| `--snippet TEXT` | Override snippet location for all profiles | No |
+| `--device TEXT` | Override device location for all profiles | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+vulnerability_protection_profiles:
+  - name: strict-vuln
+    folder: Texas
+    description: "Block critical vulnerabilities"
+
+  - name: vuln-protection
+    folder: Texas
+    description: "Standard vulnerability protection"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security vulnerability-protection-profile \
+    --file vuln-profiles.yaml
+---> 100%
+✓ Loaded vulnerability protection profile: strict-vuln
+✓ Loaded vulnerability protection profile: vuln-protection
+
+Successfully loaded 2 out of 2 vulnerability protection profiles from 'vuln-profiles.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security vulnerability-protection-profile \
+    --file vuln-profiles.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded vulnerability protection profile: strict-vuln
+✓ Loaded vulnerability protection profile: vuln-protection
+
+Successfully loaded 2 out of 2 vulnerability protection profiles from 'vuln-profiles.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Vulnerability Protection Profile
+
+Display vulnerability protection profile objects.
+
+### Syntax
+
+```bash
+scm show security vulnerability-protection-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Profile
+
+```bash
+$ scm show security vulnerability-protection-profile \
+    --folder Texas \
+    --name strict-vuln
+---> 100%
+Vulnerability Protection Profile: strict-vuln
+  Location: Folder 'Texas'
+  Description: Block critical vulnerabilities
+```
+
+#### List All Profiles (Default Behavior)
+
+```bash
+$ scm show security vulnerability-protection-profile --folder Texas
+---> 100%
+Vulnerability Protection Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: strict-vuln
+  Description: Block critical vulnerabilities
+------------------------------------------------------------
+Name: vuln-protection
+  Description: Standard vulnerability protection
+------------------------------------------------------------
+```
+
+## Backup Vulnerability Protection Profiles
+
+Backup all vulnerability protection profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security vulnerability-protection-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup profiles from | No\* |
+| `--snippet TEXT` | Snippet to backup profiles from | No\* |
+| `--device TEXT` | Device to backup profiles from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security vulnerability-protection-profile --folder Texas
+---> 100%
+Successfully backed up 5 vulnerability protection profiles to vulnerability_protection_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security vulnerability-protection-profile \
+    --folder Texas \
+    --file texas-vuln-profiles.yaml
+---> 100%
+Successfully backed up 5 vulnerability protection profiles to texas-vuln-profiles.yaml
+```
+
+## Best Practices
+
+1. **Block Critical and High Severity**: Use `--block-critical-high` to automatically block exploitation attempts for the most dangerous vulnerabilities.
+2. **Use Descriptive Names**: Name profiles to reflect their protection level and purpose (e.g., `strict-vuln`, `standard-protection`).
+3. **Apply to Security Rules**: Attach vulnerability protection profiles to security rules using the `--vulnerability` option on rules.
+4. **Backup Before Changes**: Always backup existing profiles before making bulk modifications via load commands.
+5. **Keep Profiles Updated**: Regularly review and update profiles as new vulnerability signatures become available.

--- a/docs/cli/security/wildfire-antivirus-profile.md
+++ b/docs/cli/security/wildfire-antivirus-profile.md
@@ -1,8 +1,22 @@
 # WildFire Antivirus Profile
 
-WildFire antivirus profiles configure file forwarding to WildFire for cloud-based malware analysis and prevention.
+WildFire antivirus profiles configure file forwarding to WildFire for cloud-based malware analysis and prevention. The `scm` CLI provides commands to create, update, delete, and load WildFire antivirus profiles.
+
+## Overview
+
+The `wildfire-antivirus-profile` commands allow you to:
+
+- Create WildFire antivirus profiles with file forwarding rules
+- Update existing profile configurations including packet capture settings
+- Delete profiles that are no longer needed
+- Bulk import profiles from YAML files
+- Export profiles for backup or migration
 
 ## Set WildFire Antivirus Profile
+
+Create or update a WildFire antivirus profile.
+
+### Syntax
 
 ```bash
 scm set security wildfire-antivirus-profile [OPTIONS]
@@ -12,9 +26,9 @@ scm set security wildfire-antivirus-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name | Yes |
 | `--description TEXT` | Profile description | No |
 | `--rules TEXT` | Rules configuration as JSON | No |
@@ -24,25 +38,242 @@ scm set security wildfire-antivirus-profile [OPTIONS]
 
 ### Examples
 
+#### Create Basic Profile
+
 ```bash
-# Create basic profile with default rule
-$ scm set security wildfire-antivirus-profile --folder Texas --name wf-basic \
+$ scm set security wildfire-antivirus-profile \
+    --folder Texas \
+    --name wf-basic \
     --description "Basic WildFire profile"
-
-# Create profile with custom rules
-$ scm set security wildfire-antivirus-profile --folder Texas --name wf-custom \
-    --rules '[{"name":"Forward All","direction":"both","analysis":"public-cloud","application":["any"],"file_type":["any"]}]'
-
-# Create profile with packet capture
-$ scm set security wildfire-antivirus-profile --folder Texas --name wf-capture \
-    --packet-capture
+---> 100%
+Created WildFire antivirus profile: wf-basic in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create Profile with Custom Rules
 
 ```bash
-scm show security wildfire-antivirus-profile --folder Texas
-scm delete security wildfire-antivirus-profile --folder Texas --name wf-basic
-scm load security wildfire-antivirus-profile --file wildfire.yaml --folder Texas
-scm backup security wildfire-antivirus-profile --folder Texas
+$ scm set security wildfire-antivirus-profile \
+    --folder Texas \
+    --name wf-custom \
+    --rules '[{"name":"Forward All","direction":"both","analysis":"public-cloud","application":["any"],"file_type":["any"]}]'
+---> 100%
+Created WildFire antivirus profile: wf-custom in folder Texas
 ```
+
+#### Create Profile with Packet Capture
+
+```bash
+$ scm set security wildfire-antivirus-profile \
+    --folder Texas \
+    --name wf-capture \
+    --packet-capture
+---> 100%
+Created WildFire antivirus profile: wf-capture in folder Texas
+```
+
+## Delete WildFire Antivirus Profile
+
+Delete a WildFire antivirus profile from SCM.
+
+### Syntax
+
+```bash
+scm delete security wildfire-antivirus-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to delete | Yes |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete security wildfire-antivirus-profile \
+    --folder Texas \
+    --name wf-basic
+---> 100%
+Deleted WildFire antivirus profile: wf-basic from folder Texas
+```
+
+## Load WildFire Antivirus Profile
+
+Load multiple WildFire antivirus profiles from a YAML file.
+
+### Syntax
+
+```bash
+scm load security wildfire-antivirus-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing profile definitions | Yes |
+| `--folder TEXT` | Override folder location for all profiles | No |
+| `--snippet TEXT` | Override snippet location for all profiles | No |
+| `--device TEXT` | Override device location for all profiles | No |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+wildfire_antivirus_profiles:
+  - name: wf-basic
+    folder: Texas
+    description: "Basic WildFire profile"
+
+  - name: wf-custom
+    folder: Texas
+    description: "Custom WildFire rules"
+    rules:
+      - name: Forward All
+        direction: both
+        analysis: public-cloud
+        application:
+          - any
+        file_type:
+          - any
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load security wildfire-antivirus-profile \
+    --file wildfire.yaml
+---> 100%
+✓ Loaded WildFire antivirus profile: wf-basic
+✓ Loaded WildFire antivirus profile: wf-custom
+
+Successfully loaded 2 out of 2 WildFire antivirus profiles from 'wildfire.yaml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load security wildfire-antivirus-profile \
+    --file wildfire.yaml \
+    --folder Austin
+---> 100%
+✓ Loaded WildFire antivirus profile: wf-basic
+✓ Loaded WildFire antivirus profile: wf-custom
+
+Successfully loaded 2 out of 2 WildFire antivirus profiles from 'wildfire.yaml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show WildFire Antivirus Profile
+
+Display WildFire antivirus profile objects.
+
+### Syntax
+
+```bash
+scm show security wildfire-antivirus-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Profile name to display | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Profile
+
+```bash
+$ scm show security wildfire-antivirus-profile \
+    --folder Texas \
+    --name wf-basic
+---> 100%
+WildFire Antivirus Profile: wf-basic
+  Location: Folder 'Texas'
+  Description: Basic WildFire profile
+```
+
+#### List All Profiles (Default Behavior)
+
+```bash
+$ scm show security wildfire-antivirus-profile --folder Texas
+---> 100%
+WildFire Antivirus Profiles in folder 'Texas':
+------------------------------------------------------------
+Name: wf-basic
+  Description: Basic WildFire profile
+------------------------------------------------------------
+Name: wf-custom
+  Description: Custom WildFire rules
+------------------------------------------------------------
+```
+
+## Backup WildFire Antivirus Profiles
+
+Backup all WildFire antivirus profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup security wildfire-antivirus-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup profiles from | No\* |
+| `--snippet TEXT` | Snippet to backup profiles from | No\* |
+| `--device TEXT` | Device to backup profiles from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup security wildfire-antivirus-profile --folder Texas
+---> 100%
+Successfully backed up 3 WildFire antivirus profiles to wildfire_antivirus_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup security wildfire-antivirus-profile \
+    --folder Texas \
+    --file texas-wildfire.yaml
+---> 100%
+Successfully backed up 3 WildFire antivirus profiles to texas-wildfire.yaml
+```
+
+## Best Practices
+
+1. **Forward All File Types**: Use rules with `file_type: ["any"]` and `application: ["any"]` to ensure comprehensive malware analysis coverage.
+2. **Enable Packet Capture**: Use `--packet-capture` for forensic analysis when investigating potential malware incidents.
+3. **Use Public Cloud Analysis**: Set `analysis` to `public-cloud` for the broadest threat intelligence coverage from WildFire.
+4. **Backup Before Changes**: Always backup existing profiles before making bulk modifications via load commands.
+5. **Combine with Anti-Spyware**: Layer WildFire profiles with anti-spyware and vulnerability protection for defense in depth.


### PR DESCRIPTION
## Summary
- Rewrote all 11 security CLI reference pages to conform to the docs-style skill template
- Each operation (Set, Delete, Load, Show, Backup) now has its own H2 with Syntax, Options, Examples subsections
- Added Move sections for rule pages (security rules, app-override, authentication, decryption)
- Standardized output formatting (---> 100%, Unicode checkmarks, no HTML spans)
- Added Overview, YAML File Format, and Best Practices sections to all pages

Closes #116

## Test plan
- [ ] Verify `make docs-build` passes with strict checks
- [ ] Spot-check rendered pages for correct admonition formatting
- [ ] Confirm all code blocks have correct language tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)