### PR TITLE
docs: standardize Network CLI reference pages

### DIFF
--- a/docs/cli/network/aggregate-interface.md
+++ b/docs/cli/network/aggregate-interface.md
@@ -1,8 +1,22 @@
 # Aggregate Interface
 
-Aggregate interfaces combine multiple physical interfaces into a single logical interface for link aggregation (LACP).
+Aggregate interfaces combine multiple physical interfaces into a single logical interface for link aggregation (LACP). The `scm` CLI provides commands to create, update, delete, and load aggregate interfaces.
+
+## Overview
+
+The `aggregate-interface` commands allow you to:
+
+- Create aggregate interfaces with layer2 or layer3 configurations
+- Update existing aggregate interface settings
+- Delete aggregate interfaces that are no longer needed
+- Bulk import aggregate interfaces from YAML files
+- Export aggregate interfaces for backup or migration
 
 ## Set Aggregate Interface
+
+Create or update an aggregate interface.
+
+### Syntax
 
 ```bash
 scm set network aggregate-interface NAME [OPTIONS]
@@ -13,29 +27,237 @@ scm set network aggregate-interface NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Interface name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--comment TEXT` | Interface description | No |
 | `--layer2-json TEXT` | Layer2 config as JSON | No |
 | `--layer3-json TEXT` | Layer3 config as JSON | No |
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Create a Layer3 Aggregate Interface
 
 ```bash
 $ scm set network aggregate-interface ae1 \
     --folder Texas \
     --layer3-json '{"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]}' \
     --comment "Aggregated uplink"
+---> 100%
+Created aggregate interface: ae1 in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create a Layer2 Aggregate Interface
 
 ```bash
-scm show network aggregate-interface --folder Texas
-scm delete network aggregate-interface ae1 --folder Texas
-scm load network aggregate-interface --file interfaces.yaml --folder Texas
-scm backup network aggregate-interface --folder Texas
+$ scm set network aggregate-interface ae2 \
+    --folder Texas \
+    --layer2-json '{"lldp": {"enable": true}}' \
+    --comment "Layer2 trunk"
+---> 100%
+Created aggregate interface: ae2 in folder Texas
 ```
+
+## Delete Aggregate Interface
+
+Delete an aggregate interface from SCM.
+
+### Syntax
+
+```bash
+scm delete network aggregate-interface NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Interface name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network aggregate-interface ae1 --folder Texas
+---> 100%
+Deleted aggregate interface: ae1 from folder Texas
+```
+
+## Load Aggregate Interface
+
+Load multiple aggregate interfaces from a YAML file.
+
+### Syntax
+
+```bash
+scm load network aggregate-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+aggregate_interfaces:
+  - name: ae1
+    folder: Texas
+    comment: "Aggregated uplink"
+    layer3:
+      mtu: 1500
+      ip:
+        - name: "10.0.0.1/24"
+
+  - name: ae2
+    folder: Texas
+    comment: "Layer2 trunk"
+    layer2:
+      lldp:
+        enable: true
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network aggregate-interface --file interfaces.yml
+---> 100%
+✓ Loaded aggregate interface: ae1
+✓ Loaded aggregate interface: ae2
+
+Successfully loaded 2 out of 2 aggregate interfaces from 'interfaces.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network aggregate-interface --file interfaces.yml --folder Austin
+---> 100%
+✓ Loaded aggregate interface: ae1
+✓ Loaded aggregate interface: ae2
+
+Successfully loaded 2 out of 2 aggregate interfaces from 'interfaces.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all aggregate interfaces
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Aggregate Interface
+
+Display aggregate interface objects.
+
+### Syntax
+
+```bash
+scm show network aggregate-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific interface | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Aggregate Interface
+
+```bash
+$ scm show network aggregate-interface --folder Texas --name ae1
+---> 100%
+Aggregate Interface: ae1
+  Location: Folder 'Texas'
+  Comment: Aggregated uplink
+  Layer3 MTU: 1500
+```
+
+#### List All Aggregate Interfaces (Default Behavior)
+
+```bash
+$ scm show network aggregate-interface --folder Texas
+---> 100%
+Aggregate interfaces in folder 'Texas':
+------------------------------------------------------------
+Name: ae1
+  Comment: Aggregated uplink
+  Mode: Layer3
+------------------------------------------------------------
+Name: ae2
+  Comment: Layer2 trunk
+  Mode: Layer2
+------------------------------------------------------------
+```
+
+## Backup Aggregate Interfaces
+
+Backup all aggregate interface objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network aggregate-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network aggregate-interface --folder Texas
+---> 100%
+Successfully backed up 4 aggregate interfaces to aggregate_interface_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network aggregate-interface --folder Texas --file texas-ae-interfaces.yaml
+---> 100%
+Successfully backed up 4 aggregate interfaces to texas-ae-interfaces.yaml
+```
+
+## Best Practices
+
+1. **Use Descriptive Comments**: Add comments to each aggregate interface describing its purpose and member links.
+2. **Plan IP Addressing**: Ensure layer3 aggregate interfaces have proper IP addressing before assigning to security zones.
+3. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+4. **Backup Before Changes**: Always backup existing aggregate interface configurations before making bulk modifications.
+5. **Use Consistent Naming**: Follow a naming convention like `ae1`, `ae2` for aggregate interface names.

--- a/docs/cli/network/bgp-address-family-profile.md
+++ b/docs/cli/network/bgp-address-family-profile.md
@@ -1,8 +1,22 @@
 # BGP Address Family Profile
 
-BGP address family profiles define address family configurations (IPv4 unicast/multicast) for BGP routing.
+BGP address family profiles define address family configurations (IPv4 unicast/multicast) for BGP routing. The `scm` CLI provides commands to create, update, delete, and load BGP address family profiles.
+
+## Overview
+
+The `bgp-address-family-profile` commands allow you to:
+
+- Create BGP address family profiles with IPv4 unicast or multicast settings
+- Update existing address family profile configurations
+- Delete address family profiles that are no longer needed
+- Bulk import address family profiles from YAML files
+- Export address family profiles for backup or migration
 
 ## Set BGP Address Family Profile
+
+Create or update a BGP address family profile.
+
+### Syntax
 
 ```bash
 scm set network bgp-address-family-profile NAME [OPTIONS]
@@ -13,26 +27,227 @@ scm set network bgp-address-family-profile NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Profile name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--ipv4-json TEXT` | IPv4 address family config as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create an IPv4 Unicast Profile
+
+```bash
+$ scm set network bgp-address-family-profile my-af-profile \
+    --folder Texas \
+    --ipv4-json '{"unicast": {"enable": true}}'
+---> 100%
+Created BGP address family profile: my-af-profile in folder Texas
+```
+
+#### Create an IPv4 Multicast Profile
+
+```bash
+$ scm set network bgp-address-family-profile multicast-af \
+    --folder Texas \
+    --ipv4-json '{"multicast": {"enable": true}}'
+---> 100%
+Created BGP address family profile: multicast-af in folder Texas
+```
+
+## Delete BGP Address Family Profile
+
+Delete a BGP address family profile from SCM.
+
+### Syntax
+
+```bash
+scm delete network bgp-address-family-profile NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Profile name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network bgp-address-family-profile my-af-profile \
-    --folder Texas \
-    --ipv4-json '{"unicast": {"enable": true}}'
+$ scm delete network bgp-address-family-profile my-af-profile --folder Texas
+---> 100%
+Deleted BGP address family profile: my-af-profile from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load BGP Address Family Profile
+
+Load multiple BGP address family profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network bgp-address-family-profile --folder Texas
-scm delete network bgp-address-family-profile my-af-profile --folder Texas
-scm load network bgp-address-family-profile --file af-profiles.yaml --folder Texas
-scm backup network bgp-address-family-profile --folder Texas
+scm load network bgp-address-family-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+bgp_address_family_profiles:
+  - name: unicast-af
+    folder: Texas
+    ipv4:
+      unicast:
+        enable: true
+
+  - name: multicast-af
+    folder: Texas
+    ipv4:
+      multicast:
+        enable: true
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network bgp-address-family-profile --file af-profiles.yml
+---> 100%
+✓ Loaded BGP address family profile: unicast-af
+✓ Loaded BGP address family profile: multicast-af
+
+Successfully loaded 2 out of 2 BGP address family profiles from 'af-profiles.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network bgp-address-family-profile --file af-profiles.yml --folder Austin
+---> 100%
+✓ Loaded BGP address family profile: unicast-af
+✓ Loaded BGP address family profile: multicast-af
+
+Successfully loaded 2 out of 2 BGP address family profiles from 'af-profiles.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all BGP address family profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show BGP Address Family Profile
+
+Display BGP address family profile objects.
+
+### Syntax
+
+```bash
+scm show network bgp-address-family-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific profile | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific BGP Address Family Profile
+
+```bash
+$ scm show network bgp-address-family-profile --folder Texas --name my-af-profile
+---> 100%
+BGP Address Family Profile: my-af-profile
+  Location: Folder 'Texas'
+  IPv4 Unicast: enabled
+```
+
+#### List All BGP Address Family Profiles (Default Behavior)
+
+```bash
+$ scm show network bgp-address-family-profile --folder Texas
+---> 100%
+BGP address family profiles in folder 'Texas':
+------------------------------------------------------------
+Name: unicast-af
+  IPv4 Unicast: enabled
+------------------------------------------------------------
+Name: multicast-af
+  IPv4 Multicast: enabled
+------------------------------------------------------------
+```
+
+## Backup BGP Address Family Profiles
+
+Backup all BGP address family profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network bgp-address-family-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network bgp-address-family-profile --folder Texas
+---> 100%
+Successfully backed up 3 BGP address family profiles to bgp_address_family_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network bgp-address-family-profile --folder Texas --file texas-af-profiles.yaml
+---> 100%
+Successfully backed up 3 BGP address family profiles to texas-af-profiles.yaml
+```
+
+## Best Practices
+
+1. **Enable Only Required Families**: Only enable the address families (unicast/multicast) that your network requires.
+2. **Use Consistent Naming**: Name profiles descriptively to indicate which address families are configured.
+3. **Backup Before Changes**: Always backup existing profiles before making bulk modifications.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Document Profile Purpose**: Keep track of which BGP peers reference each address family profile.

--- a/docs/cli/network/bgp-auth-profile.md
+++ b/docs/cli/network/bgp-auth-profile.md
@@ -1,8 +1,22 @@
 # BGP Auth Profile
 
-BGP auth profiles define authentication keys for BGP peer sessions.
+BGP auth profiles define authentication keys for BGP peer sessions. The `scm` CLI provides commands to create, update, delete, and load BGP auth profiles.
+
+## Overview
+
+The `bgp-auth-profile` commands allow you to:
+
+- Create BGP auth profiles with authentication secrets
+- Update existing BGP auth profile configurations
+- Delete BGP auth profiles that are no longer needed
+- Bulk import BGP auth profiles from YAML files
+- Export BGP auth profiles for backup or migration
 
 ## Set BGP Auth Profile
+
+Create or update a BGP auth profile.
+
+### Syntax
 
 ```bash
 scm set network bgp-auth-profile NAME [OPTIONS]
@@ -13,26 +27,223 @@ scm set network bgp-auth-profile NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Profile name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--secret TEXT` | BGP authentication key | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create a BGP Auth Profile
+
+```bash
+$ scm set network bgp-auth-profile my-bgp-auth \
+    --folder Texas \
+    --secret "bgp-secret-key"
+---> 100%
+Created BGP auth profile: my-bgp-auth in folder Texas
+```
+
+#### Update an Existing Auth Profile
+
+```bash
+$ scm set network bgp-auth-profile my-bgp-auth \
+    --folder Texas \
+    --secret "new-bgp-secret"
+---> 100%
+Updated BGP auth profile: my-bgp-auth in folder Texas
+```
+
+## Delete BGP Auth Profile
+
+Delete a BGP auth profile from SCM.
+
+### Syntax
+
+```bash
+scm delete network bgp-auth-profile NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Profile name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network bgp-auth-profile my-bgp-auth \
-    --folder Texas \
-    --secret "bgp-secret-key"
+$ scm delete network bgp-auth-profile my-bgp-auth --folder Texas
+---> 100%
+Deleted BGP auth profile: my-bgp-auth from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load BGP Auth Profile
+
+Load multiple BGP auth profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network bgp-auth-profile --folder Texas
-scm delete network bgp-auth-profile my-bgp-auth --folder Texas
-scm load network bgp-auth-profile --file bgp-auth.yaml --folder Texas
-scm backup network bgp-auth-profile --folder Texas
+scm load network bgp-auth-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+bgp_auth_profiles:
+  - name: peer-auth-1
+    folder: Texas
+    secret: "bgp-key-1"
+
+  - name: peer-auth-2
+    folder: Texas
+    secret: "bgp-key-2"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network bgp-auth-profile --file bgp-auth.yml
+---> 100%
+✓ Loaded BGP auth profile: peer-auth-1
+✓ Loaded BGP auth profile: peer-auth-2
+
+Successfully loaded 2 out of 2 BGP auth profiles from 'bgp-auth.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network bgp-auth-profile --file bgp-auth.yml --folder Austin
+---> 100%
+✓ Loaded BGP auth profile: peer-auth-1
+✓ Loaded BGP auth profile: peer-auth-2
+
+Successfully loaded 2 out of 2 BGP auth profiles from 'bgp-auth.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all BGP auth profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show BGP Auth Profile
+
+Display BGP auth profile objects.
+
+### Syntax
+
+```bash
+scm show network bgp-auth-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific profile | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific BGP Auth Profile
+
+```bash
+$ scm show network bgp-auth-profile --folder Texas --name my-bgp-auth
+---> 100%
+BGP Auth Profile: my-bgp-auth
+  Location: Folder 'Texas'
+  Secret: ********
+```
+
+#### List All BGP Auth Profiles (Default Behavior)
+
+```bash
+$ scm show network bgp-auth-profile --folder Texas
+---> 100%
+BGP auth profiles in folder 'Texas':
+------------------------------------------------------------
+Name: peer-auth-1
+  Secret: ********
+------------------------------------------------------------
+Name: peer-auth-2
+  Secret: ********
+------------------------------------------------------------
+```
+
+## Backup BGP Auth Profiles
+
+Backup all BGP auth profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network bgp-auth-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network bgp-auth-profile --folder Texas
+---> 100%
+Successfully backed up 3 BGP auth profiles to bgp_auth_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network bgp-auth-profile --folder Texas --file texas-bgp-auth.yaml
+---> 100%
+Successfully backed up 3 BGP auth profiles to texas-bgp-auth.yaml
+```
+
+## Best Practices
+
+1. **Use Strong Secrets**: Choose complex authentication keys that are difficult to guess or brute-force.
+2. **Rotate Keys Regularly**: Update BGP authentication secrets periodically as part of security hygiene.
+3. **Coordinate Key Changes**: Ensure both BGP peers are updated simultaneously when rotating authentication keys.
+4. **Backup Before Changes**: Always backup existing auth profiles before making bulk modifications.
+5. **Use Consistent Naming**: Name profiles to clearly identify which BGP peer relationship they authenticate.

--- a/docs/cli/network/bgp-filtering-profile.md
+++ b/docs/cli/network/bgp-filtering-profile.md
@@ -1,8 +1,22 @@
 # BGP Filtering Profile
 
-BGP filtering profiles define route filtering rules applied to BGP peer sessions for controlling route advertisements.
+BGP filtering profiles define route filtering rules applied to BGP peer sessions for controlling route advertisements. The `scm` CLI provides commands to create, update, delete, and load BGP filtering profiles.
+
+## Overview
+
+The `bgp-filtering-profile` commands allow you to:
+
+- Create BGP filtering profiles with IPv4 filtering configurations
+- Update existing filtering profile settings
+- Delete filtering profiles that are no longer needed
+- Bulk import filtering profiles from YAML files
+- Export filtering profiles for backup or migration
 
 ## Set BGP Filtering Profile
+
+Create or update a BGP filtering profile.
+
+### Syntax
 
 ```bash
 scm set network bgp-filtering-profile NAME [OPTIONS]
@@ -13,26 +27,227 @@ scm set network bgp-filtering-profile NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Profile name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--ipv4-json TEXT` | IPv4 filtering config as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create a Filtering Profile with Inbound Filter
+
+```bash
+$ scm set network bgp-filtering-profile my-filter \
+    --folder Texas \
+    --ipv4-json '{"unicast": {"filter_in": "my-prefix-list"}}'
+---> 100%
+Created BGP filtering profile: my-filter in folder Texas
+```
+
+#### Create a Filtering Profile with Outbound Filter
+
+```bash
+$ scm set network bgp-filtering-profile outbound-filter \
+    --folder Texas \
+    --ipv4-json '{"unicast": {"filter_out": "export-prefix-list"}}'
+---> 100%
+Created BGP filtering profile: outbound-filter in folder Texas
+```
+
+## Delete BGP Filtering Profile
+
+Delete a BGP filtering profile from SCM.
+
+### Syntax
+
+```bash
+scm delete network bgp-filtering-profile NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Profile name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network bgp-filtering-profile my-filter \
-    --folder Texas \
-    --ipv4-json '{"unicast": {"filter_in": "my-prefix-list"}}'
+$ scm delete network bgp-filtering-profile my-filter --folder Texas
+---> 100%
+Deleted BGP filtering profile: my-filter from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load BGP Filtering Profile
+
+Load multiple BGP filtering profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network bgp-filtering-profile --folder Texas
-scm delete network bgp-filtering-profile my-filter --folder Texas
-scm load network bgp-filtering-profile --file bgp-filters.yaml --folder Texas
-scm backup network bgp-filtering-profile --folder Texas
+scm load network bgp-filtering-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+bgp_filtering_profiles:
+  - name: inbound-filter
+    folder: Texas
+    ipv4:
+      unicast:
+        filter_in: "my-prefix-list"
+
+  - name: outbound-filter
+    folder: Texas
+    ipv4:
+      unicast:
+        filter_out: "export-prefix-list"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network bgp-filtering-profile --file bgp-filters.yml
+---> 100%
+✓ Loaded BGP filtering profile: inbound-filter
+✓ Loaded BGP filtering profile: outbound-filter
+
+Successfully loaded 2 out of 2 BGP filtering profiles from 'bgp-filters.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network bgp-filtering-profile --file bgp-filters.yml --folder Austin
+---> 100%
+✓ Loaded BGP filtering profile: inbound-filter
+✓ Loaded BGP filtering profile: outbound-filter
+
+Successfully loaded 2 out of 2 BGP filtering profiles from 'bgp-filters.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all BGP filtering profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show BGP Filtering Profile
+
+Display BGP filtering profile objects.
+
+### Syntax
+
+```bash
+scm show network bgp-filtering-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific profile | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific BGP Filtering Profile
+
+```bash
+$ scm show network bgp-filtering-profile --folder Texas --name my-filter
+---> 100%
+BGP Filtering Profile: my-filter
+  Location: Folder 'Texas'
+  IPv4 Unicast Filter In: my-prefix-list
+```
+
+#### List All BGP Filtering Profiles (Default Behavior)
+
+```bash
+$ scm show network bgp-filtering-profile --folder Texas
+---> 100%
+BGP filtering profiles in folder 'Texas':
+------------------------------------------------------------
+Name: inbound-filter
+  IPv4 Unicast Filter In: my-prefix-list
+------------------------------------------------------------
+Name: outbound-filter
+  IPv4 Unicast Filter Out: export-prefix-list
+------------------------------------------------------------
+```
+
+## Backup BGP Filtering Profiles
+
+Backup all BGP filtering profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network bgp-filtering-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network bgp-filtering-profile --folder Texas
+---> 100%
+Successfully backed up 5 BGP filtering profiles to bgp_filtering_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network bgp-filtering-profile --folder Texas --file texas-bgp-filters.yaml
+---> 100%
+Successfully backed up 5 BGP filtering profiles to texas-bgp-filters.yaml
+```
+
+## Best Practices
+
+1. **Filter Inbound and Outbound**: Apply both inbound and outbound filters to control route exchange precisely.
+2. **Reference Prefix Lists**: Use prefix lists for filtering rather than inline definitions for better reusability.
+3. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+4. **Backup Before Changes**: Always backup existing profiles before making bulk modifications.
+5. **Use Descriptive Names**: Name profiles to indicate their filtering direction and purpose.

--- a/docs/cli/network/bgp-redistribution-profile.md
+++ b/docs/cli/network/bgp-redistribution-profile.md
@@ -1,8 +1,22 @@
 # BGP Redistribution Profile
 
-BGP redistribution profiles control how routes from other protocols (OSPF, static, connected) are redistributed into BGP.
+BGP redistribution profiles control how routes from other protocols (OSPF, static, connected) are redistributed into BGP. The `scm` CLI provides commands to create, update, delete, and load BGP redistribution profiles.
+
+## Overview
+
+The `bgp-redistribution-profile` commands allow you to:
+
+- Create BGP redistribution profiles with protocol redistribution settings
+- Update existing redistribution profile configurations
+- Delete redistribution profiles that are no longer needed
+- Bulk import redistribution profiles from YAML files
+- Export redistribution profiles for backup or migration
 
 ## Set BGP Redistribution Profile
+
+Create or update a BGP redistribution profile.
+
+### Syntax
 
 ```bash
 scm set network bgp-redistribution-profile NAME [OPTIONS]
@@ -13,26 +27,229 @@ scm set network bgp-redistribution-profile NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Profile name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--ipv4-json TEXT` | IPv4 redistribution config as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Redistribute Connected Routes
+
+```bash
+$ scm set network bgp-redistribution-profile my-redist \
+    --folder Texas \
+    --ipv4-json '{"unicast": {"connected": {"enable": true}}}'
+---> 100%
+Created BGP redistribution profile: my-redist in folder Texas
+```
+
+#### Redistribute Static Routes
+
+```bash
+$ scm set network bgp-redistribution-profile static-redist \
+    --folder Texas \
+    --ipv4-json '{"unicast": {"static": {"enable": true}}}'
+---> 100%
+Created BGP redistribution profile: static-redist in folder Texas
+```
+
+## Delete BGP Redistribution Profile
+
+Delete a BGP redistribution profile from SCM.
+
+### Syntax
+
+```bash
+scm delete network bgp-redistribution-profile NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Profile name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network bgp-redistribution-profile my-redist \
-    --folder Texas \
-    --ipv4-json '{"unicast": {"connected": {"enable": true}}}'
+$ scm delete network bgp-redistribution-profile my-redist --folder Texas
+---> 100%
+Deleted BGP redistribution profile: my-redist from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load BGP Redistribution Profile
+
+Load multiple BGP redistribution profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network bgp-redistribution-profile --folder Texas
-scm delete network bgp-redistribution-profile my-redist --folder Texas
-scm load network bgp-redistribution-profile --file bgp-redist.yaml --folder Texas
-scm backup network bgp-redistribution-profile --folder Texas
+scm load network bgp-redistribution-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+bgp_redistribution_profiles:
+  - name: connected-redist
+    folder: Texas
+    ipv4:
+      unicast:
+        connected:
+          enable: true
+
+  - name: static-redist
+    folder: Texas
+    ipv4:
+      unicast:
+        static:
+          enable: true
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network bgp-redistribution-profile --file bgp-redist.yml
+---> 100%
+✓ Loaded BGP redistribution profile: connected-redist
+✓ Loaded BGP redistribution profile: static-redist
+
+Successfully loaded 2 out of 2 BGP redistribution profiles from 'bgp-redist.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network bgp-redistribution-profile --file bgp-redist.yml --folder Austin
+---> 100%
+✓ Loaded BGP redistribution profile: connected-redist
+✓ Loaded BGP redistribution profile: static-redist
+
+Successfully loaded 2 out of 2 BGP redistribution profiles from 'bgp-redist.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all BGP redistribution profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show BGP Redistribution Profile
+
+Display BGP redistribution profile objects.
+
+### Syntax
+
+```bash
+scm show network bgp-redistribution-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific profile | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific BGP Redistribution Profile
+
+```bash
+$ scm show network bgp-redistribution-profile --folder Texas --name my-redist
+---> 100%
+BGP Redistribution Profile: my-redist
+  Location: Folder 'Texas'
+  IPv4 Unicast Connected: enabled
+```
+
+#### List All BGP Redistribution Profiles (Default Behavior)
+
+```bash
+$ scm show network bgp-redistribution-profile --folder Texas
+---> 100%
+BGP redistribution profiles in folder 'Texas':
+------------------------------------------------------------
+Name: connected-redist
+  IPv4 Unicast Connected: enabled
+------------------------------------------------------------
+Name: static-redist
+  IPv4 Unicast Static: enabled
+------------------------------------------------------------
+```
+
+## Backup BGP Redistribution Profiles
+
+Backup all BGP redistribution profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network bgp-redistribution-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network bgp-redistribution-profile --folder Texas
+---> 100%
+Successfully backed up 4 BGP redistribution profiles to bgp_redistribution_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network bgp-redistribution-profile --folder Texas --file texas-bgp-redist.yaml
+---> 100%
+Successfully backed up 4 BGP redistribution profiles to texas-bgp-redist.yaml
+```
+
+## Best Practices
+
+1. **Redistribute Selectively**: Only redistribute route types that are necessary to avoid routing table bloat.
+2. **Use Route Maps**: Combine redistribution profiles with route maps for granular control over redistributed routes.
+3. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+4. **Backup Before Changes**: Always backup existing profiles before making bulk modifications.
+5. **Document Redistribution Policies**: Clearly document which protocols are redistributed and why.

--- a/docs/cli/network/bgp-route-map-redistribution.md
+++ b/docs/cli/network/bgp-route-map-redistribution.md
@@ -1,8 +1,22 @@
 # BGP Route Map Redistribution
 
-BGP route map redistributions define how routes from different source protocols are redistributed using route maps.
+BGP route map redistributions define how routes from different source protocols are redistributed using route maps. The `scm` CLI provides commands to create, update, delete, and load BGP route map redistributions.
+
+## Overview
+
+The `bgp-route-map-redistribution` commands allow you to:
+
+- Create BGP route map redistributions for various source protocols
+- Update existing route map redistribution configurations
+- Delete route map redistributions that are no longer needed
+- Bulk import route map redistributions from YAML files
+- Export route map redistributions for backup or migration
 
 ## Set BGP Route Map Redistribution
+
+Create or update a BGP route map redistribution.
+
+### Syntax
 
 ```bash
 scm set network bgp-route-map-redistribution NAME [OPTIONS]
@@ -13,28 +27,230 @@ scm set network bgp-route-map-redistribution NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--bgp-json TEXT` | BGP source protocol config as JSON | No |
 | `--ospf-json TEXT` | OSPF source protocol config as JSON | No |
 | `--connected-static-json TEXT` | Connected/Static source config as JSON | No |
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Redistribute Connected Routes via Route Map
 
 ```bash
 $ scm set network bgp-route-map-redistribution my-redist-map \
     --folder Texas \
     --connected-static-json '{"connected": {"route_map": "my-route-map"}}'
+---> 100%
+Created BGP route map redistribution: my-redist-map in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Redistribute OSPF Routes via Route Map
 
 ```bash
-scm show network bgp-route-map-redistribution --folder Texas
-scm delete network bgp-route-map-redistribution my-redist-map --folder Texas
-scm load network bgp-route-map-redistribution --file redist-maps.yaml --folder Texas
-scm backup network bgp-route-map-redistribution --folder Texas
+$ scm set network bgp-route-map-redistribution ospf-redist \
+    --folder Texas \
+    --ospf-json '{"route_map": "ospf-to-bgp-map"}'
+---> 100%
+Created BGP route map redistribution: ospf-redist in folder Texas
 ```
+
+## Delete BGP Route Map Redistribution
+
+Delete a BGP route map redistribution from SCM.
+
+### Syntax
+
+```bash
+scm delete network bgp-route-map-redistribution NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network bgp-route-map-redistribution my-redist-map --folder Texas
+---> 100%
+Deleted BGP route map redistribution: my-redist-map from folder Texas
+```
+
+## Load BGP Route Map Redistribution
+
+Load multiple BGP route map redistributions from a YAML file.
+
+### Syntax
+
+```bash
+scm load network bgp-route-map-redistribution [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+bgp_route_map_redistributions:
+  - name: connected-redist
+    folder: Texas
+    connected_static:
+      connected:
+        route_map: "my-route-map"
+
+  - name: ospf-redist
+    folder: Texas
+    ospf:
+      route_map: "ospf-to-bgp-map"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network bgp-route-map-redistribution --file redist-maps.yml
+---> 100%
+✓ Loaded BGP route map redistribution: connected-redist
+✓ Loaded BGP route map redistribution: ospf-redist
+
+Successfully loaded 2 out of 2 BGP route map redistributions from 'redist-maps.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network bgp-route-map-redistribution --file redist-maps.yml --folder Austin
+---> 100%
+✓ Loaded BGP route map redistribution: connected-redist
+✓ Loaded BGP route map redistribution: ospf-redist
+
+Successfully loaded 2 out of 2 BGP route map redistributions from 'redist-maps.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all BGP route map redistributions
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show BGP Route Map Redistribution
+
+Display BGP route map redistribution objects.
+
+### Syntax
+
+```bash
+scm show network bgp-route-map-redistribution [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific redistribution | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific BGP Route Map Redistribution
+
+```bash
+$ scm show network bgp-route-map-redistribution --folder Texas --name my-redist-map
+---> 100%
+BGP Route Map Redistribution: my-redist-map
+  Location: Folder 'Texas'
+  Connected Route Map: my-route-map
+```
+
+#### List All BGP Route Map Redistributions (Default Behavior)
+
+```bash
+$ scm show network bgp-route-map-redistribution --folder Texas
+---> 100%
+BGP route map redistributions in folder 'Texas':
+------------------------------------------------------------
+Name: connected-redist
+  Source: Connected
+  Route Map: my-route-map
+------------------------------------------------------------
+Name: ospf-redist
+  Source: OSPF
+  Route Map: ospf-to-bgp-map
+------------------------------------------------------------
+```
+
+## Backup BGP Route Map Redistributions
+
+Backup all BGP route map redistribution objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network bgp-route-map-redistribution [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network bgp-route-map-redistribution --folder Texas
+---> 100%
+Successfully backed up 3 BGP route map redistributions to bgp_route_map_redistribution_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network bgp-route-map-redistribution --folder Texas --file texas-redist-maps.yaml
+---> 100%
+Successfully backed up 3 BGP route map redistributions to texas-redist-maps.yaml
+```
+
+## Best Practices
+
+1. **Reference Existing Route Maps**: Ensure route maps referenced in redistribution configs exist before applying.
+2. **Redistribute Selectively**: Only redistribute protocols that need to be advertised via BGP.
+3. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+4. **Backup Before Changes**: Always backup existing configurations before making bulk modifications.
+5. **Coordinate with Route Maps**: Update route maps and redistribution configurations together to avoid routing inconsistencies.

--- a/docs/cli/network/bgp-route-map.md
+++ b/docs/cli/network/bgp-route-map.md
@@ -1,8 +1,22 @@
 # BGP Route Map
 
-BGP route maps define match conditions and set actions for BGP route policy processing.
+BGP route maps define match conditions and set actions for BGP route policy processing. The `scm` CLI provides commands to create, update, delete, and load BGP route maps.
+
+## Overview
+
+The `bgp-route-map` commands allow you to:
+
+- Create BGP route maps with match and set actions
+- Update existing route map configurations
+- Delete route maps that are no longer needed
+- Bulk import route maps from YAML files
+- Export route maps for backup or migration
 
 ## Set BGP Route Map
+
+Create or update a BGP route map.
+
+### Syntax
 
 ```bash
 scm set network bgp-route-map NAME [OPTIONS]
@@ -13,26 +27,232 @@ scm set network bgp-route-map NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Route map name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--route-map-json TEXT` | Route map entries as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create a Route Map with Permit Action
+
+```bash
+$ scm set network bgp-route-map my-route-map \
+    --folder Texas \
+    --route-map-json '[{"name": "rule1", "action": "permit", "match": {"as_path": "my-as-path"}}]'
+---> 100%
+Created BGP route map: my-route-map in folder Texas
+```
+
+#### Create a Route Map with Deny Action
+
+```bash
+$ scm set network bgp-route-map deny-map \
+    --folder Texas \
+    --route-map-json '[{"name": "rule1", "action": "deny", "match": {"community": "no-export"}}]'
+---> 100%
+Created BGP route map: deny-map in folder Texas
+```
+
+## Delete BGP Route Map
+
+Delete a BGP route map from SCM.
+
+### Syntax
+
+```bash
+scm delete network bgp-route-map NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Route map name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network bgp-route-map my-route-map \
-    --folder Texas \
-    --route-map-json '[{"name": "rule1", "action": "permit", "match": {"as_path": "my-as-path"}}]'
+$ scm delete network bgp-route-map my-route-map --folder Texas
+---> 100%
+Deleted BGP route map: my-route-map from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load BGP Route Map
+
+Load multiple BGP route maps from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network bgp-route-map --folder Texas
-scm delete network bgp-route-map my-route-map --folder Texas
-scm load network bgp-route-map --file route-maps.yaml --folder Texas
-scm backup network bgp-route-map --folder Texas
+scm load network bgp-route-map [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+bgp_route_maps:
+  - name: permit-map
+    folder: Texas
+    route_map:
+      - name: "rule1"
+        action: permit
+        match:
+          as_path: "my-as-path"
+
+  - name: deny-map
+    folder: Texas
+    route_map:
+      - name: "rule1"
+        action: deny
+        match:
+          community: "no-export"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network bgp-route-map --file route-maps.yml
+---> 100%
+✓ Loaded BGP route map: permit-map
+✓ Loaded BGP route map: deny-map
+
+Successfully loaded 2 out of 2 BGP route maps from 'route-maps.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network bgp-route-map --file route-maps.yml --folder Austin
+---> 100%
+✓ Loaded BGP route map: permit-map
+✓ Loaded BGP route map: deny-map
+
+Successfully loaded 2 out of 2 BGP route maps from 'route-maps.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all BGP route maps
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show BGP Route Map
+
+Display BGP route map objects.
+
+### Syntax
+
+```bash
+scm show network bgp-route-map [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific route map | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific BGP Route Map
+
+```bash
+$ scm show network bgp-route-map --folder Texas --name my-route-map
+---> 100%
+BGP Route Map: my-route-map
+  Location: Folder 'Texas'
+  Rules:
+    rule1: permit (match AS path: my-as-path)
+```
+
+#### List All BGP Route Maps (Default Behavior)
+
+```bash
+$ scm show network bgp-route-map --folder Texas
+---> 100%
+BGP route maps in folder 'Texas':
+------------------------------------------------------------
+Name: permit-map
+  Rules: 1
+------------------------------------------------------------
+Name: deny-map
+  Rules: 1
+------------------------------------------------------------
+```
+
+## Backup BGP Route Maps
+
+Backup all BGP route map objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network bgp-route-map [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network bgp-route-map --folder Texas
+---> 100%
+Successfully backed up 6 BGP route maps to bgp_route_map_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network bgp-route-map --folder Texas --file texas-route-maps.yaml
+---> 100%
+Successfully backed up 6 BGP route maps to texas-route-maps.yaml
+```
+
+## Best Practices
+
+1. **Order Rules Carefully**: Route map rules are evaluated in order; place more specific matches first.
+2. **Use Explicit Deny**: End route maps with an explicit deny rule to make the policy intent clear.
+3. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+4. **Backup Before Changes**: Always backup existing route maps before making bulk modifications.
+5. **Document Match Criteria**: Use descriptive rule names that indicate what each match condition does.

--- a/docs/cli/network/dhcp-interface.md
+++ b/docs/cli/network/dhcp-interface.md
@@ -1,8 +1,22 @@
 # DHCP Interface
 
-DHCP interfaces configure DHCP server or relay functionality on network interfaces.
+DHCP interfaces configure DHCP server or relay functionality on network interfaces. The `scm` CLI provides commands to create, update, delete, and load DHCP interfaces.
+
+## Overview
+
+The `dhcp-interface` commands allow you to:
+
+- Create DHCP interfaces with server or relay configurations
+- Update existing DHCP interface settings
+- Delete DHCP interfaces that are no longer needed
+- Bulk import DHCP interfaces from YAML files
+- Export DHCP interfaces for backup or migration
 
 ## Set DHCP Interface
+
+Create or update a DHCP interface.
+
+### Syntax
 
 ```bash
 scm set network dhcp-interface NAME [OPTIONS]
@@ -13,27 +27,232 @@ scm set network dhcp-interface NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Interface name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--server-json TEXT` | DHCP server config as JSON | No |
 | `--relay-json TEXT` | DHCP relay config as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create a DHCP Server Interface
+
+```bash
+$ scm set network dhcp-interface ethernet1/1 \
+    --folder Texas \
+    --server-json '{"ip_pool": [{"name": "pool1", "start_ip": "10.0.0.100", "end_ip": "10.0.0.200"}]}'
+---> 100%
+Created DHCP interface: ethernet1/1 in folder Texas
+```
+
+#### Create a DHCP Relay Interface
+
+```bash
+$ scm set network dhcp-interface ethernet1/2 \
+    --folder Texas \
+    --relay-json '{"server_addresses": ["10.0.1.1", "10.0.1.2"]}'
+---> 100%
+Created DHCP interface: ethernet1/2 in folder Texas
+```
+
+## Delete DHCP Interface
+
+Delete a DHCP interface from SCM.
+
+### Syntax
+
+```bash
+scm delete network dhcp-interface NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Interface name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network dhcp-interface ethernet1/1 \
-    --folder Texas \
-    --server-json '{"ip_pool": [{"name": "pool1", "start_ip": "10.0.0.100", "end_ip": "10.0.0.200"}]}'
+$ scm delete network dhcp-interface ethernet1/1 --folder Texas
+---> 100%
+Deleted DHCP interface: ethernet1/1 from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load DHCP Interface
+
+Load multiple DHCP interfaces from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network dhcp-interface --folder Texas
-scm delete network dhcp-interface ethernet1/1 --folder Texas
-scm load network dhcp-interface --file dhcp.yaml --folder Texas
-scm backup network dhcp-interface --folder Texas
+scm load network dhcp-interface [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+dhcp_interfaces:
+  - name: ethernet1/1
+    folder: Texas
+    server:
+      ip_pool:
+        - name: "pool1"
+          start_ip: "10.0.0.100"
+          end_ip: "10.0.0.200"
+
+  - name: ethernet1/2
+    folder: Texas
+    relay:
+      server_addresses:
+        - "10.0.1.1"
+        - "10.0.1.2"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network dhcp-interface --file dhcp.yml
+---> 100%
+✓ Loaded DHCP interface: ethernet1/1
+✓ Loaded DHCP interface: ethernet1/2
+
+Successfully loaded 2 out of 2 DHCP interfaces from 'dhcp.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network dhcp-interface --file dhcp.yml --folder Austin
+---> 100%
+✓ Loaded DHCP interface: ethernet1/1
+✓ Loaded DHCP interface: ethernet1/2
+
+Successfully loaded 2 out of 2 DHCP interfaces from 'dhcp.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all DHCP interfaces
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show DHCP Interface
+
+Display DHCP interface objects.
+
+### Syntax
+
+```bash
+scm show network dhcp-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific interface | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific DHCP Interface
+
+```bash
+$ scm show network dhcp-interface --folder Texas --name ethernet1/1
+---> 100%
+DHCP Interface: ethernet1/1
+  Location: Folder 'Texas'
+  Mode: Server
+  IP Pool: 10.0.0.100 - 10.0.0.200
+```
+
+#### List All DHCP Interfaces (Default Behavior)
+
+```bash
+$ scm show network dhcp-interface --folder Texas
+---> 100%
+DHCP interfaces in folder 'Texas':
+------------------------------------------------------------
+Name: ethernet1/1
+  Mode: Server
+------------------------------------------------------------
+Name: ethernet1/2
+  Mode: Relay
+------------------------------------------------------------
+```
+
+## Backup DHCP Interfaces
+
+Backup all DHCP interface objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network dhcp-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network dhcp-interface --folder Texas
+---> 100%
+Successfully backed up 5 DHCP interfaces to dhcp_interface_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network dhcp-interface --folder Texas --file texas-dhcp.yaml
+---> 100%
+Successfully backed up 5 DHCP interfaces to texas-dhcp.yaml
+```
+
+## Best Practices
+
+1. **Avoid IP Pool Overlap**: Ensure DHCP server IP pools do not overlap with static IP assignments on the network.
+2. **Configure Redundant Relays**: When using DHCP relay, specify multiple server addresses for high availability.
+3. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+4. **Backup Before Changes**: Always backup existing DHCP configurations before making bulk modifications.
+5. **Document Pool Assignments**: Maintain records of which interfaces serve which DHCP pools for troubleshooting.

--- a/docs/cli/network/ethernet-interface.md
+++ b/docs/cli/network/ethernet-interface.md
@@ -1,8 +1,22 @@
 # Ethernet Interface
 
-Ethernet interfaces configure physical network ports with layer2, layer3, or TAP mode settings.
+Ethernet interfaces configure physical network ports with layer2, layer3, or TAP mode settings. The `scm` CLI provides commands to create, update, delete, and load ethernet interfaces.
+
+## Overview
+
+The `ethernet-interface` commands allow you to:
+
+- Create ethernet interfaces with layer2, layer3, or TAP configurations
+- Update existing ethernet interface settings including link speed and duplex
+- Delete ethernet interfaces that are no longer needed
+- Bulk import ethernet interfaces from YAML files
+- Export ethernet interfaces for backup or migration
 
 ## Set Ethernet Interface
+
+Create or update an ethernet interface.
+
+### Syntax
 
 ```bash
 scm set network ethernet-interface NAME [OPTIONS]
@@ -13,9 +27,9 @@ scm set network ethernet-interface NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Interface name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--comment TEXT` | Interface description | No |
 | `--default-value TEXT` | Physical interface (e.g. ethernet1/1) | No |
 | `--link-speed TEXT` | Link speed (auto, 10, 100, 1000, 10000) | No |
@@ -27,7 +41,9 @@ scm set network ethernet-interface NAME [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Create a Layer3 Ethernet Interface
 
 ```bash
 $ scm set network ethernet-interface ethernet1/1 \
@@ -35,13 +51,223 @@ $ scm set network ethernet-interface ethernet1/1 \
     --layer3-json '{"mtu": 1500, "ip": [{"name": "10.0.0.1/24"}]}' \
     --link-speed auto \
     --comment "WAN uplink"
+---> 100%
+Created ethernet interface: ethernet1/1 in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create a TAP Mode Interface
 
 ```bash
-scm show network ethernet-interface --folder Texas
-scm delete network ethernet-interface ethernet1/1 --folder Texas
-scm load network ethernet-interface --file interfaces.yaml --folder Texas
-scm backup network ethernet-interface --folder Texas
+$ scm set network ethernet-interface ethernet1/3 \
+    --folder Texas \
+    --tap-json '{}' \
+    --comment "Traffic monitoring"
+---> 100%
+Created ethernet interface: ethernet1/3 in folder Texas
 ```
+
+## Delete Ethernet Interface
+
+Delete an ethernet interface from SCM.
+
+### Syntax
+
+```bash
+scm delete network ethernet-interface NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Interface name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network ethernet-interface ethernet1/1 --folder Texas
+---> 100%
+Deleted ethernet interface: ethernet1/1 from folder Texas
+```
+
+## Load Ethernet Interface
+
+Load multiple ethernet interfaces from a YAML file.
+
+### Syntax
+
+```bash
+scm load network ethernet-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+ethernet_interfaces:
+  - name: ethernet1/1
+    folder: Texas
+    comment: "WAN uplink"
+    link_speed: auto
+    layer3:
+      mtu: 1500
+      ip:
+        - name: "10.0.0.1/24"
+
+  - name: ethernet1/2
+    folder: Texas
+    comment: "LAN interface"
+    layer3:
+      mtu: 1500
+      ip:
+        - name: "192.168.1.1/24"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network ethernet-interface --file interfaces.yml
+---> 100%
+✓ Loaded ethernet interface: ethernet1/1
+✓ Loaded ethernet interface: ethernet1/2
+
+Successfully loaded 2 out of 2 ethernet interfaces from 'interfaces.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network ethernet-interface --file interfaces.yml --folder Austin
+---> 100%
+✓ Loaded ethernet interface: ethernet1/1
+✓ Loaded ethernet interface: ethernet1/2
+
+Successfully loaded 2 out of 2 ethernet interfaces from 'interfaces.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all ethernet interfaces
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Ethernet Interface
+
+Display ethernet interface objects.
+
+### Syntax
+
+```bash
+scm show network ethernet-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific interface | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Ethernet Interface
+
+```bash
+$ scm show network ethernet-interface --folder Texas --name ethernet1/1
+---> 100%
+Ethernet Interface: ethernet1/1
+  Location: Folder 'Texas'
+  Comment: WAN uplink
+  Link Speed: auto
+  Mode: Layer3
+  MTU: 1500
+```
+
+#### List All Ethernet Interfaces (Default Behavior)
+
+```bash
+$ scm show network ethernet-interface --folder Texas
+---> 100%
+Ethernet interfaces in folder 'Texas':
+------------------------------------------------------------
+Name: ethernet1/1
+  Comment: WAN uplink
+  Mode: Layer3
+------------------------------------------------------------
+Name: ethernet1/2
+  Comment: LAN interface
+  Mode: Layer3
+------------------------------------------------------------
+```
+
+## Backup Ethernet Interfaces
+
+Backup all ethernet interface objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network ethernet-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network ethernet-interface --folder Texas
+---> 100%
+Successfully backed up 8 ethernet interfaces to ethernet_interface_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network ethernet-interface --folder Texas --file texas-interfaces.yaml
+---> 100%
+Successfully backed up 8 ethernet interfaces to texas-interfaces.yaml
+```
+
+## Best Practices
+
+1. **Set Link Speed Explicitly**: While auto-negotiation works in most cases, set link speed explicitly for critical uplinks.
+2. **Use Descriptive Comments**: Add comments describing the purpose and connected device for each interface.
+3. **Plan IP Addressing**: Assign IP addresses following a consistent addressing scheme across all interfaces.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing interface configurations before making bulk modifications.

--- a/docs/cli/network/ike-crypto-profile.md
+++ b/docs/cli/network/ike-crypto-profile.md
@@ -1,8 +1,22 @@
 # IKE Crypto Profile
 
-IKE crypto profiles define encryption, authentication, and key exchange parameters for IKE Phase 1 negotiations.
+IKE crypto profiles define encryption, authentication, and key exchange parameters for IKE Phase 1 negotiations. The `scm` CLI provides commands to create, update, delete, and load IKE crypto profiles.
+
+## Overview
+
+The `ike-crypto-profile` commands allow you to:
+
+- Create IKE crypto profiles with encryption, hash, and DH group settings
+- Update existing IKE crypto profile configurations
+- Delete IKE crypto profiles that are no longer needed
+- Bulk import IKE crypto profiles from YAML files
+- Export IKE crypto profiles for backup or migration
 
 ## Set IKE Crypto Profile
+
+Create or update an IKE crypto profile.
+
+### Syntax
 
 ```bash
 scm set network ike-crypto-profile NAME [OPTIONS]
@@ -16,9 +30,9 @@ scm set network ike-crypto-profile NAME [OPTIONS]
 | `--hash TEXT` | Hash algorithms (sha256, sha384, sha512, sha1, md5) | Yes |
 | `--dh-group TEXT` | DH groups (group1, group2, group5, group14, group19, group20) | Yes |
 | `--encryption TEXT` | Encryption algorithms (aes-256-cbc, aes-128-cbc, etc.) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--lifetime-seconds INT` | Lifetime in seconds (180-65535) | No |
 | `--lifetime-minutes INT` | Lifetime in minutes (3-65535) | No |
 | `--lifetime-hours INT` | Lifetime in hours (1-65535) | No |
@@ -27,7 +41,9 @@ scm set network ike-crypto-profile NAME [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Create an IKE Crypto Profile with Hours Lifetime
 
 ```bash
 $ scm set network ike-crypto-profile my-ike-profile \
@@ -36,24 +52,228 @@ $ scm set network ike-crypto-profile my-ike-profile \
     --dh-group group14 \
     --encryption aes-256-cbc \
     --lifetime-hours 8
+---> 100%
+Created IKE crypto profile: my-ike-profile in folder Texas
 ```
 
-## Show IKE Crypto Profile
+#### Create an IKE Crypto Profile with Seconds Lifetime
 
 ```bash
-scm show network ike-crypto-profile --folder Texas
-scm show network ike-crypto-profile --folder Texas --name my-ike-profile
+$ scm set network ike-crypto-profile quick-rekey \
+    --folder Texas \
+    --hash sha384 \
+    --dh-group group19 \
+    --encryption aes-256-cbc \
+    --lifetime-seconds 28800
+---> 100%
+Created IKE crypto profile: quick-rekey in folder Texas
 ```
 
 ## Delete IKE Crypto Profile
 
-```bash
-scm delete network ike-crypto-profile my-ike-profile --folder Texas
-```
+Delete an IKE crypto profile from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load network ike-crypto-profile --file ike-profiles.yaml --folder Texas
-scm backup network ike-crypto-profile --folder Texas
+scm delete network ike-crypto-profile NAME [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Profile name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network ike-crypto-profile my-ike-profile --folder Texas
+---> 100%
+Deleted IKE crypto profile: my-ike-profile from folder Texas
+```
+
+## Load IKE Crypto Profile
+
+Load multiple IKE crypto profiles from a YAML file.
+
+### Syntax
+
+```bash
+scm load network ike-crypto-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+ike_crypto_profiles:
+  - name: standard-ike
+    folder: Texas
+    hash:
+      - sha256
+    dh_group:
+      - group14
+    encryption:
+      - aes-256-cbc
+    lifetime_hours: 8
+
+  - name: high-security-ike
+    folder: Texas
+    hash:
+      - sha384
+    dh_group:
+      - group19
+    encryption:
+      - aes-256-cbc
+    lifetime_hours: 4
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network ike-crypto-profile --file ike-profiles.yml
+---> 100%
+✓ Loaded IKE crypto profile: standard-ike
+✓ Loaded IKE crypto profile: high-security-ike
+
+Successfully loaded 2 out of 2 IKE crypto profiles from 'ike-profiles.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network ike-crypto-profile --file ike-profiles.yml --folder Austin
+---> 100%
+✓ Loaded IKE crypto profile: standard-ike
+✓ Loaded IKE crypto profile: high-security-ike
+
+Successfully loaded 2 out of 2 IKE crypto profiles from 'ike-profiles.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all IKE crypto profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show IKE Crypto Profile
+
+Display IKE crypto profile objects.
+
+### Syntax
+
+```bash
+scm show network ike-crypto-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific profile | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific IKE Crypto Profile
+
+```bash
+$ scm show network ike-crypto-profile --folder Texas --name my-ike-profile
+---> 100%
+IKE Crypto Profile: my-ike-profile
+  Location: Folder 'Texas'
+  Hash: sha256
+  DH Group: group14
+  Encryption: aes-256-cbc
+  Lifetime: 8 hours
+```
+
+#### List All IKE Crypto Profiles (Default Behavior)
+
+```bash
+$ scm show network ike-crypto-profile --folder Texas
+---> 100%
+IKE crypto profiles in folder 'Texas':
+------------------------------------------------------------
+Name: standard-ike
+  Hash: sha256
+  Encryption: aes-256-cbc
+------------------------------------------------------------
+Name: high-security-ike
+  Hash: sha384
+  Encryption: aes-256-cbc
+------------------------------------------------------------
+```
+
+## Backup IKE Crypto Profiles
+
+Backup all IKE crypto profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network ike-crypto-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network ike-crypto-profile --folder Texas
+---> 100%
+Successfully backed up 5 IKE crypto profiles to ike_crypto_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network ike-crypto-profile --folder Texas --file texas-ike-profiles.yaml
+---> 100%
+Successfully backed up 5 IKE crypto profiles to texas-ike-profiles.yaml
+```
+
+## Best Practices
+
+1. **Use Strong Algorithms**: Prefer sha256 or higher for hash and aes-256-cbc for encryption in production environments.
+2. **Select Appropriate DH Groups**: Use group14 or higher for adequate key exchange security.
+3. **Set Reasonable Lifetimes**: Balance security (shorter lifetimes) with performance (fewer renegotiations).
+4. **Standardize Profiles**: Create a small set of standard profiles and reuse them across IKE gateways.
+5. **Backup Before Changes**: Always backup existing profiles before making bulk modifications.

--- a/docs/cli/network/ike-gateway.md
+++ b/docs/cli/network/ike-gateway.md
@@ -1,8 +1,22 @@
 # IKE Gateway
 
-IKE gateways define VPN tunnel endpoints with peer addressing, authentication, and protocol settings.
+IKE gateways define VPN tunnel endpoints with peer addressing, authentication, and protocol settings. The `scm` CLI provides commands to create, update, delete, and load IKE gateways.
+
+## Overview
+
+The `ike-gateway` commands allow you to:
+
+- Create IKE gateways with pre-shared key or certificate authentication
+- Update existing IKE gateway configurations
+- Delete IKE gateways that are no longer needed
+- Bulk import IKE gateways from YAML files
+- Export IKE gateways for backup or migration
 
 ## Set IKE Gateway
+
+Create or update an IKE gateway.
+
+### Syntax
 
 ```bash
 scm set network ike-gateway NAME [OPTIONS]
@@ -13,13 +27,13 @@ scm set network ike-gateway NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Gateway name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
-| `--pre-shared-key TEXT` | Pre-shared key for authentication | No** |
-| `--peer-address-ip TEXT` | Peer IP address | No*** |
-| `--peer-address-fqdn TEXT` | Peer FQDN | No*** |
-| `--peer-address-dynamic` | Use dynamic peer address | No*** |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--pre-shared-key TEXT` | Pre-shared key for authentication | No\*\* |
+| `--peer-address-ip TEXT` | Peer IP address | No\*\*\* |
+| `--peer-address-fqdn TEXT` | Peer FQDN | No\*\*\* |
+| `--peer-address-dynamic` | Use dynamic peer address | No\*\*\* |
 | `--protocol-version TEXT` | IKE version (ikev1, ikev2, ikev2-preferred) | No |
 | `--ike-crypto-profile TEXT` | IKE crypto profile name | No |
 | `--peer-id-type TEXT` | Peer ID type (ipaddr, keyid, fqdn, ufqdn) | No |
@@ -30,8 +44,8 @@ scm set network ike-gateway NAME [OPTIONS]
 | `--fragmentation` | Enable IKE fragmentation | No |
 | `--passive-mode` | Enable passive mode | No |
 | `--dpd-enable` | Enable Dead Peer Detection | No |
-| `--authentication-json TEXT` | Full authentication config as JSON | No** |
-| `--peer-address-json TEXT` | Full peer address config as JSON | No*** |
+| `--authentication-json TEXT` | Full authentication config as JSON | No\*\* |
+| `--peer-address-json TEXT` | Full peer address config as JSON | No\*\*\* |
 | `--protocol-json TEXT` | Full protocol config as JSON | No |
 | `--protocol-common-json TEXT` | Full protocol_common config as JSON | No |
 
@@ -39,7 +53,9 @@ scm set network ike-gateway NAME [OPTIONS]
 \*\* Either --pre-shared-key or --authentication-json is required.
 \*\*\* One of --peer-address-ip, --peer-address-fqdn, --peer-address-dynamic, or --peer-address-json is required.
 
-### Example
+### Examples
+
+#### Create an IKE Gateway with Pre-Shared Key
 
 ```bash
 $ scm set network ike-gateway my-gateway \
@@ -49,24 +65,234 @@ $ scm set network ike-gateway my-gateway \
     --ike-crypto-profile my-ike-profile \
     --nat-traversal \
     --dpd-enable
+---> 100%
+Created IKE gateway: my-gateway in folder Texas
 ```
 
-## Show IKE Gateway
+#### Create an IKE Gateway with FQDN Peer
 
 ```bash
-scm show network ike-gateway --folder Texas
-scm show network ike-gateway --folder Texas --name my-gateway
+$ scm set network ike-gateway branch-gw \
+    --folder Texas \
+    --pre-shared-key "branch-secret" \
+    --peer-address-fqdn vpn.example.com \
+    --protocol-version ikev2 \
+    --ike-crypto-profile high-security-ike
+---> 100%
+Created IKE gateway: branch-gw in folder Texas
 ```
 
 ## Delete IKE Gateway
 
-```bash
-scm delete network ike-gateway my-gateway --folder Texas
-```
+Delete an IKE gateway from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load network ike-gateway --file ike-gateways.yaml --folder Texas
-scm backup network ike-gateway --folder Texas
+scm delete network ike-gateway NAME [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Gateway name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network ike-gateway my-gateway --folder Texas
+---> 100%
+Deleted IKE gateway: my-gateway from folder Texas
+```
+
+## Load IKE Gateway
+
+Load multiple IKE gateways from a YAML file.
+
+### Syntax
+
+```bash
+scm load network ike-gateway [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+ike_gateways:
+  - name: site-a-gw
+    folder: Texas
+    authentication:
+      pre_shared_key:
+        key: "site-a-secret"
+    peer_address:
+      ip: "203.0.113.1"
+    protocol:
+      ikev2:
+        ike_crypto_profile: "standard-ike"
+    protocol_common:
+      nat_traversal:
+        enable: true
+
+  - name: site-b-gw
+    folder: Texas
+    authentication:
+      pre_shared_key:
+        key: "site-b-secret"
+    peer_address:
+      fqdn: "vpn-b.example.com"
+    protocol:
+      ikev2:
+        ike_crypto_profile: "standard-ike"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network ike-gateway --file ike-gateways.yml
+---> 100%
+✓ Loaded IKE gateway: site-a-gw
+✓ Loaded IKE gateway: site-b-gw
+
+Successfully loaded 2 out of 2 IKE gateways from 'ike-gateways.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network ike-gateway --file ike-gateways.yml --folder Austin
+---> 100%
+✓ Loaded IKE gateway: site-a-gw
+✓ Loaded IKE gateway: site-b-gw
+
+Successfully loaded 2 out of 2 IKE gateways from 'ike-gateways.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all IKE gateways
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show IKE Gateway
+
+Display IKE gateway objects.
+
+### Syntax
+
+```bash
+scm show network ike-gateway [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific gateway | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific IKE Gateway
+
+```bash
+$ scm show network ike-gateway --folder Texas --name my-gateway
+---> 100%
+IKE Gateway: my-gateway
+  Location: Folder 'Texas'
+  Peer Address: 203.0.113.1
+  IKE Crypto Profile: my-ike-profile
+  NAT Traversal: enabled
+  DPD: enabled
+```
+
+#### List All IKE Gateways (Default Behavior)
+
+```bash
+$ scm show network ike-gateway --folder Texas
+---> 100%
+IKE gateways in folder 'Texas':
+------------------------------------------------------------
+Name: site-a-gw
+  Peer: 203.0.113.1
+  Profile: standard-ike
+------------------------------------------------------------
+Name: site-b-gw
+  Peer: vpn-b.example.com
+  Profile: standard-ike
+------------------------------------------------------------
+```
+
+## Backup IKE Gateways
+
+Backup all IKE gateway objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network ike-gateway [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network ike-gateway --folder Texas
+---> 100%
+Successfully backed up 10 IKE gateways to ike_gateway_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network ike-gateway --folder Texas --file texas-ike-gateways.yaml
+---> 100%
+Successfully backed up 10 IKE gateways to texas-ike-gateways.yaml
+```
+
+## Best Practices
+
+1. **Enable DPD**: Always enable Dead Peer Detection to detect and recover from failed tunnels.
+2. **Use NAT Traversal**: Enable NAT traversal when peers may be behind NAT devices.
+3. **Prefer IKEv2**: Use ikev2 or ikev2-preferred for improved security and performance over IKEv1.
+4. **Use Strong Pre-Shared Keys**: Generate long, random pre-shared keys for authentication.
+5. **Backup Before Changes**: Always backup existing gateway configurations before making bulk modifications.
+6. **Reference Crypto Profiles**: Ensure IKE crypto profiles exist before referencing them in gateway configurations.

--- a/docs/cli/network/ipsec-crypto-profile.md
+++ b/docs/cli/network/ipsec-crypto-profile.md
@@ -1,8 +1,22 @@
 # IPsec Crypto Profile
 
-IPsec crypto profiles define encryption and authentication parameters for IPsec Phase 2 (ESP) negotiations.
+IPsec crypto profiles define encryption and authentication parameters for IPsec Phase 2 (ESP) negotiations. The `scm` CLI provides commands to create, update, delete, and load IPsec crypto profiles.
+
+## Overview
+
+The `ipsec-crypto-profile` commands allow you to:
+
+- Create IPsec crypto profiles with ESP encryption and authentication settings
+- Update existing IPsec crypto profile configurations
+- Delete IPsec crypto profiles that are no longer needed
+- Bulk import IPsec crypto profiles from YAML files
+- Export IPsec crypto profiles for backup or migration
 
 ## Set IPsec Crypto Profile
+
+Create or update an IPsec crypto profile.
+
+### Syntax
 
 ```bash
 scm set network ipsec-crypto-profile [OPTIONS]
@@ -12,15 +26,17 @@ scm set network ipsec-crypto-profile [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | Yes |
 | `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | Yes |
 | `--esp-encryption TEXT` | ESP encryption algorithms (aes-256-cbc, aes-128-cbc, etc.) | Yes |
 | `--esp-authentication TEXT` | ESP authentication algorithms (sha256, sha384, sha512, sha1, md5) | Yes |
 | `--dh-group TEXT` | DH group for PFS (group14, group19, group20, no-pfs) | Yes |
 | `--lifetime-seconds INT` | Lifetime in seconds | No |
 | `--lifetime-hours INT` | Lifetime in hours | No |
 
-### Example
+### Examples
+
+#### Create an IPsec Crypto Profile
 
 ```bash
 $ scm set network ipsec-crypto-profile \
@@ -29,24 +45,224 @@ $ scm set network ipsec-crypto-profile \
     --esp-encryption aes-256-cbc \
     --esp-authentication sha256 \
     --dh-group group14
+---> 100%
+Created IPsec crypto profile: my-ipsec-profile in folder Texas
 ```
 
-## Show IPsec Crypto Profile
+#### Create a Profile with Custom Lifetime
 
 ```bash
-scm show network ipsec-crypto-profile --folder Texas
-scm show network ipsec-crypto-profile --folder Texas --name my-ipsec-profile
+$ scm set network ipsec-crypto-profile \
+    --folder Texas \
+    --name short-lived-profile \
+    --esp-encryption aes-256-cbc \
+    --esp-authentication sha384 \
+    --dh-group group19 \
+    --lifetime-hours 1
+---> 100%
+Created IPsec crypto profile: short-lived-profile in folder Texas
 ```
 
 ## Delete IPsec Crypto Profile
 
-```bash
-scm delete network ipsec-crypto-profile --folder Texas --name my-ipsec-profile
-```
+Delete an IPsec crypto profile from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load network ipsec-crypto-profile --file ipsec-profiles.yaml --folder Texas
-scm backup network ipsec-crypto-profile --folder Texas
+scm delete network ipsec-crypto-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Profile name | Yes |
+| `--folder TEXT` | Folder location | Yes |
+
+### Example
+
+```bash
+$ scm delete network ipsec-crypto-profile --folder Texas --name my-ipsec-profile
+---> 100%
+Deleted IPsec crypto profile: my-ipsec-profile from folder Texas
+```
+
+## Load IPsec Crypto Profile
+
+Load multiple IPsec crypto profiles from a YAML file.
+
+### Syntax
+
+```bash
+scm load network ipsec-crypto-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+ipsec_crypto_profiles:
+  - name: standard-ipsec
+    folder: Texas
+    esp:
+      encryption:
+        - aes-256-cbc
+      authentication:
+        - sha256
+    dh_group: group14
+    lifetime_hours: 8
+
+  - name: high-security-ipsec
+    folder: Texas
+    esp:
+      encryption:
+        - aes-256-cbc
+      authentication:
+        - sha384
+    dh_group: group19
+    lifetime_hours: 4
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network ipsec-crypto-profile --file ipsec-profiles.yml
+---> 100%
+✓ Loaded IPsec crypto profile: standard-ipsec
+✓ Loaded IPsec crypto profile: high-security-ipsec
+
+Successfully loaded 2 out of 2 IPsec crypto profiles from 'ipsec-profiles.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network ipsec-crypto-profile --file ipsec-profiles.yml --folder Austin
+---> 100%
+✓ Loaded IPsec crypto profile: standard-ipsec
+✓ Loaded IPsec crypto profile: high-security-ipsec
+
+Successfully loaded 2 out of 2 IPsec crypto profiles from 'ipsec-profiles.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all IPsec crypto profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show IPsec Crypto Profile
+
+Display IPsec crypto profile objects.
+
+### Syntax
+
+```bash
+scm show network ipsec-crypto-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific profile | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific IPsec Crypto Profile
+
+```bash
+$ scm show network ipsec-crypto-profile --folder Texas --name my-ipsec-profile
+---> 100%
+IPsec Crypto Profile: my-ipsec-profile
+  Location: Folder 'Texas'
+  ESP Encryption: aes-256-cbc
+  ESP Authentication: sha256
+  DH Group: group14
+```
+
+#### List All IPsec Crypto Profiles (Default Behavior)
+
+```bash
+$ scm show network ipsec-crypto-profile --folder Texas
+---> 100%
+IPsec crypto profiles in folder 'Texas':
+------------------------------------------------------------
+Name: standard-ipsec
+  ESP Encryption: aes-256-cbc
+  DH Group: group14
+------------------------------------------------------------
+Name: high-security-ipsec
+  ESP Encryption: aes-256-cbc
+  DH Group: group19
+------------------------------------------------------------
+```
+
+## Backup IPsec Crypto Profiles
+
+Backup all IPsec crypto profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network ipsec-crypto-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network ipsec-crypto-profile --folder Texas
+---> 100%
+Successfully backed up 5 IPsec crypto profiles to ipsec_crypto_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network ipsec-crypto-profile --folder Texas --file texas-ipsec-profiles.yaml
+---> 100%
+Successfully backed up 5 IPsec crypto profiles to texas-ipsec-profiles.yaml
+```
+
+## Best Practices
+
+1. **Enable PFS**: Use a DH group (group14 or higher) for Perfect Forward Secrecy rather than no-pfs.
+2. **Use Strong Encryption**: Prefer aes-256-cbc with sha256 or higher authentication for production tunnels.
+3. **Match IKE and IPsec Profiles**: Ensure IPsec profile security level is consistent with the paired IKE crypto profile.
+4. **Set Appropriate Lifetimes**: Shorter lifetimes increase security but may impact performance during rekeying.
+5. **Backup Before Changes**: Always backup existing profiles before making bulk modifications.

--- a/docs/cli/network/layer2-subinterface.md
+++ b/docs/cli/network/layer2-subinterface.md
@@ -1,8 +1,22 @@
 # Layer2 Subinterface
 
-Layer2 subinterfaces create VLAN-tagged subinterfaces operating in layer2 (switching) mode.
+Layer2 subinterfaces create VLAN-tagged subinterfaces operating in layer2 (switching) mode. The `scm` CLI provides commands to create, update, delete, and load layer2 subinterfaces.
+
+## Overview
+
+The `layer2-subinterface` commands allow you to:
+
+- Create layer2 subinterfaces with VLAN tag configurations
+- Update existing layer2 subinterface settings
+- Delete layer2 subinterfaces that are no longer needed
+- Bulk import layer2 subinterfaces from YAML files
+- Export layer2 subinterfaces for backup or migration
 
 ## Set Layer2 Subinterface
+
+Create or update a layer2 subinterface.
+
+### Syntax
 
 ```bash
 scm set network layer2-subinterface NAME [OPTIONS]
@@ -14,28 +28,233 @@ scm set network layer2-subinterface NAME [OPTIONS]
 | --- | --- | --- |
 | `NAME` | Subinterface name (positional) | Yes |
 | `--vlan-tag TEXT` | VLAN tag (1-4096) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--parent-interface TEXT` | Parent interface name | No |
 | `--comment TEXT` | Interface description | No |
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Create a Layer2 Subinterface
 
 ```bash
 $ scm set network layer2-subinterface ethernet1/1.100 \
     --folder Texas \
     --vlan-tag 100 \
     --parent-interface ethernet1/1
+---> 100%
+Created layer2 subinterface: ethernet1/1.100 in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create with Description
 
 ```bash
-scm show network layer2-subinterface --folder Texas
-scm delete network layer2-subinterface ethernet1/1.100 --folder Texas
-scm load network layer2-subinterface --file subinterfaces.yaml --folder Texas
-scm backup network layer2-subinterface --folder Texas
+$ scm set network layer2-subinterface ethernet1/2.200 \
+    --folder Texas \
+    --vlan-tag 200 \
+    --parent-interface ethernet1/2 \
+    --comment "Guest VLAN"
+---> 100%
+Created layer2 subinterface: ethernet1/2.200 in folder Texas
 ```
+
+## Delete Layer2 Subinterface
+
+Delete a layer2 subinterface from SCM.
+
+### Syntax
+
+```bash
+scm delete network layer2-subinterface NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Subinterface name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network layer2-subinterface ethernet1/1.100 --folder Texas
+---> 100%
+Deleted layer2 subinterface: ethernet1/1.100 from folder Texas
+```
+
+## Load Layer2 Subinterface
+
+Load multiple layer2 subinterfaces from a YAML file.
+
+### Syntax
+
+```bash
+scm load network layer2-subinterface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+layer2_subinterfaces:
+  - name: ethernet1/1.100
+    folder: Texas
+    vlan_tag: 100
+    parent_interface: ethernet1/1
+
+  - name: ethernet1/1.200
+    folder: Texas
+    vlan_tag: 200
+    parent_interface: ethernet1/1
+    comment: "Guest VLAN"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network layer2-subinterface --file subinterfaces.yml
+---> 100%
+✓ Loaded layer2 subinterface: ethernet1/1.100
+✓ Loaded layer2 subinterface: ethernet1/1.200
+
+Successfully loaded 2 out of 2 layer2 subinterfaces from 'subinterfaces.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network layer2-subinterface --file subinterfaces.yml --folder Austin
+---> 100%
+✓ Loaded layer2 subinterface: ethernet1/1.100
+✓ Loaded layer2 subinterface: ethernet1/1.200
+
+Successfully loaded 2 out of 2 layer2 subinterfaces from 'subinterfaces.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all layer2 subinterfaces
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Layer2 Subinterface
+
+Display layer2 subinterface objects.
+
+### Syntax
+
+```bash
+scm show network layer2-subinterface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific subinterface | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Layer2 Subinterface
+
+```bash
+$ scm show network layer2-subinterface --folder Texas --name ethernet1/1.100
+---> 100%
+Layer2 Subinterface: ethernet1/1.100
+  Location: Folder 'Texas'
+  VLAN Tag: 100
+  Parent Interface: ethernet1/1
+```
+
+#### List All Layer2 Subinterfaces (Default Behavior)
+
+```bash
+$ scm show network layer2-subinterface --folder Texas
+---> 100%
+Layer2 subinterfaces in folder 'Texas':
+------------------------------------------------------------
+Name: ethernet1/1.100
+  VLAN Tag: 100
+  Parent: ethernet1/1
+------------------------------------------------------------
+Name: ethernet1/1.200
+  VLAN Tag: 200
+  Parent: ethernet1/1
+------------------------------------------------------------
+```
+
+## Backup Layer2 Subinterfaces
+
+Backup all layer2 subinterface objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network layer2-subinterface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network layer2-subinterface --folder Texas
+---> 100%
+Successfully backed up 6 layer2 subinterfaces to layer2_subinterface_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network layer2-subinterface --folder Texas --file texas-l2-subinterfaces.yaml
+---> 100%
+Successfully backed up 6 layer2 subinterfaces to texas-l2-subinterfaces.yaml
+```
+
+## Best Practices
+
+1. **Use Consistent VLAN Tags**: Coordinate VLAN tag assignments across all subinterfaces to avoid conflicts.
+2. **Specify Parent Interface**: Always specify the parent interface for clarity and proper association.
+3. **Add Descriptive Comments**: Document the purpose of each VLAN subinterface for easier management.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing subinterface configurations before making bulk modifications.

--- a/docs/cli/network/layer3-subinterface.md
+++ b/docs/cli/network/layer3-subinterface.md
@@ -1,8 +1,22 @@
 # Layer3 Subinterface
 
-Layer3 subinterfaces create VLAN-tagged subinterfaces operating in layer3 (routing) mode with IP addressing.
+Layer3 subinterfaces create VLAN-tagged subinterfaces operating in layer3 (routing) mode with IP addressing. The `scm` CLI provides commands to create, update, delete, and load layer3 subinterfaces.
+
+## Overview
+
+The `layer3-subinterface` commands allow you to:
+
+- Create layer3 subinterfaces with VLAN tags and IP addressing
+- Update existing layer3 subinterface configurations
+- Delete layer3 subinterfaces that are no longer needed
+- Bulk import layer3 subinterfaces from YAML files
+- Export layer3 subinterfaces for backup or migration
 
 ## Set Layer3 Subinterface
+
+Create or update a layer3 subinterface.
+
+### Syntax
 
 ```bash
 scm set network layer3-subinterface NAME [OPTIONS]
@@ -13,9 +27,9 @@ scm set network layer3-subinterface NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Subinterface name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--tag INT` | VLAN tag (1-4096) | No |
 | `--parent-interface TEXT` | Parent interface name | No |
 | `--comment TEXT` | Interface description | No |
@@ -25,7 +39,9 @@ scm set network layer3-subinterface NAME [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Create a Layer3 Subinterface with Static IP
 
 ```bash
 $ scm set network layer3-subinterface ethernet1/1.200 \
@@ -34,13 +50,224 @@ $ scm set network layer3-subinterface ethernet1/1.200 \
     --parent-interface ethernet1/1 \
     --mtu 1500 \
     --ip-json '[{"name": "10.0.2.1/24"}]'
+---> 100%
+Created layer3 subinterface: ethernet1/1.200 in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create a Layer3 Subinterface with DHCP
 
 ```bash
-scm show network layer3-subinterface --folder Texas
-scm delete network layer3-subinterface ethernet1/1.200 --folder Texas
-scm load network layer3-subinterface --file subinterfaces.yaml --folder Texas
-scm backup network layer3-subinterface --folder Texas
+$ scm set network layer3-subinterface ethernet1/2.300 \
+    --folder Texas \
+    --tag 300 \
+    --parent-interface ethernet1/2 \
+    --dhcp-client-json '{"enable": true}' \
+    --comment "DHCP-assigned VLAN"
+---> 100%
+Created layer3 subinterface: ethernet1/2.300 in folder Texas
 ```
+
+## Delete Layer3 Subinterface
+
+Delete a layer3 subinterface from SCM.
+
+### Syntax
+
+```bash
+scm delete network layer3-subinterface NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Subinterface name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network layer3-subinterface ethernet1/1.200 --folder Texas
+---> 100%
+Deleted layer3 subinterface: ethernet1/1.200 from folder Texas
+```
+
+## Load Layer3 Subinterface
+
+Load multiple layer3 subinterfaces from a YAML file.
+
+### Syntax
+
+```bash
+scm load network layer3-subinterface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+layer3_subinterfaces:
+  - name: ethernet1/1.200
+    folder: Texas
+    tag: 200
+    parent_interface: ethernet1/1
+    mtu: 1500
+    ip:
+      - name: "10.0.2.1/24"
+
+  - name: ethernet1/1.300
+    folder: Texas
+    tag: 300
+    parent_interface: ethernet1/1
+    mtu: 1500
+    ip:
+      - name: "10.0.3.1/24"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network layer3-subinterface --file subinterfaces.yml
+---> 100%
+✓ Loaded layer3 subinterface: ethernet1/1.200
+✓ Loaded layer3 subinterface: ethernet1/1.300
+
+Successfully loaded 2 out of 2 layer3 subinterfaces from 'subinterfaces.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network layer3-subinterface --file subinterfaces.yml --folder Austin
+---> 100%
+✓ Loaded layer3 subinterface: ethernet1/1.200
+✓ Loaded layer3 subinterface: ethernet1/1.300
+
+Successfully loaded 2 out of 2 layer3 subinterfaces from 'subinterfaces.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all layer3 subinterfaces
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Layer3 Subinterface
+
+Display layer3 subinterface objects.
+
+### Syntax
+
+```bash
+scm show network layer3-subinterface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific subinterface | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Layer3 Subinterface
+
+```bash
+$ scm show network layer3-subinterface --folder Texas --name ethernet1/1.200
+---> 100%
+Layer3 Subinterface: ethernet1/1.200
+  Location: Folder 'Texas'
+  VLAN Tag: 200
+  Parent Interface: ethernet1/1
+  MTU: 1500
+  IP: 10.0.2.1/24
+```
+
+#### List All Layer3 Subinterfaces (Default Behavior)
+
+```bash
+$ scm show network layer3-subinterface --folder Texas
+---> 100%
+Layer3 subinterfaces in folder 'Texas':
+------------------------------------------------------------
+Name: ethernet1/1.200
+  VLAN Tag: 200
+  IP: 10.0.2.1/24
+------------------------------------------------------------
+Name: ethernet1/1.300
+  VLAN Tag: 300
+  IP: 10.0.3.1/24
+------------------------------------------------------------
+```
+
+## Backup Layer3 Subinterfaces
+
+Backup all layer3 subinterface objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network layer3-subinterface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network layer3-subinterface --folder Texas
+---> 100%
+Successfully backed up 8 layer3 subinterfaces to layer3_subinterface_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network layer3-subinterface --folder Texas --file texas-l3-subinterfaces.yaml
+---> 100%
+Successfully backed up 8 layer3 subinterfaces to texas-l3-subinterfaces.yaml
+```
+
+## Best Practices
+
+1. **Plan IP Addressing**: Assign subnet addresses consistently across layer3 subinterfaces to avoid overlap.
+2. **Set Appropriate MTU**: Configure MTU to account for VLAN encapsulation overhead when needed.
+3. **Use Consistent VLAN Tags**: Coordinate VLAN tag assignments with network switches and other devices.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing subinterface configurations before making bulk modifications.

--- a/docs/cli/network/loopback-interface.md
+++ b/docs/cli/network/loopback-interface.md
@@ -1,8 +1,22 @@
 # Loopback Interface
 
-Loopback interfaces are virtual interfaces used for management access, routing protocols, and NAT.
+Loopback interfaces are virtual interfaces used for management access, routing protocols, and NAT. The `scm` CLI provides commands to create, update, delete, and load loopback interfaces.
+
+## Overview
+
+The `loopback-interface` commands allow you to:
+
+- Create loopback interfaces with IP addressing
+- Update existing loopback interface configurations
+- Delete loopback interfaces that are no longer needed
+- Bulk import loopback interfaces from YAML files
+- Export loopback interfaces for backup or migration
 
 ## Set Loopback Interface
+
+Create or update a loopback interface.
+
+### Syntax
 
 ```bash
 scm set network loopback-interface NAME [OPTIONS]
@@ -13,9 +27,9 @@ scm set network loopback-interface NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Interface name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--comment TEXT` | Interface description | No |
 | `--default-value TEXT` | Default interface (e.g. loopback.1) | No |
 | `--mtu INT` | MTU (576-9216) | No |
@@ -24,20 +38,226 @@ scm set network loopback-interface NAME [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Create a Loopback Interface
 
 ```bash
 $ scm set network loopback-interface loopback.1 \
     --folder Texas \
     --ip-json '[{"name": "10.0.0.1/32"}]' \
     --comment "Management loopback"
+---> 100%
+Created loopback interface: loopback.1 in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create a Loopback with IPv6
 
 ```bash
-scm show network loopback-interface --folder Texas
-scm delete network loopback-interface loopback.1 --folder Texas
-scm load network loopback-interface --file loopbacks.yaml --folder Texas
-scm backup network loopback-interface --folder Texas
+$ scm set network loopback-interface loopback.2 \
+    --folder Texas \
+    --ip-json '[{"name": "10.0.0.2/32"}]' \
+    --ipv6-json '{"addresses": [{"name": "fd00::1/128"}]}' \
+    --comment "Dual-stack loopback"
+---> 100%
+Created loopback interface: loopback.2 in folder Texas
 ```
+
+## Delete Loopback Interface
+
+Delete a loopback interface from SCM.
+
+### Syntax
+
+```bash
+scm delete network loopback-interface NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Interface name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network loopback-interface loopback.1 --folder Texas
+---> 100%
+Deleted loopback interface: loopback.1 from folder Texas
+```
+
+## Load Loopback Interface
+
+Load multiple loopback interfaces from a YAML file.
+
+### Syntax
+
+```bash
+scm load network loopback-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+loopback_interfaces:
+  - name: loopback.1
+    folder: Texas
+    comment: "Management loopback"
+    ip:
+      - name: "10.0.0.1/32"
+
+  - name: loopback.2
+    folder: Texas
+    comment: "Routing protocol loopback"
+    ip:
+      - name: "10.0.0.2/32"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network loopback-interface --file loopbacks.yml
+---> 100%
+✓ Loaded loopback interface: loopback.1
+✓ Loaded loopback interface: loopback.2
+
+Successfully loaded 2 out of 2 loopback interfaces from 'loopbacks.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network loopback-interface --file loopbacks.yml --folder Austin
+---> 100%
+✓ Loaded loopback interface: loopback.1
+✓ Loaded loopback interface: loopback.2
+
+Successfully loaded 2 out of 2 loopback interfaces from 'loopbacks.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all loopback interfaces
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Loopback Interface
+
+Display loopback interface objects.
+
+### Syntax
+
+```bash
+scm show network loopback-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific interface | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Loopback Interface
+
+```bash
+$ scm show network loopback-interface --folder Texas --name loopback.1
+---> 100%
+Loopback Interface: loopback.1
+  Location: Folder 'Texas'
+  Comment: Management loopback
+  IP: 10.0.0.1/32
+```
+
+#### List All Loopback Interfaces (Default Behavior)
+
+```bash
+$ scm show network loopback-interface --folder Texas
+---> 100%
+Loopback interfaces in folder 'Texas':
+------------------------------------------------------------
+Name: loopback.1
+  Comment: Management loopback
+  IP: 10.0.0.1/32
+------------------------------------------------------------
+Name: loopback.2
+  Comment: Routing protocol loopback
+  IP: 10.0.0.2/32
+------------------------------------------------------------
+```
+
+## Backup Loopback Interfaces
+
+Backup all loopback interface objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network loopback-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network loopback-interface --folder Texas
+---> 100%
+Successfully backed up 4 loopback interfaces to loopback_interface_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network loopback-interface --folder Texas --file texas-loopbacks.yaml
+---> 100%
+Successfully backed up 4 loopback interfaces to texas-loopbacks.yaml
+```
+
+## Best Practices
+
+1. **Use /32 Addresses**: Assign /32 subnet masks to loopback interfaces as they represent a single host address.
+2. **Dedicate for Routing**: Use dedicated loopback interfaces for routing protocol peering (BGP, OSPF).
+3. **Add Descriptive Comments**: Document the purpose of each loopback interface for easier management.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing loopback configurations before making bulk modifications.

--- a/docs/cli/network/nat-rule.md
+++ b/docs/cli/network/nat-rule.md
@@ -1,8 +1,22 @@
 # NAT Rule
 
-NAT rules define network address translation policies for traffic flowing between zones.
+NAT rules define network address translation policies for traffic flowing between zones. The `scm` CLI provides commands to create, update, delete, and load NAT rules.
+
+## Overview
+
+The `nat-rule` commands allow you to:
+
+- Create NAT rules with source and destination translation
+- Update existing NAT rule configurations
+- Delete NAT rules that are no longer needed
+- Bulk import NAT rules from YAML files
+- Export NAT rules for backup or migration
 
 ## Set NAT Rule
+
+Create or update a NAT rule.
+
+### Syntax
 
 ```bash
 scm set network nat-rule [OPTIONS]
@@ -12,8 +26,8 @@ scm set network nat-rule [OPTIONS]
 
 | Option | Description | Required |
 | --- | --- | --- |
-| `--folder TEXT` | Folder location | Yes |
 | `--name TEXT` | Rule name | Yes |
+| `--folder TEXT` | Folder location | Yes |
 | `--description TEXT` | Rule description | No |
 | `--tag TEXT` | Tags | No |
 | `--disabled` | Disable the rule | No |
@@ -29,36 +43,246 @@ scm set network nat-rule [OPTIONS]
 
 ### Examples
 
-```bash
-# Create outbound NAT rule
-$ scm set network nat-rule --folder Texas --name outbound-nat \
-    --from-zone trust --to-zone untrust \
-    --source any --destination any \
-    --source-translation '{"dynamic_ip_and_port": {"type": "dynamic_ip_and_port", "translated_address": ["10.0.0.1"]}}'
+#### Create an Outbound NAT Rule
 
-# Create destination NAT rule
-$ scm set network nat-rule --folder Texas --name inbound-web \
-    --from-zone untrust --to-zone dmz \
-    --destination 203.0.113.10 \
-    --destination-translation '{"translated_address": "192.168.1.10", "translated_port": 443}'
+```bash
+$ scm set network nat-rule \
+    --folder Texas \
+    --name outbound-nat \
+    --from-zone trust \
+    --to-zone untrust \
+    --source any \
+    --destination any \
+    --source-translation '{"dynamic_ip_and_port": {"type": "dynamic_ip_and_port", "translated_address": ["10.0.0.1"]}}'
+---> 100%
+Created NAT rule: outbound-nat in folder Texas
 ```
 
-## Show NAT Rule
+#### Create a Destination NAT Rule
 
 ```bash
-scm show network nat-rule --folder Texas
-scm show network nat-rule --folder Texas --name outbound-nat
+$ scm set network nat-rule \
+    --folder Texas \
+    --name inbound-web \
+    --from-zone untrust \
+    --to-zone dmz \
+    --destination 203.0.113.10 \
+    --destination-translation '{"translated_address": "192.168.1.10", "translated_port": 443}'
+---> 100%
+Created NAT rule: inbound-web in folder Texas
 ```
 
 ## Delete NAT Rule
 
-```bash
-scm delete network nat-rule --folder Texas --name outbound-nat
-```
+Delete a NAT rule from SCM.
 
-## Load / Backup
+### Syntax
 
 ```bash
-scm load network nat-rule --file nat-rules.yaml --folder Texas
-scm backup network nat-rule --folder Texas
+scm delete network nat-rule [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Rule name | Yes |
+| `--folder TEXT` | Folder location | Yes |
+
+### Example
+
+```bash
+$ scm delete network nat-rule --folder Texas --name outbound-nat
+---> 100%
+Deleted NAT rule: outbound-nat from folder Texas
+```
+
+## Load NAT Rule
+
+Load multiple NAT rules from a YAML file.
+
+### Syntax
+
+```bash
+scm load network nat-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+nat_rules:
+  - name: outbound-nat
+    folder: Texas
+    from_zone:
+      - trust
+    to_zone:
+      - untrust
+    source:
+      - any
+    destination:
+      - any
+    source_translation:
+      dynamic_ip_and_port:
+        type: dynamic_ip_and_port
+        translated_address:
+          - "10.0.0.1"
+
+  - name: inbound-web
+    folder: Texas
+    from_zone:
+      - untrust
+    to_zone:
+      - dmz
+    destination:
+      - "203.0.113.10"
+    destination_translation:
+      translated_address: "192.168.1.10"
+      translated_port: 443
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network nat-rule --file nat-rules.yml
+---> 100%
+✓ Loaded NAT rule: outbound-nat
+✓ Loaded NAT rule: inbound-web
+
+Successfully loaded 2 out of 2 NAT rules from 'nat-rules.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network nat-rule --file nat-rules.yml --folder Austin
+---> 100%
+✓ Loaded NAT rule: outbound-nat
+✓ Loaded NAT rule: inbound-web
+
+Successfully loaded 2 out of 2 NAT rules from 'nat-rules.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all NAT rules
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show NAT Rule
+
+Display NAT rule objects.
+
+### Syntax
+
+```bash
+scm show network nat-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific rule | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific NAT Rule
+
+```bash
+$ scm show network nat-rule --folder Texas --name outbound-nat
+---> 100%
+NAT Rule: outbound-nat
+  Location: Folder 'Texas'
+  From Zone: trust
+  To Zone: untrust
+  Source: any
+  Destination: any
+  Source Translation: dynamic_ip_and_port (10.0.0.1)
+```
+
+#### List All NAT Rules (Default Behavior)
+
+```bash
+$ scm show network nat-rule --folder Texas
+---> 100%
+NAT rules in folder 'Texas':
+------------------------------------------------------------
+Name: outbound-nat
+  From: trust -> To: untrust
+  Type: Source Translation
+------------------------------------------------------------
+Name: inbound-web
+  From: untrust -> To: dmz
+  Type: Destination Translation
+------------------------------------------------------------
+```
+
+## Backup NAT Rules
+
+Backup all NAT rule objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network nat-rule [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network nat-rule --folder Texas
+---> 100%
+Successfully backed up 12 NAT rules to nat_rule_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network nat-rule --folder Texas --file texas-nat-rules.yaml
+---> 100%
+Successfully backed up 12 NAT rules to texas-nat-rules.yaml
+```
+
+## Best Practices
+
+1. **Order Rules Carefully**: NAT rules are evaluated in order; place more specific rules before general ones.
+2. **Use Descriptive Names**: Name NAT rules to clearly indicate the translation direction and purpose.
+3. **Specify Zones Explicitly**: Always define source and destination zones to limit NAT rule scope.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing NAT rules before making bulk modifications.
+6. **Avoid Overlapping Rules**: Ensure NAT rules do not conflict with each other to prevent unexpected translations.

--- a/docs/cli/network/ospf-auth-profile.md
+++ b/docs/cli/network/ospf-auth-profile.md
@@ -1,8 +1,22 @@
 # OSPF Auth Profile
 
-OSPF auth profiles define authentication settings for OSPF neighbor relationships, supporting simple password and MD5 authentication.
+OSPF auth profiles define authentication settings for OSPF neighbor relationships, supporting simple password and MD5 authentication. The `scm` CLI provides commands to create, update, delete, and load OSPF auth profiles.
+
+## Overview
+
+The `ospf-auth-profile` commands allow you to:
+
+- Create OSPF auth profiles with password or MD5 authentication
+- Update existing OSPF auth profile configurations
+- Delete OSPF auth profiles that are no longer needed
+- Bulk import OSPF auth profiles from YAML files
+- Export OSPF auth profiles for backup or migration
 
 ## Set OSPF Auth Profile
+
+Create or update an OSPF auth profile.
+
+### Syntax
 
 ```bash
 scm set network ospf-auth-profile NAME [OPTIONS]
@@ -13,31 +27,226 @@ scm set network ospf-auth-profile NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Profile name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--password TEXT` | Simple password authentication | No |
 | `--md5-json TEXT` | MD5 authentication keys as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create with Simple Password Authentication
+
+```bash
+$ scm set network ospf-auth-profile my-ospf-auth \
+    --folder Texas \
+    --password "ospf-secret"
+---> 100%
+Created OSPF auth profile: my-ospf-auth in folder Texas
+```
+
+#### Create with MD5 Authentication
+
+```bash
+$ scm set network ospf-auth-profile my-ospf-md5 \
+    --folder Texas \
+    --md5-json '[{"key_id": 1, "key": "md5-key"}]'
+---> 100%
+Created OSPF auth profile: my-ospf-md5 in folder Texas
+```
+
+## Delete OSPF Auth Profile
+
+Delete an OSPF auth profile from SCM.
+
+### Syntax
+
+```bash
+scm delete network ospf-auth-profile NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Profile name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network ospf-auth-profile my-ospf-auth \
-    --folder Texas \
-    --password "ospf-secret"
-
-$ scm set network ospf-auth-profile my-ospf-md5 \
-    --folder Texas \
-    --md5-json '[{"key_id": 1, "key": "md5-key"}]'
+$ scm delete network ospf-auth-profile my-ospf-auth --folder Texas
+---> 100%
+Deleted OSPF auth profile: my-ospf-auth from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load OSPF Auth Profile
+
+Load multiple OSPF auth profiles from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network ospf-auth-profile --folder Texas
-scm delete network ospf-auth-profile my-ospf-auth --folder Texas
-scm load network ospf-auth-profile --file ospf-auth.yaml --folder Texas
-scm backup network ospf-auth-profile --folder Texas
+scm load network ospf-auth-profile [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+ospf_auth_profiles:
+  - name: simple-auth
+    folder: Texas
+    password: "ospf-secret"
+
+  - name: md5-auth
+    folder: Texas
+    md5:
+      - key_id: 1
+        key: "md5-key-1"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network ospf-auth-profile --file ospf-auth.yml
+---> 100%
+✓ Loaded OSPF auth profile: simple-auth
+✓ Loaded OSPF auth profile: md5-auth
+
+Successfully loaded 2 out of 2 OSPF auth profiles from 'ospf-auth.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network ospf-auth-profile --file ospf-auth.yml --folder Austin
+---> 100%
+✓ Loaded OSPF auth profile: simple-auth
+✓ Loaded OSPF auth profile: md5-auth
+
+Successfully loaded 2 out of 2 OSPF auth profiles from 'ospf-auth.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all OSPF auth profiles
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show OSPF Auth Profile
+
+Display OSPF auth profile objects.
+
+### Syntax
+
+```bash
+scm show network ospf-auth-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific profile | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific OSPF Auth Profile
+
+```bash
+$ scm show network ospf-auth-profile --folder Texas --name my-ospf-auth
+---> 100%
+OSPF Auth Profile: my-ospf-auth
+  Location: Folder 'Texas'
+  Authentication: Simple Password
+```
+
+#### List All OSPF Auth Profiles (Default Behavior)
+
+```bash
+$ scm show network ospf-auth-profile --folder Texas
+---> 100%
+OSPF auth profiles in folder 'Texas':
+------------------------------------------------------------
+Name: simple-auth
+  Authentication: Simple Password
+------------------------------------------------------------
+Name: md5-auth
+  Authentication: MD5
+------------------------------------------------------------
+```
+
+## Backup OSPF Auth Profiles
+
+Backup all OSPF auth profile objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network ospf-auth-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network ospf-auth-profile --folder Texas
+---> 100%
+Successfully backed up 3 OSPF auth profiles to ospf_auth_profile_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network ospf-auth-profile --folder Texas --file texas-ospf-auth.yaml
+---> 100%
+Successfully backed up 3 OSPF auth profiles to texas-ospf-auth.yaml
+```
+
+## Best Practices
+
+1. **Prefer MD5 Over Simple Password**: MD5 authentication provides stronger security than simple password authentication.
+2. **Rotate Keys Regularly**: Update OSPF authentication keys periodically as part of security hygiene.
+3. **Coordinate Key Changes**: Ensure all OSPF neighbors are updated simultaneously when rotating authentication keys.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing auth profiles before making bulk modifications.

--- a/docs/cli/network/route-access-list.md
+++ b/docs/cli/network/route-access-list.md
@@ -1,8 +1,22 @@
 # Route Access List
 
-Route access lists filter routes based on network prefixes for use with routing protocols.
+Route access lists filter routes based on network prefixes for use with routing protocols. The `scm` CLI provides commands to create, update, delete, and load route access lists.
+
+## Overview
+
+The `route-access-list` commands allow you to:
+
+- Create route access lists with prefix-based filtering rules
+- Update existing route access list configurations
+- Delete route access lists that are no longer needed
+- Bulk import route access lists from YAML files
+- Export route access lists for backup or migration
 
 ## Set Route Access List
+
+Create or update a route access list.
+
+### Syntax
 
 ```bash
 scm set network route-access-list NAME [OPTIONS]
@@ -13,27 +27,239 @@ scm set network route-access-list NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Access list name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--description TEXT` | Description | No |
 | `--type-json TEXT` | Access list type config as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create a Route Access List with Permit
+
+```bash
+$ scm set network route-access-list my-acl \
+    --folder Texas \
+    --type-json '{"prefix": [{"name": 1, "network": "10.0.0.0/8", "action": "permit"}]}'
+---> 100%
+Created route access list: my-acl in folder Texas
+```
+
+#### Create a Route Access List with Multiple Entries
+
+```bash
+$ scm set network route-access-list multi-acl \
+    --folder Texas \
+    --type-json '{"prefix": [{"name": 1, "network": "10.0.0.0/8", "action": "permit"}, {"name": 2, "network": "172.16.0.0/12", "action": "deny"}]}'
+---> 100%
+Created route access list: multi-acl in folder Texas
+```
+
+## Delete Route Access List
+
+Delete a route access list from SCM.
+
+### Syntax
+
+```bash
+scm delete network route-access-list NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Access list name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network route-access-list my-acl \
-    --folder Texas \
-    --type-json '{"prefix": [{"name": 1, "network": "10.0.0.0/8", "action": "permit"}]}'
+$ scm delete network route-access-list my-acl --folder Texas
+---> 100%
+Deleted route access list: my-acl from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load Route Access List
+
+Load multiple route access lists from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network route-access-list --folder Texas
-scm delete network route-access-list my-acl --folder Texas
-scm load network route-access-list --file access-lists.yaml --folder Texas
-scm backup network route-access-list --folder Texas
+scm load network route-access-list [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+route_access_lists:
+  - name: internal-acl
+    folder: Texas
+    type:
+      prefix:
+        - name: 1
+          network: "10.0.0.0/8"
+          action: permit
+
+  - name: rfc1918-acl
+    folder: Texas
+    type:
+      prefix:
+        - name: 1
+          network: "10.0.0.0/8"
+          action: permit
+        - name: 2
+          network: "172.16.0.0/12"
+          action: permit
+        - name: 3
+          network: "192.168.0.0/16"
+          action: permit
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network route-access-list --file access-lists.yml
+---> 100%
+✓ Loaded route access list: internal-acl
+✓ Loaded route access list: rfc1918-acl
+
+Successfully loaded 2 out of 2 route access lists from 'access-lists.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network route-access-list --file access-lists.yml --folder Austin
+---> 100%
+✓ Loaded route access list: internal-acl
+✓ Loaded route access list: rfc1918-acl
+
+Successfully loaded 2 out of 2 route access lists from 'access-lists.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all route access lists
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Route Access List
+
+Display route access list objects.
+
+### Syntax
+
+```bash
+scm show network route-access-list [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific access list | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Route Access List
+
+```bash
+$ scm show network route-access-list --folder Texas --name my-acl
+---> 100%
+Route Access List: my-acl
+  Location: Folder 'Texas'
+  Entries:
+    1: 10.0.0.0/8 (permit)
+```
+
+#### List All Route Access Lists (Default Behavior)
+
+```bash
+$ scm show network route-access-list --folder Texas
+---> 100%
+Route access lists in folder 'Texas':
+------------------------------------------------------------
+Name: internal-acl
+  Entries: 1
+------------------------------------------------------------
+Name: rfc1918-acl
+  Entries: 3
+------------------------------------------------------------
+```
+
+## Backup Route Access Lists
+
+Backup all route access list objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network route-access-list [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network route-access-list --folder Texas
+---> 100%
+Successfully backed up 5 route access lists to route_access_list_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network route-access-list --folder Texas --file texas-access-lists.yaml
+---> 100%
+Successfully backed up 5 route access lists to texas-access-lists.yaml
+```
+
+## Best Practices
+
+1. **Order Entries Logically**: Number entries sequentially and place more specific prefixes before broader ones.
+2. **Use Implicit Deny**: Remember that access lists have an implicit deny at the end; only permitted prefixes pass.
+3. **Document Purpose**: Use descriptive names that indicate what the access list filters.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing access lists before making bulk modifications.

--- a/docs/cli/network/route-prefix-list.md
+++ b/docs/cli/network/route-prefix-list.md
@@ -1,8 +1,22 @@
 # Route Prefix List
 
-Route prefix lists filter routes based on IP prefixes with optional length matching, used with BGP and OSPF route maps.
+Route prefix lists filter routes based on IP prefixes with optional length matching, used with BGP and OSPF route maps. The `scm` CLI provides commands to create, update, delete, and load route prefix lists.
+
+## Overview
+
+The `route-prefix-list` commands allow you to:
+
+- Create route prefix lists with prefix matching and length constraints
+- Update existing route prefix list configurations
+- Delete route prefix lists that are no longer needed
+- Bulk import route prefix lists from YAML files
+- Export route prefix lists for backup or migration
 
 ## Set Route Prefix List
+
+Create or update a route prefix list.
+
+### Syntax
 
 ```bash
 scm set network route-prefix-list NAME [OPTIONS]
@@ -13,27 +27,233 @@ scm set network route-prefix-list NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Prefix list name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--description TEXT` | Description | No |
 | `--ipv4-json TEXT` | IPv4 prefix list config as JSON | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create a Prefix List with Length Matching
+
+```bash
+$ scm set network route-prefix-list my-prefix-list \
+    --folder Texas \
+    --ipv4-json '[{"name": "rule1", "prefix": "10.0.0.0/8", "action": "permit", "ge": 16, "le": 24}]'
+---> 100%
+Created route prefix list: my-prefix-list in folder Texas
+```
+
+#### Create a Simple Prefix List
+
+```bash
+$ scm set network route-prefix-list default-only \
+    --folder Texas \
+    --ipv4-json '[{"name": "rule1", "prefix": "0.0.0.0/0", "action": "permit"}]'
+---> 100%
+Created route prefix list: default-only in folder Texas
+```
+
+## Delete Route Prefix List
+
+Delete a route prefix list from SCM.
+
+### Syntax
+
+```bash
+scm delete network route-prefix-list NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Prefix list name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm set network route-prefix-list my-prefix-list \
-    --folder Texas \
-    --ipv4-json '[{"name": "rule1", "prefix": "10.0.0.0/8", "action": "permit", "ge": 16, "le": 24}]'
+$ scm delete network route-prefix-list my-prefix-list --folder Texas
+---> 100%
+Deleted route prefix list: my-prefix-list from folder Texas
 ```
 
-## Show / Delete / Load / Backup
+## Load Route Prefix List
+
+Load multiple route prefix lists from a YAML file.
+
+### Syntax
 
 ```bash
-scm show network route-prefix-list --folder Texas
-scm delete network route-prefix-list my-prefix-list --folder Texas
-scm load network route-prefix-list --file prefix-lists.yaml --folder Texas
-scm backup network route-prefix-list --folder Texas
+scm load network route-prefix-list [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+route_prefix_lists:
+  - name: internal-prefixes
+    folder: Texas
+    ipv4:
+      - name: "rule1"
+        prefix: "10.0.0.0/8"
+        action: permit
+        ge: 16
+        le: 24
+
+  - name: default-route
+    folder: Texas
+    ipv4:
+      - name: "rule1"
+        prefix: "0.0.0.0/0"
+        action: permit
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network route-prefix-list --file prefix-lists.yml
+---> 100%
+✓ Loaded route prefix list: internal-prefixes
+✓ Loaded route prefix list: default-route
+
+Successfully loaded 2 out of 2 route prefix lists from 'prefix-lists.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network route-prefix-list --file prefix-lists.yml --folder Austin
+---> 100%
+✓ Loaded route prefix list: internal-prefixes
+✓ Loaded route prefix list: default-route
+
+Successfully loaded 2 out of 2 route prefix lists from 'prefix-lists.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all route prefix lists
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Route Prefix List
+
+Display route prefix list objects.
+
+### Syntax
+
+```bash
+scm show network route-prefix-list [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific prefix list | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Route Prefix List
+
+```bash
+$ scm show network route-prefix-list --folder Texas --name my-prefix-list
+---> 100%
+Route Prefix List: my-prefix-list
+  Location: Folder 'Texas'
+  Entries:
+    rule1: 10.0.0.0/8 (permit, ge: 16, le: 24)
+```
+
+#### List All Route Prefix Lists (Default Behavior)
+
+```bash
+$ scm show network route-prefix-list --folder Texas
+---> 100%
+Route prefix lists in folder 'Texas':
+------------------------------------------------------------
+Name: internal-prefixes
+  Entries: 1
+------------------------------------------------------------
+Name: default-route
+  Entries: 1
+------------------------------------------------------------
+```
+
+## Backup Route Prefix Lists
+
+Backup all route prefix list objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network route-prefix-list [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network route-prefix-list --folder Texas
+---> 100%
+Successfully backed up 4 route prefix lists to route_prefix_list_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network route-prefix-list --folder Texas --file texas-prefix-lists.yaml
+---> 100%
+Successfully backed up 4 route prefix lists to texas-prefix-lists.yaml
+```
+
+## Best Practices
+
+1. **Use ge/le for Flexibility**: Use greater-than-or-equal (ge) and less-than-or-equal (le) modifiers to match a range of prefix lengths.
+2. **Order Rules Carefully**: Prefix list entries are evaluated in order; place more specific matches first.
+3. **Document Prefix Purposes**: Use descriptive names that indicate what prefixes the list matches.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing prefix lists before making bulk modifications.

--- a/docs/cli/network/security-zone.md
+++ b/docs/cli/network/security-zone.md
@@ -1,6 +1,25 @@
-# Security Zones
+# Security Zone
 
 Security zones are logical divisions of the network that define boundaries for traffic control and enforce security policies. The `scm` CLI provides commands to create, update, delete, and load security zones.
+
+## Overview
+
+The `security-zone` commands allow you to:
+
+- Create security zones with layer3, layer2, virtual-wire, or TAP mode
+- Update existing security zone configurations
+- Delete security zones that are no longer needed
+- Bulk import security zones from YAML files
+- Export security zones for backup or migration
+
+## Zone Modes
+
+| Mode | Description |
+| --- | --- |
+| `layer3` | Standard routed mode with IP addressing |
+| `layer2` | Switched mode for bridging traffic |
+| `virtual-wire` | Transparent inline mode between two interfaces |
+| `tap` | Passive monitoring mode for traffic analysis |
 
 ## Set Security Zone
 
@@ -14,38 +33,47 @@ scm set network security-zone [OPTIONS]
 
 ### Options
 
-| Option                        | Description                                              | Required |
-| ----------------------------- | -------------------------------------------------------- | -------- |
-| `--folder TEXT`               | Folder for the security zone                             | Yes      |
-| `--name TEXT`                 | Name of the security zone                                | Yes      |
-| `--description TEXT`          | Description for the security zone                        | No       |
-| `--tags LIST`                 | List of tags to apply to the security zone               | No       |
-| `--mode TEXT`                 | Zone protection mode (layer3, layer2, virtual-wire, tap) | Yes      |
-| `--enable-user-id BOOLEAN`    | Enable User-ID for this zone                             | No       |
-| `--exclude-local-pan BOOLEAN` | Exclude local Panorama from User-ID distribution         | No       |
-| `--log-setting TEXT`          | Log forwarding profile                                   | No       |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the security zone | Yes |
+| `--folder TEXT` | Folder location | Yes |
+| `--mode TEXT` | Zone protection mode (layer3, layer2, virtual-wire, tap) | Yes |
+| `--description TEXT` | Description for the security zone | No |
+| `--tags LIST` | List of tags to apply | No |
+| `--enable-user-id BOOLEAN` | Enable User-ID for this zone | No |
+| `--exclude-local-pan BOOLEAN` | Exclude local Panorama from User-ID distribution | No |
+| `--log-setting TEXT` | Log forwarding profile | No |
 
 ### Examples
 
-#### Create a Layer 3 Security Zone
+#### Create a Layer3 Security Zone
 
 ```bash
-$ scm set network security-zone --folder Shared --name Trust --mode layer3 --enable-user-id true --description "Internal trusted network zone"
-Creating security zone 'Trust' in folder 'Shared'...
-Security zone created successfully.
+$ scm set network security-zone \
+    --folder Shared \
+    --name Trust \
+    --mode layer3 \
+    --enable-user-id true \
+    --description "Internal trusted network zone"
+---> 100%
+Created security zone: Trust in folder Shared
 ```
 
 #### Create a Virtual-Wire Security Zone
 
 ```bash
-$ scm set network security-zone --folder Shared --name DMZ --mode virtual-wire --description "DMZ between trusted and untrusted networks"
-Creating security zone 'DMZ' in folder 'Shared'...
-Security zone created successfully.
+$ scm set network security-zone \
+    --folder Shared \
+    --name DMZ \
+    --mode virtual-wire \
+    --description "DMZ between trusted and untrusted networks"
+---> 100%
+Created security zone: DMZ in folder Shared
 ```
 
 ## Delete Security Zone
 
-Delete a security zone.
+Delete a security zone from SCM.
 
 ### Syntax
 
@@ -55,22 +83,22 @@ scm delete network security-zone [OPTIONS]
 
 ### Options
 
-| Option          | Description                         | Required |
-| --------------- | ----------------------------------- | -------- |
-| `--folder TEXT` | Folder containing the security zone | Yes      |
-| `--name TEXT`   | Name of the security zone to delete | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the security zone to delete | Yes |
+| `--folder TEXT` | Folder location | Yes |
 
 ### Example
 
 ```bash
 $ scm delete network security-zone --folder Shared --name DMZ
-Deleting security zone 'DMZ' from folder 'Shared'...
-Security zone deleted successfully.
+---> 100%
+Deleted security zone: DMZ from folder Shared
 ```
 
-## Load Security Zones
+## Load Security Zone
 
-Create or update multiple security zones from a YAML file.
+Load multiple security zones from a YAML file.
 
 ### Syntax
 
@@ -80,16 +108,23 @@ scm load network security-zone [OPTIONS]
 
 ### Options
 
-| Option          | Description                                            | Required |
-| --------------- | ------------------------------------------------------ | -------- |
-| `--folder TEXT` | Folder for the security zones                          | Yes      |
-| `--file TEXT`   | Path to YAML file containing security zone definitions | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing security zone definitions | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
 
-### Example YAML File
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
 
 ```yaml
+---
 security_zones:
   - name: Trust
+    folder: Shared
     description: "Internal trusted network zone"
     mode: layer3
     enable_user_id: true
@@ -98,6 +133,7 @@ security_zones:
       - trusted
 
   - name: Untrust
+    folder: Shared
     description: "External untrusted network zone"
     mode: layer3
     enable_user_id: false
@@ -106,6 +142,7 @@ security_zones:
       - untrusted
 
   - name: DMZ
+    folder: Shared
     description: "DMZ between trusted and untrusted networks"
     mode: virtual-wire
     enable_user_id: true
@@ -113,39 +150,141 @@ security_zones:
       - dmz
 ```
 
-### Example Command
+### Examples
+
+#### Load with Original Locations
 
 ```bash
-$ scm load network security-zone --folder Shared --file security-zones.yaml
-Loading security zones from 'security-zones.yaml' into folder 'Shared'...
-Created 3 security zones successfully.
+$ scm load network security-zone --file security-zones.yml
+---> 100%
+✓ Loaded security zone: Trust
+✓ Loaded security zone: Untrust
+✓ Loaded security zone: DMZ
+
+Successfully loaded 3 out of 3 security zones from 'security-zones.yml'
 ```
 
-## List Security Zones
+#### Load with Folder Override
 
-List all security zones in a folder.
+```bash
+$ scm load network security-zone --file security-zones.yml --folder Austin
+---> 100%
+✓ Loaded security zone: Trust
+✓ Loaded security zone: Untrust
+✓ Loaded security zone: DMZ
+
+Successfully loaded 3 out of 3 security zones from 'security-zones.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all security zones
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Security Zone
+
+Display security zone objects.
 
 ### Syntax
 
 ```bash
-scm set network security-zone --list [OPTIONS]
+scm show network security-zone [OPTIONS]
 ```
 
 ### Options
 
-| Option          | Description                        | Required |
-| --------------- | ---------------------------------- | -------- |
-| `--folder TEXT` | Folder to list security zones from | Yes      |
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific security zone | No |
 
-### Example
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Security Zone
 
 ```bash
-$ scm set network security-zone --list --folder Shared
-Listing security zones in folder 'Shared'...
-
-| Name    | Mode       | Description                        | User-ID | Tags                |
-|---------|------------|------------------------------------|---------|--------------------|
-| Trust   | layer3     | Internal trusted network zone      | Enabled | internal, trusted  |
-| Untrust | layer3     | External untrusted network zone    | Disabled| external, untrusted|
-| DMZ     | virtual-wire | DMZ between networks              | Enabled | dmz                |
+$ scm show network security-zone --folder Shared --name Trust
+---> 100%
+Security Zone: Trust
+  Location: Folder 'Shared'
+  Mode: layer3
+  Description: Internal trusted network zone
+  User-ID: enabled
+  Tags: internal, trusted
 ```
+
+#### List All Security Zones (Default Behavior)
+
+```bash
+$ scm show network security-zone --folder Shared
+---> 100%
+Security zones in folder 'Shared':
+------------------------------------------------------------
+Name: Trust
+  Mode: layer3
+  User-ID: enabled
+------------------------------------------------------------
+Name: Untrust
+  Mode: layer3
+  User-ID: disabled
+------------------------------------------------------------
+Name: DMZ
+  Mode: virtual-wire
+  User-ID: enabled
+------------------------------------------------------------
+```
+
+## Backup Security Zones
+
+Backup all security zone objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network security-zone [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network security-zone --folder Shared
+---> 100%
+Successfully backed up 5 security zones to security_zone_folder_shared_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network security-zone --folder Shared --file shared-zones.yaml
+---> 100%
+Successfully backed up 5 security zones to shared-zones.yaml
+```
+
+## Best Practices
+
+1. **Use Descriptive Names**: Name zones clearly to indicate their security posture (Trust, Untrust, DMZ).
+2. **Enable User-ID Selectively**: Only enable User-ID on zones where user identification is needed for policy enforcement.
+3. **Choose Appropriate Mode**: Select the zone mode (layer3, layer2, virtual-wire, tap) that matches your network topology.
+4. **Apply Tags for Organization**: Use tags to categorize and organize security zones for easier management.
+5. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+6. **Backup Before Changes**: Always backup existing security zone configurations before making bulk modifications.

--- a/docs/cli/network/tunnel-interface.md
+++ b/docs/cli/network/tunnel-interface.md
@@ -1,8 +1,22 @@
 # Tunnel Interface
 
-Tunnel interfaces are virtual interfaces used for VPN tunnels and encapsulation.
+Tunnel interfaces are virtual interfaces used for VPN tunnels and encapsulation. The `scm` CLI provides commands to create, update, delete, and load tunnel interfaces.
+
+## Overview
+
+The `tunnel-interface` commands allow you to:
+
+- Create tunnel interfaces with IP addressing
+- Update existing tunnel interface configurations
+- Delete tunnel interfaces that are no longer needed
+- Bulk import tunnel interfaces from YAML files
+- Export tunnel interfaces for backup or migration
 
 ## Set Tunnel Interface
+
+Create or update a tunnel interface.
+
+### Syntax
 
 ```bash
 scm set network tunnel-interface NAME [OPTIONS]
@@ -13,9 +27,9 @@ scm set network tunnel-interface NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Interface name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--comment TEXT` | Interface description | No |
 | `--default-value TEXT` | Default interface (e.g. tunnel.1) | No |
 | `--mtu INT` | MTU (576-9216) | No |
@@ -23,20 +37,227 @@ scm set network tunnel-interface NAME [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Create a Tunnel Interface
 
 ```bash
 $ scm set network tunnel-interface tunnel.1 \
     --folder Texas \
     --ip-json '[{"name": "10.0.0.1/30"}]' \
     --comment "VPN tunnel"
+---> 100%
+Created tunnel interface: tunnel.1 in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create a Tunnel Interface with Custom MTU
 
 ```bash
-scm show network tunnel-interface --folder Texas
-scm delete network tunnel-interface tunnel.1 --folder Texas
-scm load network tunnel-interface --file tunnels.yaml --folder Texas
-scm backup network tunnel-interface --folder Texas
+$ scm set network tunnel-interface tunnel.2 \
+    --folder Texas \
+    --ip-json '[{"name": "10.0.0.5/30"}]' \
+    --mtu 1400 \
+    --comment "Site-to-site VPN"
+---> 100%
+Created tunnel interface: tunnel.2 in folder Texas
 ```
+
+## Delete Tunnel Interface
+
+Delete a tunnel interface from SCM.
+
+### Syntax
+
+```bash
+scm delete network tunnel-interface NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Interface name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network tunnel-interface tunnel.1 --folder Texas
+---> 100%
+Deleted tunnel interface: tunnel.1 from folder Texas
+```
+
+## Load Tunnel Interface
+
+Load multiple tunnel interfaces from a YAML file.
+
+### Syntax
+
+```bash
+scm load network tunnel-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+tunnel_interfaces:
+  - name: tunnel.1
+    folder: Texas
+    comment: "VPN tunnel to site A"
+    ip:
+      - name: "10.0.0.1/30"
+
+  - name: tunnel.2
+    folder: Texas
+    comment: "VPN tunnel to site B"
+    mtu: 1400
+    ip:
+      - name: "10.0.0.5/30"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network tunnel-interface --file tunnels.yml
+---> 100%
+✓ Loaded tunnel interface: tunnel.1
+✓ Loaded tunnel interface: tunnel.2
+
+Successfully loaded 2 out of 2 tunnel interfaces from 'tunnels.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network tunnel-interface --file tunnels.yml --folder Austin
+---> 100%
+✓ Loaded tunnel interface: tunnel.1
+✓ Loaded tunnel interface: tunnel.2
+
+Successfully loaded 2 out of 2 tunnel interfaces from 'tunnels.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all tunnel interfaces
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show Tunnel Interface
+
+Display tunnel interface objects.
+
+### Syntax
+
+```bash
+scm show network tunnel-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific interface | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Tunnel Interface
+
+```bash
+$ scm show network tunnel-interface --folder Texas --name tunnel.1
+---> 100%
+Tunnel Interface: tunnel.1
+  Location: Folder 'Texas'
+  Comment: VPN tunnel
+  IP: 10.0.0.1/30
+```
+
+#### List All Tunnel Interfaces (Default Behavior)
+
+```bash
+$ scm show network tunnel-interface --folder Texas
+---> 100%
+Tunnel interfaces in folder 'Texas':
+------------------------------------------------------------
+Name: tunnel.1
+  Comment: VPN tunnel
+  IP: 10.0.0.1/30
+------------------------------------------------------------
+Name: tunnel.2
+  Comment: Site-to-site VPN
+  IP: 10.0.0.5/30
+------------------------------------------------------------
+```
+
+## Backup Tunnel Interfaces
+
+Backup all tunnel interface objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network tunnel-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network tunnel-interface --folder Texas
+---> 100%
+Successfully backed up 6 tunnel interfaces to tunnel_interface_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network tunnel-interface --folder Texas --file texas-tunnels.yaml
+---> 100%
+Successfully backed up 6 tunnel interfaces to texas-tunnels.yaml
+```
+
+## Best Practices
+
+1. **Use /30 Subnets**: Assign /30 subnets for point-to-point tunnel interfaces to conserve IP addresses.
+2. **Set Appropriate MTU**: Reduce MTU below the physical interface to account for tunnel encapsulation overhead.
+3. **Add Descriptive Comments**: Document which VPN or site each tunnel interface connects to.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing tunnel configurations before making bulk modifications.

--- a/docs/cli/network/vlan-interface.md
+++ b/docs/cli/network/vlan-interface.md
@@ -1,8 +1,22 @@
 # VLAN Interface
 
-VLAN interfaces are virtual interfaces associated with VLAN tags for inter-VLAN routing.
+VLAN interfaces are virtual interfaces associated with VLAN tags for inter-VLAN routing. The `scm` CLI provides commands to create, update, delete, and load VLAN interfaces.
+
+## Overview
+
+The `vlan-interface` commands allow you to:
+
+- Create VLAN interfaces with IP addressing and VLAN tags
+- Update existing VLAN interface configurations
+- Delete VLAN interfaces that are no longer needed
+- Bulk import VLAN interfaces from YAML files
+- Export VLAN interfaces for backup or migration
 
 ## Set VLAN Interface
+
+Create or update a VLAN interface.
+
+### Syntax
 
 ```bash
 scm set network vlan-interface NAME [OPTIONS]
@@ -13,9 +27,9 @@ scm set network vlan-interface NAME [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `NAME` | Interface name (positional) | Yes |
-| `--folder TEXT` | Folder location | No* |
-| `--snippet TEXT` | Snippet location | No* |
-| `--device TEXT` | Device location | No* |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
 | `--comment TEXT` | Interface description | No |
 | `--default-value TEXT` | Default interface (e.g. vlan.100) | No |
 | `--vlan-tag TEXT` | VLAN tag (1-4096) | No |
@@ -25,7 +39,9 @@ scm set network vlan-interface NAME [OPTIONS]
 
 \* One of --folder, --snippet, or --device is required.
 
-### Example
+### Examples
+
+#### Create a VLAN Interface with Static IP
 
 ```bash
 $ scm set network vlan-interface vlan.100 \
@@ -33,13 +49,220 @@ $ scm set network vlan-interface vlan.100 \
     --vlan-tag 100 \
     --ip-json '[{"name": "10.0.100.1/24"}]' \
     --comment "VLAN 100 gateway"
+---> 100%
+Created VLAN interface: vlan.100 in folder Texas
 ```
 
-## Show / Delete / Load / Backup
+#### Create a VLAN Interface with DHCP
 
 ```bash
-scm show network vlan-interface --folder Texas
-scm delete network vlan-interface vlan.100 --folder Texas
-scm load network vlan-interface --file vlans.yaml --folder Texas
-scm backup network vlan-interface --folder Texas
+$ scm set network vlan-interface vlan.200 \
+    --folder Texas \
+    --vlan-tag 200 \
+    --dhcp-client-json '{"enable": true}' \
+    --comment "DHCP-assigned VLAN"
+---> 100%
+Created VLAN interface: vlan.200 in folder Texas
 ```
+
+## Delete VLAN Interface
+
+Delete a VLAN interface from SCM.
+
+### Syntax
+
+```bash
+scm delete network vlan-interface NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Interface name (positional) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete network vlan-interface vlan.100 --folder Texas
+---> 100%
+Deleted VLAN interface: vlan.100 from folder Texas
+```
+
+## Load VLAN Interface
+
+Load multiple VLAN interfaces from a YAML file.
+
+### Syntax
+
+```bash
+scm load network vlan-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--dry-run` | Preview changes without applying | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### YAML File Format
+
+```yaml
+---
+vlan_interfaces:
+  - name: vlan.100
+    folder: Texas
+    vlan_tag: 100
+    comment: "VLAN 100 gateway"
+    ip:
+      - name: "10.0.100.1/24"
+
+  - name: vlan.200
+    folder: Texas
+    vlan_tag: 200
+    comment: "VLAN 200 gateway"
+    ip:
+      - name: "10.0.200.1/24"
+```
+
+### Examples
+
+#### Load with Original Locations
+
+```bash
+$ scm load network vlan-interface --file vlans.yml
+---> 100%
+✓ Loaded VLAN interface: vlan.100
+✓ Loaded VLAN interface: vlan.200
+
+Successfully loaded 2 out of 2 VLAN interfaces from 'vlans.yml'
+```
+
+#### Load with Folder Override
+
+```bash
+$ scm load network vlan-interface --file vlans.yml --folder Austin
+---> 100%
+✓ Loaded VLAN interface: vlan.100
+✓ Loaded VLAN interface: vlan.200
+
+Successfully loaded 2 out of 2 VLAN interfaces from 'vlans.yml'
+```
+
+!!! note
+    When using container override options (--folder, --snippet, --device), all VLAN interfaces
+    will be loaded into the specified container, ignoring the container specified in the
+    YAML file.
+
+## Show VLAN Interface
+
+Display VLAN interface objects.
+
+### Syntax
+
+```bash
+scm show network vlan-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific interface | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific VLAN Interface
+
+```bash
+$ scm show network vlan-interface --folder Texas --name vlan.100
+---> 100%
+VLAN Interface: vlan.100
+  Location: Folder 'Texas'
+  VLAN Tag: 100
+  Comment: VLAN 100 gateway
+  IP: 10.0.100.1/24
+```
+
+#### List All VLAN Interfaces (Default Behavior)
+
+```bash
+$ scm show network vlan-interface --folder Texas
+---> 100%
+VLAN interfaces in folder 'Texas':
+------------------------------------------------------------
+Name: vlan.100
+  VLAN Tag: 100
+  IP: 10.0.100.1/24
+------------------------------------------------------------
+Name: vlan.200
+  VLAN Tag: 200
+  IP: 10.0.200.1/24
+------------------------------------------------------------
+```
+
+## Backup VLAN Interfaces
+
+Backup all VLAN interface objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup network vlan-interface [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--file TEXT` | Custom output filename | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup network vlan-interface --folder Texas
+---> 100%
+Successfully backed up 8 VLAN interfaces to vlan_interface_folder_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup network vlan-interface --folder Texas --file texas-vlans.yaml
+---> 100%
+Successfully backed up 8 VLAN interfaces to texas-vlans.yaml
+```
+
+## Best Practices
+
+1. **Match VLAN Tags to Network Design**: Ensure VLAN tags align with your switch and network infrastructure configuration.
+2. **Use Consistent IP Schemes**: Assign IP addresses following a pattern (e.g., x.x.VLAN_ID.1/24) for easier management.
+3. **Add Descriptive Comments**: Document the purpose of each VLAN interface for easier troubleshooting.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing VLAN configurations before making bulk modifications.


### PR DESCRIPTION
## Summary
- Rewrote all 22 network CLI reference pages to conform to the docs-style skill template
- Expanded collapsed "Show / Delete / Load / Backup" sections into individual H2 sections with full Syntax, Options, and Examples subsections
- Added Overview, YAML File Format, Best Practices sections to every page
- Standardized output formatting (---> 100%, Unicode checkmarks, consistent success messages)
- Added container override admonitions in Load sections and "no --name = list all" notes in Show sections

Closes #115

## Test plan
- [ ] Run `make docs-build` to verify no broken links or formatting issues
- [ ] Spot-check rendered pages for correct heading hierarchy and code block formatting
- [ ] Verify all 22 files follow canonical section order: Set, Delete, Load, Show, Backup, Best Practices

🤖 Generated with [Claude Code](https://claude.com/claude-code)