### PR TITLE
fix: resolve CLI bugs #140-#144

### DIFF
--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -364,8 +364,9 @@ class SCMClient:
                     "name": name,
                     "allocated_bandwidth": bandwidth,
                     "spn_name_list": spn_name_list,
-                    "description": description or "",
                 }
+                if description:
+                    allocation_data["description"] = description
                 if tags:
                     allocation_data["tags"] = tags
                 created = self.client.bandwidth_allocation.create(allocation_data)
@@ -1487,8 +1488,9 @@ class SCMClient:
             group_data = {
                 "name": name,
                 "folder": folder,
-                "description": description or "",
             }
+            if description:
+                group_data["description"] = description
 
             # SDK expects either 'static' or 'dynamic' key, not 'type'
             if type.lower() == "static":
@@ -1528,7 +1530,8 @@ class SCMClient:
                     self.logger.info(f"Successfully recreated address group '{name}' with new type")
                 else:
                     # Update only the fields that are changing
-                    existing_group.description = description or ""
+                    if description:
+                        existing_group.description = description
                     if tags is not None:  # Only update tags if explicitly provided
                         existing_group.tag = tags
 
@@ -1774,8 +1777,9 @@ class SCMClient:
                 "subcategory": subcategory,
                 "technology": technology,
                 "risk": risk,
-                "description": description or "",
             }
+            if description:
+                app_data["description"] = description
 
             # Add optional fields only if they have non-default values
             if ports:
@@ -1806,7 +1810,8 @@ class SCMClient:
                 existing_app.subcategory = subcategory
                 existing_app.technology = technology
                 existing_app.risk = risk
-                existing_app.description = description or ""
+                if description:
+                    existing_app.description = description
 
                 # Update optional fields
                 if ports is not None:
@@ -2522,8 +2527,9 @@ class SCMClient:
                 "name": name,
                 "folder": folder,
                 "filter": filter,
-                "description": description or "",
             }
+            if description:
+                group_data["description"] = description
 
             if tags:
                 group_data["tag"] = tags  # SDK expects 'tag', not 'tags'
@@ -2532,7 +2538,8 @@ class SCMClient:
             if existing_group:
                 # Update fields
                 existing_group.filter = filter
-                existing_group.description = description or ""
+                if description:
+                    existing_group.description = description
                 if tags is not None:  # Only update tags if explicitly provided
                     existing_group.tag = tags
 
@@ -4073,7 +4080,7 @@ class SCMClient:
             return device_data
 
         try:
-            created = self.client.quarantined_devices.create(device_data)
+            created = self.client.quarantined_device.create(device_data)
             self.logger.info(f"Created quarantined device: {device_data.get('host_id')}")
             return json.loads(created.model_dump_json(exclude_unset=True))
         except Exception as e:
@@ -4096,7 +4103,7 @@ class SCMClient:
             return
 
         try:
-            self.client.quarantined_devices.delete(host_id=host_id)
+            self.client.quarantined_device.delete(host_id=host_id)
             self.logger.info(f"Deleted quarantined device: {host_id}")
         except Exception as e:
             self._handle_api_exception("deleting", "quarantined-devices", f"device '{host_id}'", e)
@@ -4131,7 +4138,7 @@ class SCMClient:
             ]
 
         try:
-            results = self.client.quarantined_devices.list(
+            results = self.client.quarantined_device.list(
                 host_id=host_id,
                 serial_number=serial_number,
             )
@@ -5156,7 +5163,7 @@ class SCMClient:
             if needs_update:
                 self.logger.info(f"Updating tag fields: {', '.join(update_fields)}")
                 try:
-                    updated = existing_tag.update()
+                    updated = self.client.tag.update(existing_tag)
                     self.logger.info(f"Successfully updated tag '{tag_data['name']}' in {container_field} '{container_value}'")
                     result = json.loads(updated.model_dump_json(exclude_unset=True))
                     result["__action__"] = "updated"
@@ -7078,11 +7085,13 @@ class SCMClient:
                 "application": applications,  # SDK uses application instead of applications
                 "service": services,  # Use provided services or default to any
                 "action": action,
-                "description": description or "",
                 "disabled": not enabled,  # SDK uses disabled instead of enabled
                 "category": ["any"],  # Required by SDK
                 "source_user": ["any"],  # Required by SDK
             }
+
+            if description:
+                rule_data["description"] = description
 
             if tags:
                 rule_data["tag"] = tags  # SDK expects 'tag', not 'tags'
@@ -7105,7 +7114,8 @@ class SCMClient:
                 existing_rule.application = applications
                 existing_rule.service = services
                 existing_rule.action = action
-                existing_rule.description = description or ""
+                if description:
+                    existing_rule.description = description
                 existing_rule.disabled = not enabled
                 existing_rule.category = ["any"]  # Required by SDK
                 existing_rule.source_user = ["any"]  # Required by SDK

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -13,6 +13,7 @@ from typing import Any, NoReturn
 
 from oauthlib.oauth2.rfc6749.errors import InvalidClientError
 from scm.client import Scm
+from pydantic import ValidationError
 from scm.exceptions import APIError, AuthenticationError, ClientError, NotFoundError
 
 from .config import get_credentials, settings
@@ -236,6 +237,17 @@ class SCMClient:
             self.logger.error(f"Authentication error during {operation} of {resource_name}: {str(exception)}")
         elif isinstance(exception, NotFoundError):
             self.logger.error(f"Resource not found: {resource_name} in folder {folder}")
+        elif isinstance(exception, ValidationError):
+            self.logger.error(
+                f"SDK model validation error during {operation} of {resource_name}: {str(exception)}. "
+                "This is likely a mismatch between the SDK model and the API response. "
+                "Consider updating pan-scm-sdk."
+            )
+        elif isinstance(exception, AttributeError) and "has no attribute" in str(exception):
+            self.logger.error(
+                f"SDK service not available for {resource_name}: {str(exception)}. "
+                "This feature may not be implemented in the current pan-scm-sdk version."
+            )
         elif isinstance(exception, ClientError):
             self.logger.error(f"Validation error during {operation} of {resource_name}: {str(exception)}")
         elif isinstance(exception, APIError):


### PR DESCRIPTION
## Summary
- **#140**: Added graceful error handling for auto-tag-action when SDK service is unavailable (module commented out in SDK)
- **#141**: Fixed `quarantined_devices` → `quarantined_device` (singular SDK service name) in create, delete, and list methods
- **#142**: Fixed `existing_tag.update()` → `self.client.tag.update(existing_tag)` to call update on SDK service, not response model
- **#143**: Added graceful error handling for decryption-rule when SDK model validation fails (required `action` field missing from API response)
- **#144**: Changed `description or ""` to conditional `if description:` inclusion across 9 locations to avoid sending empty strings to the API

Also improved `_handle_api_exception` to recognize `ValidationError` and `AttributeError` with clear messages pointing to SDK version.

Closes #140, closes #141, closes #142, closes #143, closes #144

## Test plan
- [ ] Verify quarantined device commands use correct SDK service name
- [ ] Verify tag update calls `self.client.tag.update()`
- [ ] Verify create/update commands omit description when not provided
- [ ] Verify auto-tag-action shows clear error about SDK limitation
- [ ] Verify decryption-rule shows clear error about SDK model mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)