### PR TITLE
docs: standardize Guide pages

### DIFF
--- a/docs/guide/advanced-topics.md
+++ b/docs/guide/advanced-topics.md
@@ -1,50 +1,98 @@
-# Advanced CLI Topics
+# Advanced Topics
 
-This guide covers advanced features and techniques for working with the Strata Cloud Manager CLI.
+The `scm` CLI supports advanced workflows including multi-folder operations, bulk loading, mock mode testing, verbose output, environment variable configuration, and script integration. This guide covers techniques for power users and automation scenarios.
 
-## Working with Multiple Folders
+## Overview
 
-The CLI supports working with objects in different configuration folders.
+This guide covers advanced CLI capabilities:
 
-### Specifying Folders
+- Work with objects across multiple configuration folders
+- Perform bulk operations using YAML files
+- Test commands safely with mock mode
+- Enable verbose output for troubleshooting
+- Configure the CLI with environment variables
+- Integrate the CLI into scripts and automation pipelines
 
-All object-related commands require the `--folder` parameter to specify where objects should be created, updated, or retrieved from:
+## Prerequisites
+
+Before using these advanced features, ensure you have:
+
+- The `scm` CLI installed and authenticated (see [Getting Started](getting-started.md))
+- Familiarity with basic CLI operations (see [Configuration Objects](configuration-objects.md))
+- For scripting: a POSIX-compatible shell (bash, zsh) or PowerShell
+
+## Core Concepts
+
+### Folder-Based Organization
+
+All object-related commands require the `--folder` parameter to specify where objects should be created, updated, or retrieved from. SCM uses folders to organize configurations hierarchically.
+
+### Mock Mode
+
+The `--mock` flag allows you to run any command without making actual API calls. This is useful for validating syntax, testing YAML files, and developing scripts.
+
+### Verbose Output
+
+The `--verbose` flag provides detailed information about API requests, responses, timing, and errors. Use it when troubleshooting unexpected behavior.
+
+## Examples
+
+### Working with Multiple Folders
+
+#### Specifying Folders
 
 ```bash
-# Create an address in the Shared folder
-scm set object address --folder Shared --name web-server --ip-netmask 10.1.1.10/32
+$ scm set object address \
+    --folder Shared \
+    --name web-server \
+    --ip-netmask 10.1.1.10/32
+---> 100%
+Created address: web-server in folder Shared
 ```
 
-### Common Folder Operations
-
-Working across multiple folders:
+#### Listing Objects Across Folders
 
 ```bash
-# List all address objects in the Shared folder
-scm set object address --list --folder Shared
-
-# List all address objects in a different folder
-scm set object address --list --folder Branch-Office-1
+$ scm show object address --folder Shared
+---> 100%
+Addresses in folder 'Shared':
+------------------------------------------------------------
+Name: web-server
+  IP Netmask: 10.1.1.10/32
+------------------------------------------------------------
 ```
 
-## Bulk Operations
+```bash
+$ scm show object address --folder Branch-Office-1
+---> 100%
+Addresses in folder 'Branch-Office-1':
+------------------------------------------------------------
+Name: branch-server
+  IP Netmask: 10.2.1.10/32
+------------------------------------------------------------
+```
 
-The CLI provides powerful bulk operations through the `load` commands.
+### Bulk Operations
 
-### Loading Multiple Objects
+#### Loading Multiple Objects
 
 Load multiple objects of the same type from a YAML file:
 
 ```bash
-# Create multiple addresses defined in a YAML file
-scm load object address --folder Shared --file addresses.yaml
+$ scm load object address --folder Shared --file addresses.yaml
+---> 100%
+✓ Loaded address: web-server-1
+✓ Loaded address: web-server-2
+
+Successfully loaded 2 out of 2 addresses from 'addresses.yaml'
 ```
 
-### YAML Structure for Bulk Loading
+#### YAML Structure for Bulk Loading
 
-Each resource type has a specific YAML structure. Here's an example for address objects:
+Each resource type has a specific YAML structure:
 
 ```yaml
+---
 addresses:
   - name: web-server-1
     description: "Web server 1"
@@ -61,36 +109,44 @@ addresses:
       - production
 ```
 
-## Mock Mode
+!!! tip
+    Use YAML files for complex or repeatable configurations. Store them in
+    version control to track changes over time.
 
-The CLI offers a mock mode for testing commands without making actual API calls.
+### Mock Mode
 
-### Enabling Mock Mode
+#### Testing Commands Safely
 
-Add the `--mock` flag to any command to run it in mock mode:
+Add the `--mock` flag to any command to run it without API calls:
 
 ```bash
-# Test creating an address without actually calling the API
-scm set object address --mock --folder Shared --name test-server --ip-netmask 10.1.1.10/32
+$ scm set object address \
+    --mock \
+    --folder Shared \
+    --name test-server \
+    --ip-netmask 10.1.1.10/32
+---> 100%
+Created address: test-server in folder Shared (mock mode)
 ```
 
-This is useful for:
+Mock mode is useful for:
 
 - Testing command syntax without making changes
 - Validating YAML files before bulk loading
 - Script development and testing
 
-## Verbose Output
+### Verbose Output
 
-For troubleshooting, use verbose mode to see more details.
-
-### Enabling Verbose Mode
+#### Troubleshooting with Verbose Mode
 
 Add the `--verbose` flag to see detailed operation information:
 
 ```bash
-# Get verbose output when creating an address
-scm set object address --verbose --folder Shared --name test-server --ip-netmask 10.1.1.10/32
+$ scm set object address \
+    --verbose \
+    --folder Shared \
+    --name test-server \
+    --ip-netmask 10.1.1.10/32
 ```
 
 Verbose output includes:
@@ -100,54 +156,70 @@ Verbose output includes:
 - Timing information
 - Error details (when failures occur)
 
-## Using Environment Variables
+### Environment Variables
 
-The CLI can be configured using environment variables for authentication and other settings.
+#### Available Environment Variables
 
-### Available Environment Variables
+| Variable | Description | Example |
+| --- | --- | --- |
+| `SCM_CLIENT_ID` | Client ID for authentication | `export SCM_CLIENT_ID=client-id-value` |
+| `SCM_CLIENT_SECRET` | Client secret for authentication | `export SCM_CLIENT_SECRET=client-secret-value` |
+| `SCM_TSG_ID` | Tenant Service Group ID | `export SCM_TSG_ID=tsg-id-value` |
+| `SCM_LOG_LEVEL` | Logging level (DEBUG, INFO, etc.) | `export SCM_LOG_LEVEL=DEBUG` |
 
-| Variable            | Purpose                           | Example                                        |
-| ------------------- | --------------------------------- | ---------------------------------------------- |
-| `SCM_CLIENT_ID`     | Client ID for authentication      | `export SCM_CLIENT_ID=client-id-value`         |
-| `SCM_CLIENT_SECRET` | Client secret for authentication  | `export SCM_CLIENT_SECRET=client-secret-value` |
-| `SCM_TSG_ID`        | Tenant Service Group ID           | `export SCM_TSG_ID=tsg-id-value`               |
-| `SCM_CLI_LOG_LEVEL` | Logging level (DEBUG, INFO, etc.) | `export SCM_CLI_LOG_LEVEL=DEBUG`               |
+!!! info
+    For full details on configuration sources and precedence, see
+    [Configuration Management](configuration.md).
 
-## Script Integration
+### Script Integration
 
-The CLI is designed to work well in scripts and automation.
+#### Exit Codes
 
-### Exit Codes
+The CLI uses standard exit codes for scripting:
 
-The CLI uses standard exit codes:
+| Exit Code | Meaning |
+| --- | --- |
+| `0` | Success |
+| Non-zero | Failure |
 
-- `0`: Success
-- Non-zero: Failure
-
-This allows for scripting with error checking:
+#### Error Checking in Scripts
 
 ```bash
 #!/bin/bash
 # Create an address and check if successful
-scm set object address --folder Shared --name test-server --ip-netmask 10.1.1.10/32
+scm set object address \
+    --folder Shared \
+    --name test-server \
+    --ip-netmask 10.1.1.10/32
+
 if [ $? -eq 0 ]; then
-  echo "Address created successfully"
+    echo "Address created successfully"
 else
-  echo "Failed to create address"
-  exit 1
+    echo "Failed to create address"
+    exit 1
 fi
 ```
 
-### Parsing Output
-
-For programmatic use, consider parsing the CLI output:
+#### Parsing CLI Output
 
 ```bash
-# Get a list of addresses in JSON format and process with jq
-ADDRESSES=$(scm set object address --list --folder Shared --output json | jq '.[] | select(.name | startswith("web-"))')
+# Get a list of addresses and process with jq
+ADDRESSES=$(scm show object address \
+    --folder Shared \
+    --output json | jq '.[] | select(.name | startswith("web-"))')
 ```
+
+## Best Practices
+
+1. **Use mock mode for development**: Always test new scripts and YAML files with `--mock` before running against production.
+2. **Organize objects by folder**: Use SCM folders to logically separate configurations by environment or location.
+3. **Store YAML files in version control**: Track configuration changes alongside your infrastructure code.
+4. **Use verbose mode for debugging**: Enable `--verbose` when troubleshooting unexpected behavior.
+5. **Handle exit codes in scripts**: Always check return codes when integrating the CLI into automation pipelines.
+6. **Use environment variables for CI/CD**: Set credentials via environment variables in automated workflows rather than hardcoding them.
 
 ## Next Steps
 
 - Explore the [CLI Reference](../cli/index.md) for detailed information on all available commands
+- Review [Data Formats](data-models.md) for YAML file structures and validation rules
 - Check the [GitHub repository](https://github.com/cdot65/pan-scm-cli) for examples and updates

--- a/docs/guide/configuration-objects.md
+++ b/docs/guide/configuration-objects.md
@@ -1,127 +1,307 @@
-# Working with Configuration Objects in the CLI
+# Configuration Objects
 
-The `scm` CLI provides a consistent interface for managing various configuration objects in Strata Cloud Manager.
+The `scm` CLI provides a consistent interface for managing configuration objects in Strata Cloud Manager. This guide explains the object categories, common operations, and how objects relate to each other.
 
-## Object Categories and Commands
+## Overview
+
+Configuration objects are the building blocks of your SCM environment. The CLI allows you to:
+
+- Create and update objects across multiple categories (objects, network, security, deployment)
+- Delete objects that are no longer needed
+- List and inspect existing objects
+- Bulk import objects from YAML files
+- Back up objects for migration or disaster recovery
+
+## Prerequisites
+
+Before working with configuration objects, ensure you have:
+
+- The `scm` CLI installed and authenticated (see [Getting Started](getting-started.md))
+- Appropriate permissions for the target SCM folders
+- An understanding of which object types your workflow requires
+
+## Core Concepts
+
+### Object Categories
 
 The CLI organizes configuration management commands into logical categories:
 
-### Objects
+| Category | Description | Example Resources |
+| --- | --- | --- |
+| `object` | Network objects | Address, address group, application, service, tag |
+| `network` | Network configurations | Security zone |
+| `security` | Security policies | Security rule, anti-spyware profile, decryption profile |
+| `deployment` | Deployment settings | Bandwidth allocation |
 
-Commands for managing network objects:
+### Command Pattern
 
-```bash
-# Address Objects
-scm set object address --folder Shared --name web-server --ip-netmask 10.1.1.10/32
-scm delete object address --folder Shared --name web-server
-scm load object address --folder Shared --file addresses.yaml
-
-# Address Groups
-scm set object address-group --folder Shared --name web-servers --static --members "web-server-1,web-server-2"
-scm delete object address-group --folder Shared --name web-servers
-scm load object address-group --folder Shared --file address-groups.yaml
-```
-
-### Network
-
-Commands for managing network configurations:
+All object commands follow a consistent pattern:
 
 ```bash
-# Security Zones
-scm set network security-zone --folder Shared --name Trust --mode layer3
-scm delete network security-zone --folder Shared --name Trust
-scm load network security-zone --folder Shared --file security-zones.yaml
+scm <action> <category> <object> [OPTIONS]
 ```
 
-### Security
+### Object Relationships
 
-Commands for managing security policies:
+Configuration objects often have dependencies. For example:
+
+- Address groups reference address objects
+- Security rules reference zones, address objects, and address groups
+- Service groups reference service objects
+
+!!! warning
+    When creating objects, ensure that any referenced objects already exist.
+    Creating an address group that references a nonexistent address will fail.
+
+## Examples
+
+### Objects Category
+
+#### Address Objects
 
 ```bash
-# Security Rules
-scm set security rule --folder Shared --name "Allow-Web" --source-zones Trust --destination-zones Untrust
-scm delete security rule --folder Shared --name "Allow-Web"
-scm load security rule --folder Shared --file security-rules.yaml
+$ scm set object address \
+    --folder Shared \
+    --name web-server \
+    --ip-netmask 10.1.1.10/32
+---> 100%
+Created address: web-server in folder Shared
 ```
-
-### Deployment
-
-Commands for managing deployment settings:
 
 ```bash
-# Bandwidth Allocation
-scm set deployment bandwidth --folder Shared --name "Standard-Branch" --egress-guaranteed 50 --egress-max 100
-scm delete deployment bandwidth --folder Shared --name "Standard-Branch"
-scm load deployment bandwidth --folder Shared --file bandwidth-allocations.yaml
+$ scm delete object address --folder Shared --name web-server
+---> 100%
+Deleted address: web-server from folder Shared
 ```
-
-## Common Operations
-
-### Creating Objects
-
-Every object type has a specific `set` command with required and optional parameters:
 
 ```bash
-scm set object address --folder Shared --name web-server --ip-netmask 10.1.1.10/32 --description "Web server" --tags "web,production"
+$ scm load object address --folder Shared --file addresses.yaml
+---> 100%
+✓ Loaded address: web-server-1
+✓ Loaded address: web-server-2
+
+Successfully loaded 2 out of 2 addresses from 'addresses.yaml'
 ```
 
-### Updating Objects
-
-Updating uses the same `set` command as creating. The CLI will update the object if it exists:
+#### Address Groups
 
 ```bash
-# Update an existing address object
-scm set object address --folder Shared --name web-server --ip-netmask 10.1.1.20/32 --description "Updated web server"
+$ scm set object address-group \
+    --folder Shared \
+    --name web-servers \
+    --static \
+    --members "web-server-1,web-server-2"
+---> 100%
+Created address-group: web-servers in folder Shared
 ```
-
-### Deleting Objects
-
-Delete objects using the `delete` command:
 
 ```bash
-scm delete object address --folder Shared --name web-server
+$ scm delete object address-group --folder Shared --name web-servers
+---> 100%
+Deleted address-group: web-servers from folder Shared
 ```
-
-### Listing Objects
-
-List objects using the `--list` option with the `set` command:
 
 ```bash
-scm set object address --list --folder Shared
+$ scm load object address-group --folder Shared --file address-groups.yaml
+---> 100%
+✓ Loaded address-group: web-servers
+✓ Loaded address-group: db-servers
+
+Successfully loaded 2 out of 2 address-groups from 'address-groups.yaml'
 ```
 
-### Bulk Operations
+### Network Category
+
+#### Security Zones
+
+```bash
+$ scm set network security-zone \
+    --folder Shared \
+    --name Trust \
+    --mode layer3
+---> 100%
+Created security-zone: Trust in folder Shared
+```
+
+```bash
+$ scm delete network security-zone --folder Shared --name Trust
+---> 100%
+Deleted security-zone: Trust from folder Shared
+```
+
+```bash
+$ scm load network security-zone --folder Shared --file security-zones.yaml
+---> 100%
+✓ Loaded security-zone: Trust
+✓ Loaded security-zone: Untrust
+
+Successfully loaded 2 out of 2 security-zones from 'security-zones.yaml'
+```
+
+### Security Category
+
+#### Security Rules
+
+```bash
+$ scm set security rule \
+    --folder Shared \
+    --name "Allow-Web" \
+    --source-zones Trust \
+    --destination-zones Untrust
+---> 100%
+Created security rule: Allow-Web in folder Shared
+```
+
+```bash
+$ scm delete security rule --folder Shared --name "Allow-Web"
+---> 100%
+Deleted security rule: Allow-Web from folder Shared
+```
+
+```bash
+$ scm load security rule --folder Shared --file security-rules.yaml
+---> 100%
+✓ Loaded security rule: Allow-Web
+✓ Loaded security rule: Block-Malware
+
+Successfully loaded 2 out of 2 security rules from 'security-rules.yaml'
+```
+
+### Deployment Category
+
+#### Bandwidth Allocation
+
+```bash
+$ scm set deployment bandwidth \
+    --folder Shared \
+    --name "Standard-Branch" \
+    --egress-guaranteed 50 \
+    --egress-max 100
+---> 100%
+Created bandwidth: Standard-Branch in folder Shared
+```
+
+```bash
+$ scm delete deployment bandwidth --folder Shared --name "Standard-Branch"
+---> 100%
+Deleted bandwidth: Standard-Branch from folder Shared
+```
+
+```bash
+$ scm load deployment bandwidth --folder Shared --file bandwidth-allocations.yaml
+---> 100%
+✓ Loaded bandwidth: Standard-Branch
+✓ Loaded bandwidth: Premium-Branch
+
+Successfully loaded 2 out of 2 bandwidth allocations from 'bandwidth-allocations.yaml'
+```
+
+### Common Operations
+
+#### Creating Objects
+
+Every object type has a `set` command with required and optional parameters:
+
+```bash
+$ scm set object address \
+    --folder Shared \
+    --name web-server \
+    --ip-netmask 10.1.1.10/32 \
+    --description "Web server" \
+    --tags "web,production"
+---> 100%
+Created address: web-server in folder Shared
+```
+
+#### Updating Objects
+
+Updating uses the same `set` command. The CLI updates the object if it already exists:
+
+```bash
+$ scm set object address \
+    --folder Shared \
+    --name web-server \
+    --ip-netmask 10.1.1.20/32 \
+    --description "Updated web server"
+---> 100%
+Updated address: web-server in folder Shared
+```
+
+#### Listing Objects
+
+List objects using the `show` command:
+
+```bash
+$ scm show object address --folder Shared
+---> 100%
+Addresses in folder 'Shared':
+------------------------------------------------------------
+Name: web-server-1
+  IP Netmask: 10.1.1.10/32
+------------------------------------------------------------
+Name: web-server-2
+  IP Netmask: 10.1.1.11/32
+------------------------------------------------------------
+```
+
+#### Bulk Operations
 
 Load multiple objects from YAML files:
 
 ```bash
-scm load object address --folder Shared --file addresses.yaml
+$ scm load object address --folder Shared --file addresses.yaml
+---> 100%
+✓ Loaded address: web-server-1
+✓ Loaded address: web-server-2
+
+Successfully loaded 2 out of 2 addresses from 'addresses.yaml'
 ```
 
-## Understanding Object Relationships
+### Building Object Dependencies
 
-Configuration objects often have relationships. For example:
-
-- Address Groups reference Address objects
-- Security Rules reference Zones, Address objects, and Address Groups
-
-When creating objects, ensure that any referenced objects already exist:
+Create objects in the correct order to satisfy dependencies:
 
 ```bash
 # First create the address objects
-scm set object address --folder Shared --name web-server-1 --ip-netmask 10.1.1.10/32
-scm set object address --folder Shared --name web-server-2 --ip-netmask 10.1.1.11/32
+$ scm set object address \
+    --folder Shared \
+    --name web-server-1 \
+    --ip-netmask 10.1.1.10/32
+---> 100%
+Created address: web-server-1 in folder Shared
+
+$ scm set object address \
+    --folder Shared \
+    --name web-server-2 \
+    --ip-netmask 10.1.1.11/32
+---> 100%
+Created address: web-server-2 in folder Shared
 
 # Then create an address group that references them
-scm set object address-group --folder Shared --name web-servers --static --members "web-server-1,web-server-2"
+$ scm set object address-group \
+    --folder Shared \
+    --name web-servers \
+    --static \
+    --members "web-server-1,web-server-2"
+---> 100%
+Created address-group: web-servers in folder Shared
 ```
+
+## Best Practices
+
+1. **Create dependencies first**: Always create referenced objects before the objects that reference them (e.g., addresses before address groups).
+2. **Use YAML for complex setups**: Bulk loading from YAML files ensures consistency and is easier to maintain in version control.
+3. **Validate with mock mode**: Use `--mock` to test commands before making changes to production.
+4. **Use descriptive names**: Choose clear, meaningful names for objects to make policies easier to understand.
+5. **Organize by folder**: Use SCM folders to logically separate objects by environment or location.
 
 ## Next Steps
 
-For detailed information on specific object types, see the CLI reference documentation:
-
-- [Address Objects](../cli/objects/address.md)
-- [Address Groups](../cli/objects/address-group.md)
-- [Security Zones](../cli/network/security-zone.md)
-- [Security Rules](../cli/security/rules.md)
-- [Bandwidth Allocation](../cli/deployment/bandwidth.md)
+- See the [CLI Reference](../cli/index.md) for detailed command documentation on each object type:
+    - [Address Objects](../cli/objects/address.md)
+    - [Address Groups](../cli/objects/address-group.md)
+    - [Security Zones](../cli/network/security-zone.md)
+    - [Security Rules](../cli/security/rules.md)
+    - [Bandwidth Allocation](../cli/deployment/bandwidth.md)
+- Learn about [Data Formats](data-models.md) for YAML file structures
+- Review [Advanced CLI Topics](advanced-topics.md) for automation workflows

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,26 +1,168 @@
-# Configuration Management with Dynaconf
+# Configuration Management
 
-The pan-scm-cli uses [Dynaconf](https://www.dynaconf.com/) for flexible configuration management, supporting multiple configuration sources with clear precedence rules. The CLI also supports **multi-tenant authentication** through context management, allowing you to easily switch between different SCM environments.
+The `scm` CLI uses Dynaconf for flexible configuration management, supporting multiple configuration sources with clear precedence rules. The CLI also supports multi-tenant authentication through context management, allowing you to switch between different SCM environments.
 
-## Multi-Tenant Context Management (Recommended)
+## Overview
 
-The CLI supports managing multiple SCM tenant configurations through contexts. This is the recommended approach for users who work with multiple SCM environments.
+This guide explains how to configure the CLI for your environment:
 
-### Context Commands
+- Manage multiple SCM tenants with context-based authentication
+- Configure environment variables for CI/CD pipelines
+- Understand configuration precedence across sources
+- Debug and troubleshoot configuration issues
+
+## Prerequisites
+
+Before configuring the CLI, ensure you have:
+
+- The `scm` CLI installed (see [Getting Started](getting-started.md))
+- Service account credentials for at least one SCM tenant
+- Access to create files in `~/.scm-cli/` (for context storage)
+
+## Core Concepts
+
+### Configuration Precedence
+
+When multiple sources define the same setting, the CLI follows this precedence (highest to lowest):
+
+1. Environment variables (when set, they override everything)
+2. Current context configuration (`~/.scm-cli/contexts/<current>.yaml`)
+3. `settings.yaml` defaults
+
+!!! info
+    The CLI prioritizes contexts to support multi-tenant workflows. Environment
+    variables can still override specific settings when needed for automation or CI/CD.
+
+### Authentication Credentials
+
+The CLI requires three credentials for SCM API authentication:
+
+| Setting | Environment Variable | Description |
+| --- | --- | --- |
+| `client_id` | `SCM_CLIENT_ID` | Service account client ID |
+| `client_secret` | `SCM_CLIENT_SECRET` | Service account client secret |
+| `tsg_id` | `SCM_TSG_ID` | Tenant Service Group ID |
+
+### Authentication Fallback
+
+If no credentials are configured, the CLI automatically enters mock mode:
+
+```bash
+$ scm show object address --folder Shared
+⚠️  No API credentials found. Using mock mode.
+```
+
+## Examples
+
+### Multi-Tenant Setup with Contexts
+
+#### Creating Contexts
+
+```bash
+$ scm context create prod-us \
+    --client-id "us-prod@111111111.iam.panserviceaccount.com" \
+    --client-secret "us-prod-secret" \
+    --tsg-id "111111111" \
+    --log-level WARNING
+---> 100%
+✓ Context 'prod-us' created successfully
+```
+
+```bash
+$ scm context create prod-eu \
+    --client-id "eu-prod@222222222.iam.panserviceaccount.com" \
+    --client-secret "eu-prod-secret" \
+    --tsg-id "222222222" \
+    --log-level WARNING
+---> 100%
+✓ Context 'prod-eu' created successfully
+```
+
+```bash
+$ scm context create dev \
+    --client-id "dev@333333333.iam.panserviceaccount.com" \
+    --client-secret "dev-secret" \
+    --tsg-id "333333333" \
+    --log-level DEBUG
+---> 100%
+✓ Context 'dev' created successfully
+```
+
+#### Listing and Inspecting Contexts
+
+```bash
+$ scm context list
+                           SCM Authentication Contexts
+┏━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Context  ┃ Current ┃ Client ID                                          ┃
+┡━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ prod-us  │ ✓       │ us-prod@11...@111111111.iam.panserviceaccount.com │
+│ prod-eu  │         │ eu-prod@22...@222222222.iam.panserviceaccount.com │
+│ dev      │         │ dev@333333...@333333333.iam.panserviceaccount.com │
+└──────────┴─────────┴────────────────────────────────────────────────────┘
+```
+
+```bash
+$ scm context show prod-eu
+Context: prod-eu
+
+Configuration:
+  Client ID: eu-prod@222222222.iam.panserviceaccount.com
+  TSG ID: 222222222
+  Log Level: WARNING
+  Client Secret: ***** (configured)
+```
+
+#### Switching and Testing Contexts
+
+```bash
+$ scm context test prod-eu
+Testing authentication for context: prod-eu
+✓ Authentication successful!
+  Client ID: eu-prod@222222222.iam.panserviceaccount.com
+  TSG ID: 222222222
+✓ API connectivity verified (found 187 address objects in Shared folder)
+```
+
+```bash
+$ scm context use dev
+---> 100%
+✓ Switched to context 'dev'
+
+Client ID: dev@333333333.iam.panserviceaccount.com
+TSG ID: 333333333
+```
+
+#### Using Commands with Active Context
+
+```bash
+$ scm show object address --folder Development
+[INFO] Using authentication context: dev
+DEBUG:scm_cli.utils.sdk_client:Listing addresses in folder='Development'
+Addresses in folder 'Development':
+...
+```
+
+#### Deleting a Context
+
+```bash
+$ scm context delete old-tenant
+Are you sure you want to delete context 'old-tenant'? [y/N]: y
+✓ Context 'old-tenant' deleted
+```
+
+### Context Commands Reference
 
 ```bash
 # List all contexts
 scm context list
 
-# Create a new context (interactive)
-scm context create production
-
 # Create a new context (non-interactive)
 scm context create staging \
-  --client-id "staging@123456.iam.panserviceaccount.com" \
-  --client-secret "your-secret" \
-  --tsg-id "123456" \
-  --log-level INFO
+    --client-id "staging@123456.iam.panserviceaccount.com" \
+    --client-secret "your-secret" \
+    --tsg-id "123456" \
+    --log-level INFO
 
 # Switch to a different context
 scm context use production
@@ -47,6 +189,7 @@ scm context test
 Contexts are stored in `~/.scm-cli/contexts/` as individual YAML files:
 
 ```yaml
+---
 # ~/.scm-cli/contexts/production.yaml
 client_id: "prod-app@987654321.iam.panserviceaccount.com"
 client_secret: "production-secret-key"
@@ -56,104 +199,53 @@ log_level: "WARNING"
 
 The current active context is tracked in `~/.scm-cli/current-context`.
 
-### Example: Managing Multiple Tenants
-
-Let me demonstrate a real workflow with multiple tenants:
+### CI/CD Setup with Environment Variables
 
 ```bash
-# Create context for US production environment
-$ scm context create prod-us \
-  --client-id "us-prod@111111111.iam.panserviceaccount.com" \
-  --client-secret "us-prod-secret" \
-  --tsg-id "111111111" \
-  --log-level WARNING
-✓ Context 'prod-us' created successfully
+# Set credentials for automated workflows
+export SCM_CLIENT_ID="ci-app@555555555.iam.panserviceaccount.com"
+export SCM_CLIENT_SECRET="ci-secret-key"
+export SCM_TSG_ID="555555555"
+export SCM_LOG_LEVEL="WARNING"
 
-# Create context for EU production environment
-$ scm context create prod-eu \
-  --client-id "eu-prod@222222222.iam.panserviceaccount.com" \
-  --client-secret "eu-prod-secret" \
-  --tsg-id "222222222" \
-  --log-level WARNING
-✓ Context 'prod-eu' created successfully
+# Run commands in CI pipeline
+scm context test
+scm load object address --file addresses.yaml --folder Production
+```
 
-# Create development context with debug logging
-$ scm context create dev \
-  --client-id "dev@333333333.iam.panserviceaccount.com" \
-  --client-secret "dev-secret" \
-  --tsg-id "333333333" \
-  --log-level DEBUG
-✓ Context 'dev' created successfully
+!!! tip
+    The CLI supports both new and legacy environment variable patterns:
+    new (`SCM_CLIENT_ID`) and legacy (`SCM_SCM_CLIENT_ID`).
 
-# List all available contexts
-$ scm context list
-                           SCM Authentication Contexts                            
-┏━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-┃ Context  ┃ Current ┃ Client ID                                          ┃
-┡━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-│ prod-us  │ ✓       │ us-prod@11...@111111111.iam.panserviceaccount.com │
-│ prod-eu  │         │ eu-prod@22...@222222222.iam.panserviceaccount.com │
-│ dev      │         │ dev@333333...@333333333.iam.panserviceaccount.com │
-└──────────┴─────────┴────────────────────────────────────────────────────┘
+### Context with Environment Variable Override
 
-# Show details of a specific context
-$ scm context show prod-eu
-Context: prod-eu
+```bash
+# Use a context as base configuration
+scm context use staging
 
-Configuration:
-  Client ID: eu-prod@222222222.iam.panserviceaccount.com
-  TSG ID: 222222222
-  Log Level: WARNING
-  Client Secret: ***** (configured)
+# Override specific settings for a one-off command
+SCM_LOG_LEVEL=DEBUG scm show object address --folder Texas
+```
 
-# Test authentication without switching contexts
-$ scm context test prod-eu
-Testing authentication for context: prod-eu
-✓ Authentication successful!
-  Client ID: eu-prod@222222222.iam.panserviceaccount.com
-  TSG ID: 222222222
-✓ API connectivity verified (found 187 address objects in Shared folder)
+### Switching Between Environments
 
-# Current context remains unchanged
-$ scm context current
-Current context: prod-us
+```bash
+# Switch between environments
+scm context use production
+scm show object address --folder Texas
 
-Client ID: us-prod@111111111.iam.panserviceaccount.com
-TSG ID: 111111111
-
-# Switch to development context
-$ scm context use dev
-✓ Switched to context 'dev'
-
-Client ID: dev@333333333.iam.panserviceaccount.com
-TSG ID: 333333333
-
-# Now all commands use the dev context with DEBUG logging
-$ scm show object address --folder Development
-[INFO] Using authentication context: dev
-DEBUG:scm_cli.utils.sdk_client:Listing addresses in folder='Development'
-Addresses in folder 'Development':
-...
-
-# Switch to EU production for operations
-$ scm context use prod-eu
-✓ Switched to context 'prod-eu'
-
-# Delete a context that's no longer needed
-$ scm context delete old-tenant
-Are you sure you want to delete context 'old-tenant'? [y/N]: y
-✓ Context 'old-tenant' deleted
+scm context use development
+scm show object address --folder DevFolder
 ```
 
 ## Configuration Sources
 
-The CLI uses the following configuration sources in order of precedence:
+### Current Context
 
-### 1. Current Context (Highest Priority for File-based Config)
-
-When you use `scm context use <name>`, that context's configuration takes precedence:
+When you use `scm context use <name>`, that context's configuration takes effect:
 
 ```yaml
+---
 # ~/.scm-cli/contexts/production.yaml
 client_id: "prod-app@987654321.iam.panserviceaccount.com"
 client_secret: "production-secret-key"
@@ -161,9 +253,9 @@ tsg_id: "987654321"
 log_level: "WARNING"
 ```
 
-### 2. Environment Variables (Override Contexts for CI/CD)
+### Environment Variables
 
-Environment variables can override context settings, useful for CI/CD pipelines:
+Environment variables can override context settings:
 
 ```bash
 export SCM_CLIENT_ID="your-client-id@1234567890.iam.panserviceaccount.com"
@@ -172,57 +264,44 @@ export SCM_TSG_ID="1234567890"
 export SCM_LOG_LEVEL="DEBUG"
 ```
 
-!!! note "Backward Compatibility"
-    The CLI supports both new and legacy environment variable patterns:
-    
-    - New: `SCM_CLIENT_ID`, `SCM_CLIENT_SECRET`, `SCM_TSG_ID`
-    - Legacy: `SCM_SCM_CLIENT_ID`, `SCM_SCM_CLIENT_SECRET`, `SCM_SCM_TSG_ID`
-
-### 3. Default Settings (Lowest Priority)
+### Default Settings
 
 The `settings.yaml` file contains default application settings:
 
 ```yaml
 ---
 default:
-  # Logging configuration
   log_level: "INFO"
 
 production:
-  # Production-specific settings
   log_level: "WARNING"
 ```
 
-!!! warning "Legacy Configuration Files No Longer Supported"
-    The following configuration methods are **no longer supported** as of version 0.4.0:
-    
-    - `~/.scm-cli/config.yaml` - Migrate to contexts using `scm context create`
-    - `.secrets.yaml` - Use contexts for development credentials
-    
-    These files will be ignored if present. Please migrate to the context system for better multi-tenant support.
+!!! warning
+    The following legacy configuration methods are no longer supported as of version 0.4.0:
+    `~/.scm-cli/config.yaml` and `.secrets.yaml`. Migrate to contexts using
+    `scm context create`.
 
-## Configuration Precedence
+## Available Settings
 
-When multiple sources define the same setting, the CLI follows this precedence (highest to lowest):
+### Active Settings
 
-1. Current context configuration (`~/.scm-cli/contexts/<current>.yaml`)
-2. Environment variables (when set, they override context values)
-3. `settings.yaml` (defaults)
+| Setting | Default | Environment Variable | Description |
+| --- | --- | --- | --- |
+| `log_level` | `"INFO"` | `SCM_LOG_LEVEL` | Controls SDK client logging verbosity |
+| `client_id` | None | `SCM_CLIENT_ID` | SCM API authentication |
+| `client_secret` | None | `SCM_CLIENT_SECRET` | SCM API authentication |
+| `tsg_id` | None | `SCM_TSG_ID` | SCM API tenant identification |
 
-!!! info "Context-First Design"
-    The CLI prioritizes contexts to support multi-tenant workflows. Environment variables can still override specific settings when needed for automation or CI/CD.
+### Reserved Settings
 
-## Authentication Configuration
+| Setting | Default | Description |
+| --- | --- | --- |
+| `app_name` | `"pan-scm-cli"` | Application identifier (reserved for future use) |
+| `environment` | `"development"` | Environment mode (reserved for future use) |
+| `debug` | `true`/`false` | Debug mode flag (reserved for future use) |
 
-The CLI requires three credentials for SCM API authentication:
-
-| Setting         | Environment Variable | Description                   |
-|-----------------|----------------------|-------------------------------|
-| `client_id`     | `SCM_CLIENT_ID`      | Service account client ID     |
-| `client_secret` | `SCM_CLIENT_SECRET`  | Service account client secret |
-| `tsg_id`        | `SCM_TSG_ID`         | Tenant Service Group ID       |
-
-### Testing Authentication
+## Testing Authentication
 
 You can test authentication in several ways:
 
@@ -238,92 +317,11 @@ scm context test --mock
 scm context test staging --mock
 ```
 
-### Authentication Fallback
-
-If no credentials are configured, the CLI automatically enters **mock mode**:
-
-```bash
-$ scm list address
-⚠️  No API credentials found. Using mock mode.
-```
-
-## Available Settings
-
-### Used Settings
-
-| Setting         | Default  | Environment Variable | Usage                                 |
-|-----------------|----------|----------------------|---------------------------------------|
-| `log_level`     | `"INFO"` | `SCM_LOG_LEVEL`      | Controls SDK client logging verbosity |
-| `client_id`     | None     | `SCM_CLIENT_ID`      | SCM API authentication                |
-| `client_secret` | None     | `SCM_CLIENT_SECRET`  | SCM API authentication                |
-| `tsg_id`        | None     | `SCM_TSG_ID`         | SCM API tenant identification         |
-
-### Unused Settings
-
-The following settings are defined in `settings.yaml` but not currently used by the CLI:
-
-| Setting       | Default         | Purpose                                          |
-|---------------|-----------------|--------------------------------------------------|
-| `app_name`    | `"pan-scm-cli"` | Application identifier (reserved for future use) |
-| `environment` | `"development"` | Environment mode (reserved for future use)       |
-| `debug`       | `true`/`false`  | Debug mode flag (reserved for future use)        |
-
-## Configuration Examples
-
-### Example 1: Multi-Tenant Setup with Contexts
-
-```bash
-# Create contexts for different environments
-scm context create production \
-  --client-id "prod-app@987654321.iam.panserviceaccount.com" \
-  --client-secret "production-secret-key" \
-  --tsg-id "987654321" \
-  --log-level WARNING
-
-scm context create development \
-  --client-id "dev-app@123456789.iam.panserviceaccount.com" \
-  --client-secret "dev-secret-key" \
-  --tsg-id "123456789" \
-  --log-level DEBUG
-
-# Switch between environments
-scm context use production
-scm show object address --folder Texas
-
-scm context use development
-scm show object address --folder DevFolder
-```
-
-### Example 2: CI/CD Setup with Environment Variables
-
-```bash
-# Set credentials for automated workflows
-export SCM_CLIENT_ID="ci-app@555555555.iam.panserviceaccount.com"
-export SCM_CLIENT_SECRET="ci-secret-key"
-export SCM_TSG_ID="555555555"
-export SCM_LOG_LEVEL="WARNING"
-
-# Run commands in CI pipeline
-scm context test
-scm load object address --file addresses.yaml --folder Production
-```
-
-### Example 3: Context with Environment Variable Override
-
-```bash
-# Use a context as base configuration
-scm context use staging
-
-# Override specific settings for a one-off command
-SCM_LOG_LEVEL=DEBUG scm show object address --folder Texas
-```
-
 ## Debugging Configuration
 
 To see which configuration values are being loaded:
 
 ```python
-# In Python
 from scm_cli.utils.config import settings
 
 print(f"Client ID: {settings.get('client_id', 'NOT SET')}")
@@ -334,21 +332,19 @@ print(f"Log Level: {settings.get('log_level', 'NOT SET')}")
 
 ### Context-Aware Dynaconf Initialization
 
-The CLI initializes dynaconf with context awareness in `src/scm_cli/utils/context.py`:
+The CLI initializes Dynaconf with context awareness in `src/scm_cli/utils/context.py`:
 
 ```python
 def get_context_aware_settings() -> Dynaconf:
     """Get Dynaconf settings with context awareness."""
-    # Start with only the base settings file
     settings_files = ["settings.yaml"]
-    
-    # Add current context file FIRST so it has priority
+
     current_context = get_current_context()
     if current_context:
         context_file = os.path.join(CONTEXT_DIR, f"{current_context}.yaml")
         if os.path.exists(context_file):
             settings_files.insert(0, context_file)
-    
+
     return Dynaconf(
         envvar_prefix="SCM",
         settings_files=settings_files,
@@ -359,10 +355,11 @@ def get_context_aware_settings() -> Dynaconf:
 ```
 
 Key configuration options:
+
 - `envvar_prefix="SCM"`: Environment variables must start with `SCM_`
 - Context file loaded first for highest file-based priority
 - `load_dotenv=True`: Loads `.env` files if present
-- `environments=False`: Disables dynaconf's environment switching
+- `environments=False`: Disables Dynaconf's environment switching
 - `merge_enabled=True`: Merges configurations from all sources
 
 ### Configuration Access Pattern
@@ -372,36 +369,41 @@ The CLI uses a centralized `get_auth_config()` function to retrieve credentials:
 ```python
 def get_auth_config():
     """Get authentication configuration from various sources."""
-    # Check settings (includes env vars and config files)
     client_id = settings.get("client_id") or settings.get("scm_client_id")
     client_secret = settings.get("client_secret") or settings.get("scm_client_secret")
     tsg_id = settings.get("tsg_id") or settings.get("scm_tsg_id")
-    
+
     return client_id, client_secret, tsg_id
 ```
 
 ## Best Practices
 
-1. **Use contexts** for managing multiple SCM tenants - this is the recommended approach
-2. **Use environment variables** only for CI/CD pipelines and automation
-3. **Never commit secrets** to version control
-4. **Set appropriate log levels** for different environments (INFO for general use, WARNING for production)
-5. **Test with mock mode** before using real credentials
-6. **Use context test** to verify authentication without switching contexts
-7. **Name contexts meaningfully** (e.g., production, staging, dev-tenant1)
+1. **Use contexts for multi-tenant management**: Contexts are the recommended approach for managing multiple SCM tenants.
+2. **Reserve environment variables for CI/CD**: Use environment variables only for automation pipelines.
+3. **Never commit secrets to version control**: Keep credentials in contexts or environment variables, never in code.
+4. **Set appropriate log levels**: Use `INFO` for general use, `WARNING` for production, `DEBUG` for troubleshooting.
+5. **Test with mock mode first**: Use `--mock` to validate commands before using real credentials.
+6. **Use `context test` to verify authentication**: Test connectivity without switching contexts by specifying the context name.
+7. **Name contexts meaningfully**: Use descriptive names like `production`, `staging`, or `dev-tenant1`.
 
 ## Troubleshooting
 
 ### Configuration Not Loading
 
 1. Check environment variable names (must start with `SCM_`)
-2. Verify file paths and permissions
-3. Ensure YAML syntax is correct
+2. Verify file paths and permissions for context files
+3. Ensure YAML syntax is correct in context files
 4. Use `settings.reload()` to force reload configuration
 
 ### Credential Issues
 
-1. Verify all three credentials are set (client_id, client_secret, tsg_id)
+1. Verify all three credentials are set (`client_id`, `client_secret`, `tsg_id`)
 2. Check for typos in environment variable names
 3. Ensure credentials have proper SCM permissions
 4. Test with mock mode to isolate authentication issues
+
+## Next Steps
+
+- Review [Getting Started](getting-started.md) for initial setup instructions
+- Explore [Working with Configuration Objects](configuration-objects.md) to manage resources
+- Read [Advanced CLI Topics](advanced-topics.md) for scripting and automation

--- a/docs/guide/data-models.md
+++ b/docs/guide/data-models.md
@@ -1,49 +1,99 @@
-# Working with Data Formats
+# Data Formats
 
-The Strata Cloud Manager CLI handles data validation and formatting internally, but it's important to understand the expected data formats for various commands, especially when working with bulk operations.
+The `scm` CLI handles data validation and formatting internally, but understanding the expected data formats is important when working with command parameters and bulk operations. This guide covers parameter types, YAML file structures, and validation rules.
 
-## Command Parameters
+## Overview
 
-Each CLI command accepts specific parameters in appropriate formats:
+This guide explains the data formats used by the CLI:
 
-### String Parameters
+- Understand parameter types for command-line input (strings, booleans, lists)
+- Write correctly structured YAML files for bulk loading
+- Validate input data before submitting to the API
+- Troubleshoot common validation errors
+
+## Prerequisites
+
+Before working with data formats, ensure you have:
+
+- The `scm` CLI installed (see [Getting Started](getting-started.md))
+- Familiarity with YAML syntax for bulk operations
+- An understanding of the object types you plan to manage (see [Configuration Objects](configuration-objects.md))
+
+## Core Concepts
+
+### Parameter Types
+
+CLI commands accept parameters in several formats depending on the field type.
+
+#### String Parameters
 
 Most simple parameters are provided as strings:
 
 ```bash
-# Name, description, and folder are string parameters
-scm set object address --name "web-server" --description "Web server in DMZ" --folder "Shared"
+$ scm set object address \
+    --name "web-server" \
+    --description "Web server in DMZ" \
+    --folder "Shared"
+---> 100%
+Created address: web-server in folder Shared
 ```
 
-### Boolean Parameters
+#### Boolean Parameters
 
-Boolean parameters can be specified as `true` or `false`:
+Boolean parameters accept `true` or `false`:
 
 ```bash
-# Disabled is a boolean parameter
-scm set security rule --name "Allow-Web" --folder "Shared" --disabled false
+$ scm set security rule \
+    --name "Allow-Web" \
+    --folder "Shared" \
+    --disabled false
+---> 100%
+Created security rule: Allow-Web in folder Shared
 ```
 
-### List Parameters
+#### List Parameters
 
-Lists can be provided as comma-separated values:
+Lists are provided as comma-separated values:
 
 ```bash
-# Tags is a list parameter
-scm set object address --name "web-server" --folder "Shared" --tags "web,dmz,production"
+$ scm set object address \
+    --name "web-server" \
+    --folder "Shared" \
+    --tags "web,dmz,production"
+---> 100%
+Created address: web-server in folder Shared
 ```
 
-### Object Parameters
+#### Object Parameters
 
-Some complex parameters might require structured input. In these cases, you'll typically use the YAML file loading feature.
+Complex parameters with nested structure typically require YAML file loading rather than command-line input.
 
-## YAML File Formats
+### YAML Key Naming
 
-The CLI's `load` commands allow you to provide data in YAML files for bulk operations. Each resource type has an expected YAML structure.
+YAML files use `snake_case` keys matching the SDK model field names, while CLI flags use `kebab-case`:
 
-### Address Objects
+| YAML Key | CLI Flag |
+| --- | --- |
+| `ip_netmask` | `--ip-netmask` |
+| `source_zones` | `--source-zones` |
+| `enable_user_id` | `--enable-user-id` |
+
+### Data Validation
+
+The CLI performs validation at multiple stages:
+
+1. **Command-line parameters**: Validated immediately when you run the command
+2. **YAML files**: Validated when processed by `load` commands
+3. **Object relationships**: Referenced objects must exist (e.g., address group members)
+
+## Examples
+
+### YAML File Formats
+
+#### Address Objects
 
 ```yaml
+---
 addresses:
   - name: web-server-1
     description: "Web server 1"
@@ -60,9 +110,10 @@ addresses:
       - production
 ```
 
-### Address Groups
+#### Address Groups
 
 ```yaml
+---
 address_groups:
   - name: web-servers
     description: "Group of web servers"
@@ -82,9 +133,10 @@ address_groups:
       - endpoints
 ```
 
-### Security Zones
+#### Security Zones
 
 ```yaml
+---
 security_zones:
   - name: Trust
     description: "Internal trusted network zone"
@@ -102,9 +154,10 @@ security_zones:
       - external
 ```
 
-### Security Rules
+#### Security Rules
 
 ```yaml
+---
 security_rules:
   - name: Allow-Internal-Web
     description: "Allow internal users to access web servers"
@@ -127,9 +180,10 @@ security_rules:
       - internal-access
 ```
 
-### Bandwidth Allocation
+#### Bandwidth Allocation
 
 ```yaml
+---
 bandwidth_allocations:
   - name: Standard-Branch
     description: "Standard bandwidth allocation for branch offices"
@@ -142,30 +196,27 @@ bandwidth_allocations:
       - standard
 ```
 
-## Data Validation
-
-The CLI performs validation on input data:
-
-1. **Command-line parameters** are validated immediately when you run the command
-2. **YAML files** are validated when processed by `load` commands
-3. **Relationships** between objects are checked (e.g., referenced objects must exist)
-
-If validation fails, the CLI will display an error message explaining the issue.
-
 ### Common Validation Rules
 
-- **Names** must be unique within their scope
-- **IP addresses** must be in valid formats
-- **References** to other objects must point to existing objects
-- **Required fields** must be provided
-- **Exclusive fields** (where only one can be specified) are enforced
+| Rule | Description |
+| --- | --- |
+| Unique names | Names must be unique within their scope |
+| Valid IP formats | IP addresses must use valid CIDR or host notation |
+| Valid references | References to other objects must point to existing objects |
+| Required fields | All required fields must be provided |
+| Exclusive fields | Mutually exclusive fields cannot both be specified |
+
+!!! tip
+    Use the `--mock` flag to validate YAML files and command parameters
+    without making changes to your SCM environment.
 
 ## Best Practices
 
-1. **Use YAML files for complex or bulk operations** - This provides better structure and maintainability
-2. **Keep YAML files in version control** - Track changes to your configurations
-3. **Validate YAML** - Use the `--mock` flag to validate without making changes
-4. **Check command help** - Use `--help` with any command to see required parameters and formats
+1. **Use YAML files for complex or bulk operations**: Structured files are easier to maintain and review than long command lines.
+2. **Keep YAML files in version control**: Track configuration changes alongside your infrastructure code.
+3. **Validate before applying**: Use `--mock` to validate YAML files and commands before making changes.
+4. **Check command help for formats**: Use `--help` with any command to see required parameters and accepted formats.
+5. **Use `snake_case` in YAML**: Match the SDK model field names exactly when writing YAML files.
 
 ## Next Steps
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,8 +1,46 @@
-# Getting Started with the CLI
+# Getting Started
 
-This guide provides a quick introduction to using the Strata Cloud Manager CLI.
+The `scm` CLI provides a command-line interface for managing Palo Alto Networks Strata Cloud Manager configurations. This guide walks you through installation, authentication, and your first commands.
 
-## Installation
+## Overview
+
+This guide covers the essentials for getting up and running with the CLI:
+
+- Install the CLI using pip or Poetry
+- Configure authentication via contexts or environment variables
+- Run basic commands to create, list, update, and delete objects
+- Perform bulk operations with YAML files
+- Access built-in help for any command
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- Python 3.12 or later installed
+- Access to a Strata Cloud Manager tenant
+- Service account credentials (client ID, client secret, TSG ID)
+
+## Core Concepts
+
+### Command Structure
+
+The CLI follows a consistent pattern:
+
+```bash
+scm <action> <category> <object> [OPTIONS]
+```
+
+| Component | Description | Examples |
+| --- | --- | --- |
+| `action` | Operation to perform | `set`, `show`, `delete`, `load`, `backup` |
+| `category` | Resource category | `object`, `network`, `security`, `deployment` |
+| `object` | Resource type | `address`, `address-group`, `security-zone`, `rule` |
+
+### Smart Upsert
+
+The `set` command uses a smart upsert pattern: if an object with the given name exists, it updates only changed fields. If it does not exist, it creates it.
+
+### Installation
 
 Install the CLI using pip:
 
@@ -10,52 +48,60 @@ Install the CLI using pip:
 pip install pan-scm-cli
 ```
 
-Or with poetry:
+Or with Poetry:
 
 ```bash
 poetry add pan-scm-cli
 ```
 
-## Authentication
+### Authentication
 
 The SCM CLI uses contexts to manage authentication credentials for multiple SCM tenants.
 
-### Option 1: Context-based Authentication (Recommended)
+#### Context-Based Authentication (Recommended)
 
-Context management is the recommended approach for working with SCM, especially when managing multiple tenants or environments:
+Context management is the recommended approach, especially when managing multiple tenants or environments:
 
 ```bash
-# Create a context for production
 $ scm context create production \
-  --client-id "prod@123456789.iam.panserviceaccount.com" \
-  --client-secret "your-secret-key" \
-  --tsg-id "123456789"
+    --client-id "prod@123456789.iam.panserviceaccount.com" \
+    --client-secret "your-secret-key" \
+    --tsg-id "123456789"
+---> 100%
 ✓ Context 'production' created successfully
 ✓ Context 'production' set as current
+```
 
-# Create a context for development with debug logging
+```bash
 $ scm context create development \
-  --client-id "dev@987654321.iam.panserviceaccount.com" \
-  --client-secret "your-dev-secret" \
-  --tsg-id "987654321" \
-  --log-level DEBUG
+    --client-id "dev@987654321.iam.panserviceaccount.com" \
+    --client-secret "your-dev-secret" \
+    --tsg-id "987654321" \
+    --log-level DEBUG
+---> 100%
 ✓ Context 'development' created successfully
+```
 
-# View all contexts
+View all contexts:
+
+```bash
 $ scm context list
-                       SCM Authentication Contexts                        
+                       SCM Authentication Contexts
 ┏━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Context     ┃ Current ┃ Client ID                                       ┃
 ┡━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
 │ production  │ ✓       │ prod@12345...@123456789.iam.panserviceaccount.com │
 │ development │         │ dev@987654...@987654321.iam.panserviceaccount.com │
 └─────────────┴─────────┴────────────────────────────────────────────────────┘
+```
 
-# Switch between contexts
+Switch between contexts and test authentication:
+
+```bash
 $ scm context use development
+---> 100%
 ✓ Switched to context 'development'
 
-# Test authentication
 $ scm context test
 Testing authentication for context: development
 ✓ Authentication successful!
@@ -64,9 +110,11 @@ Testing authentication for context: development
 ✓ API connectivity verified (found 42 address objects in Shared folder)
 ```
 
-> **Note**: Contexts are stored in `~/.scm-cli/contexts/` with appropriate file permissions. Each context is isolated, making it safe to work with multiple tenants.
+!!! info
+    Contexts are stored in `~/.scm-cli/contexts/` with appropriate file permissions.
+    Each context is isolated, making it safe to work with multiple tenants.
 
-### Option 2: Environment Variables (For CI/CD)
+#### Environment Variables (For CI/CD)
 
 For automated workflows and CI/CD pipelines, use environment variables:
 
@@ -75,45 +123,64 @@ For automated workflows and CI/CD pipelines, use environment variables:
 export SCM_CLIENT_ID="your-client-id@123456789.iam.panserviceaccount.com"
 export SCM_CLIENT_SECRET="your-client-secret"
 export SCM_TSG_ID="123456789"
+```
 
+```bash
 # For Windows PowerShell
 $env:SCM_CLIENT_ID = "your-client-id@123456789.iam.panserviceaccount.com"
 $env:SCM_CLIENT_SECRET = "your-client-secret"
 $env:SCM_TSG_ID = "123456789"
 ```
 
-> **Important**: Environment variables take precedence over contexts when both are set.
+!!! warning
+    Environment variables take precedence over contexts when both are set.
+    Avoid committing credentials to version control.
 
-## Basic Usage Examples
-
-Here are some examples to help you get started with common CLI operations:
-
-### Listing Address Objects
-
-```bash
-# List all address objects in the Shared folder
-scm set object address --list --folder Shared
-```
+## Examples
 
 ### Creating an Address Object
 
 ```bash
-# Create a new address object
-scm set object address --folder Shared --name example-server --ip-netmask 192.168.1.100/32 --description "Example server"
+$ scm set object address \
+    --folder Shared \
+    --name web-server \
+    --ip-netmask 192.168.1.100/32 \
+    --description "Web server"
+---> 100%
+Created address: web-server in folder Shared
+```
+
+### Listing Address Objects
+
+```bash
+$ scm show object address --folder Shared
+---> 100%
+Addresses in folder 'Shared':
+------------------------------------------------------------
+Name: web-server
+  IP Netmask: 192.168.1.100/32
+  Description: Web server
+------------------------------------------------------------
 ```
 
 ### Updating an Address Object
 
 ```bash
-# Update an existing address object
-scm set object address --folder Shared --name example-server --ip-netmask 192.168.1.200/32 --description "Updated example server"
+$ scm set object address \
+    --folder Shared \
+    --name web-server \
+    --ip-netmask 192.168.1.200/32 \
+    --description "Updated web server"
+---> 100%
+Updated address: web-server in folder Shared
 ```
 
 ### Deleting an Address Object
 
 ```bash
-# Delete an address object
-scm delete object address --folder Shared --name example-server
+$ scm delete object address --folder Shared --name web-server
+---> 100%
+Deleted address: web-server from folder Shared
 ```
 
 ### Bulk Operations with YAML
@@ -121,6 +188,7 @@ scm delete object address --folder Shared --name example-server
 Create a file named `addresses.yaml`:
 
 ```yaml
+---
 addresses:
   - name: web-server-1
     description: "Web server 1"
@@ -140,24 +208,37 @@ addresses:
 Then load these address objects:
 
 ```bash
-scm load object address --folder Shared --file addresses.yaml
+$ scm load object address --folder Shared --file addresses.yaml
+---> 100%
+✓ Loaded address: web-server-1
+✓ Loaded address: web-server-2
+
+Successfully loaded 2 out of 2 addresses from 'addresses.yaml'
 ```
 
-## Getting Help
+### Getting Help
 
 The CLI includes comprehensive help information:
 
 ```bash
-# Show general help
 scm --help
+```
 
-# Show help for a specific command
+```bash
 scm set object address --help
 ```
+
+## Best Practices
+
+1. **Use contexts for authentication**: Contexts provide safe, isolated credential storage for multiple tenants.
+2. **Start with mock mode**: Use the `--mock` flag to test commands without making API changes.
+3. **Use YAML for bulk operations**: Loading objects from YAML files is more maintainable than individual commands.
+4. **Test authentication first**: Run `scm context test` to verify credentials before running commands.
+5. **Check help for options**: Every command supports `--help` to show available parameters.
 
 ## Next Steps
 
 - Explore [Working with Configuration Objects](configuration-objects.md) to learn about different object types
-- Read [Advanced CLI Topics](advanced-topics.md) for tips on automation and scripting
-- Review [CLI Operations](operations.md) for information on managing deployments
+- Read [Configuration Management](configuration.md) for details on multi-tenant setup and settings
+- Review [Advanced CLI Topics](advanced-topics.md) for tips on automation and scripting
 - See the [CLI Reference](../cli/index.md) for detailed command documentation

--- a/docs/guide/operations.md
+++ b/docs/guide/operations.md
@@ -1,174 +1,245 @@
-# CLI Operations Management
+# Operations Management
 
-The `scm` CLI provides capabilities beyond just managing individual configuration objects, allowing you to handle operations like deployment, status checking, and more.
+The `scm` CLI provides capabilities beyond managing individual configuration objects, including deployment, job monitoring, health checks, and audit logging. This guide covers operational workflows for managing your SCM environment.
 
-## Configuration Deployment
+## Overview
 
-After making changes to your configurations using the CLI, you need to deploy those changes to make them active in your environment.
+This guide covers operational tasks you can perform with the CLI:
 
-### Committing Changes
+- Deploy configuration changes by committing and pushing
+- Monitor asynchronous jobs and check their status
+- Inspect license status and system health
+- Review audit logs to track changes
+- Manage scheduled tasks for recurring operations
+- Troubleshoot issues with diagnostic tools
 
-To commit your configuration changes:
+## Prerequisites
+
+Before performing operational tasks, ensure you have:
+
+- The `scm` CLI installed and authenticated (see [Getting Started](getting-started.md))
+- Appropriate permissions for deployment and operational commands
+- Configuration changes staged and ready to deploy (for commit/push operations)
+
+## Core Concepts
+
+### Deployment Workflow
+
+After making changes to your configurations, you must commit and push those changes to make them active. The workflow is:
+
+1. Make configuration changes using `set`, `delete`, or `load` commands
+2. Commit the candidate configuration with a description
+3. Push the committed configuration to devices
+
+### Asynchronous Jobs
+
+Many SCM operations run asynchronously and generate jobs. Use the job monitoring commands to track their progress and verify completion.
+
+## Examples
+
+### Configuration Deployment
+
+#### Committing Changes
 
 ```bash
-# Commit changes with a description
-scm set deployment commit --description "Updated address objects and security rules"
+$ scm set deployment commit \
+    --description "Updated address objects and security rules"
+---> 100%
+Commit initiated successfully
 ```
 
-### Pushing Configurations
-
-To push configurations to devices:
+#### Pushing Configurations
 
 ```bash
-# Push configurations to all devices
-scm set deployment push
-
-# Push to specific device groups
-scm set deployment push --device-groups "Branch-Firewalls,DataCenter"
+$ scm set deployment push
+---> 100%
+Push initiated successfully
 ```
 
-## Job Monitoring
-
-Many operations in Strata Cloud Manager generate jobs that run asynchronously. The CLI provides commands to monitor these jobs.
-
-### Checking Job Status
-
-To check the status of a job:
-
 ```bash
-# Check job status by ID
-scm get operations job --job-id "12345"
+$ scm set deployment push \
+    --device-groups "Branch-Firewalls,DataCenter"
+---> 100%
+Push initiated to device groups: Branch-Firewalls, DataCenter
 ```
 
-### Listing Recent Jobs
+!!! tip
+    After committing or pushing, check job status to confirm the operation
+    completed successfully.
 
-To view recent jobs:
+### Job Monitoring
+
+#### Checking Job Status
 
 ```bash
-# List the 10 most recent jobs
-scm get operations jobs --limit 10
+$ scm get operations job --job-id "12345"
+---> 100%
+Job: 12345
+  Status: completed
+  Type: commit
+  Result: success
 ```
 
-## License Management
-
-Manage licenses for your deployment using the CLI.
-
-### Checking License Status
+#### Listing Recent Jobs
 
 ```bash
-# Check current license status
-scm get operations licenses
+$ scm get operations jobs --limit 10
+---> 100%
+Recent Jobs:
+------------------------------------------------------------
+Job ID: 12345
+  Type: commit
+  Status: completed
+------------------------------------------------------------
+Job ID: 12344
+  Type: push
+  Status: in_progress
+------------------------------------------------------------
 ```
 
-## Health Monitoring
+### License Management
 
-Monitor the health of your Strata Cloud Manager deployment.
-
-### System Status
-
-Check the current system status:
+#### Checking License Status
 
 ```bash
-# Get overall system status
-scm get operations status
+$ scm get operations licenses
+---> 100%
+License Status:
+  Type: Enterprise
+  Status: Active
+  Expiration: 2026-12-31
 ```
 
-### Connectivity Tests
+### Health Monitoring
 
-Test connectivity to various services:
+#### System Status
 
 ```bash
-# Test connectivity to firewalls
-scm get operations connectivity-test --target firewalls
+$ scm get operations status
+---> 100%
+System Status: Healthy
+  API: Connected
+  Services: All Running
 ```
 
-## User Management
-
-The CLI includes commands for managing users and roles.
-
-### Listing Users
+#### Connectivity Tests
 
 ```bash
-# List all users
-scm get operations users
+$ scm get operations connectivity-test --target firewalls
+---> 100%
+Connectivity Test Results:
+  Target: firewalls
+  Status: All reachable
 ```
 
-### User Roles
+### User Management
+
+#### Listing Users
 
 ```bash
-# List available roles
-scm get operations roles
+$ scm get operations users
+---> 100%
+Users:
+  admin (Administrator)
+  readonly (Read-Only)
 ```
 
-## Audit Logs
-
-Access audit logs to track changes made through the CLI and other interfaces.
-
-### Retrieving Audit Logs
+#### User Roles
 
 ```bash
-# Get recent audit logs
-scm get operations audit-logs --limit 20
+$ scm get operations roles
+---> 100%
+Available Roles:
+  Administrator
+  Read-Only
+  Security Admin
 ```
 
-### Filtering Audit Logs
+### Audit Logs
+
+#### Retrieving Audit Logs
 
 ```bash
-# Filter audit logs by user
-scm get operations audit-logs --filter-user "admin"
-
-# Filter audit logs by date range
-scm get operations audit-logs --start-date "2025-03-01" --end-date "2025-03-30"
+$ scm get operations audit-logs --limit 20
+---> 100%
+Audit Logs (last 20 entries):
+  2026-03-08 10:30:00 - admin - Created address: web-server
+  2026-03-08 10:25:00 - admin - Updated security rule: Allow-Web
 ```
 
-## Scheduled Tasks
-
-Manage scheduled tasks for recurring operations.
-
-### Listing Scheduled Tasks
+#### Filtering Audit Logs
 
 ```bash
-# List all scheduled tasks
-scm get operations scheduled-tasks
+$ scm get operations audit-logs --filter-user "admin"
+---> 100%
+Audit Logs (filtered by user: admin):
+  2026-03-08 10:30:00 - Created address: web-server
+  2026-03-08 10:25:00 - Updated security rule: Allow-Web
 ```
 
-### Creating Backup Tasks
-
 ```bash
-# Create a scheduled backup
-scm set operations scheduled-task --type backup --name "Daily-Backup" --schedule "0 0 * * *"
+$ scm get operations audit-logs \
+    --start-date "2026-03-01" \
+    --end-date "2026-03-08"
+---> 100%
+Audit Logs (2026-03-01 to 2026-03-08):
+  2026-03-08 10:30:00 - admin - Created address: web-server
+  2026-03-05 14:00:00 - admin - Committed configuration
 ```
 
-## Troubleshooting
+### Scheduled Tasks
 
-The CLI provides tools to help with troubleshooting.
-
-### Diagnostic Tools
+#### Listing Scheduled Tasks
 
 ```bash
-# Run diagnostic checks
-scm get operations diagnostics
+$ scm get operations scheduled-tasks
+---> 100%
+Scheduled Tasks:
+  Daily-Backup (0 0 * * *) - Active
 ```
 
-### Log Collection
+#### Creating Backup Tasks
 
 ```bash
-# Collect logs for support
-scm get operations collect-logs --output-dir "./support-logs"
+$ scm set operations scheduled-task \
+    --type backup \
+    --name "Daily-Backup" \
+    --schedule "0 0 * * *"
+---> 100%
+Created scheduled task: Daily-Backup
+```
+
+### Troubleshooting
+
+#### Diagnostic Tools
+
+```bash
+$ scm get operations diagnostics
+---> 100%
+Diagnostics:
+  API Connectivity: OK
+  Authentication: Valid
+  Configuration Sync: Up to date
+```
+
+#### Log Collection
+
+```bash
+$ scm get operations collect-logs --output-dir "./support-logs"
+---> 100%
+Logs collected to ./support-logs/
 ```
 
 ## Best Practices
 
-When using the CLI for operations management:
-
-1. **Use descriptive commit messages** to document your changes
-2. **Check job status** after initiating operations that generate jobs
-3. **Review audit logs** periodically to track changes
-4. **Set up scheduled tasks** for recurring operations
-5. **Use the `--verbose` flag** when troubleshooting operations
+1. **Use descriptive commit messages**: Document your changes clearly for audit trail purposes.
+2. **Check job status after operations**: Verify that commits and pushes complete successfully before proceeding.
+3. **Review audit logs periodically**: Track changes made through the CLI and other interfaces to maintain accountability.
+4. **Set up scheduled tasks for backups**: Automate recurring operations to ensure consistent configuration backups.
+5. **Use verbose mode for troubleshooting**: Add `--verbose` to commands when diagnosing operational issues.
 
 ## Next Steps
 
-- Explore the [Command Reference](../cli/index.md) for detailed information on all available commands
+- Explore the [CLI Reference](../cli/index.md) for detailed information on all available commands
 - Learn more about [Advanced Topics](advanced-topics.md) for scripting and automation
 - Review [Configuration Objects](configuration-objects.md) to understand the types of resources you can manage


### PR DESCRIPTION
## Summary

- Rewrote all 6 guide pages (`getting-started.md`, `configuration.md`, `configuration-objects.md`, `advanced-topics.md`, `data-models.md`, `operations.md`) to conform to the docs-style skill
- Applied Guide page conventions: Overview/Prerequisites → Core Concepts → Examples → Best Practices → Next Steps
- Fixed formatting: proper code block language tags, `$` prefix on examples only, `✓` Unicode instead of HTML spans, 4-space indented admonitions, backslash continuation with 4-space indent, consistent table formatting, correct heading hierarchy

Closes #122

## Test plan

- [ ] Run `make docs-build` to verify no broken links or build errors
- [ ] Run `make docs-serve` and visually inspect each guide page
- [ ] Verify all cross-references between guide pages resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)