### PR TITLE
fix: tag --name flag and comma-separated list params

### DIFF
--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -41,6 +41,20 @@ from ..utils.validators import (
 # ========================================================================================================================================================================================
 
 
+def parse_comma_separated_list(values: list[str]) -> list[str]:
+    """Split comma-separated values in list options.
+
+    Allows both `--members a,b,c` and `--members a --members b --members c`.
+    """
+    result = []
+    for value in values:
+        for item in value.split(","):
+            stripped = item.strip()
+            if stripped:
+                result.append(stripped)
+    return result
+
+
 def show_context_info() -> None:
     """Display current context information if log level is INFO."""
     log_level = settings.get("log_level", "INFO").upper()
@@ -700,15 +714,19 @@ def set_address_group(
 
     """
     try:
+        # Parse comma-separated list options
+        parsed_members = parse_comma_separated_list(members) if members else []
+        parsed_tags = parse_comma_separated_list(tags) if tags else []
+
         # Validate inputs using the Pydantic model
         address_group = AddressGroup(
             folder=folder,
             name=name,
             type=type,
-            members=members or [],
+            members=parsed_members,
             filter=filter,
             description=description or "",
-            tags=tags or [],
+            tags=parsed_tags,
         )
 
         # Call the SDK client to create the address group
@@ -1882,11 +1900,14 @@ def set_application_group(
 
     """
     try:
+        # Parse comma-separated members
+        parsed_members = parse_comma_separated_list(members)
+
         # Validate inputs using the Pydantic model
         app_group = ApplicationGroup(
             folder=folder,
             name=name,
-            members=members,
+            members=parsed_members,
         )
 
         # Call the SDK client to create the application group
@@ -6851,7 +6872,7 @@ def backup_tag(
 
 @delete_app.command("tag", help="Delete a tag.")
 def delete_tag(
-    name: str = typer.Argument(..., help="Name of the tag to delete"),
+    name: str = typer.Option(..., "--name", help="Name of the tag to delete"),
     folder: str = typer.Option(None, "--folder", help="Folder location"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet location"),
     device: str = typer.Option(None, "--device", help="Device location"),
@@ -6969,7 +6990,7 @@ def load_tag(
 
 @set_app.command("tag", help="Create or update a tag.")
 def set_tag(
-    name: str = typer.Argument(..., help="Name of the tag"),
+    name: str = typer.Option(..., "--name", help="Name of the tag"),
     color: str = typer.Option(None, "--color", help="Color for the tag (e.g., Red, Blue, Green)"),
     comments: str = typer.Option(None, "--comments", help="Comments for the tag"),
     folder: str = typer.Option(None, "--folder", help="Folder location"),

--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -219,6 +219,20 @@ URL_PROFILE_ALLOW_OPTION = typer.Option(None, "--allow", help="URL categories to
 # ========================================================================================================================================================================================
 
 
+def parse_comma_separated_list(values: list[str]) -> list[str]:
+    """Split comma-separated values in list options.
+
+    Allows both `--members a,b,c` and `--members a --members b --members c`.
+    """
+    result = []
+    for value in values:
+        for item in value.split(","):
+            stripped = item.strip()
+            if stripped:
+                result.append(stripped)
+    return result
+
+
 def validate_location_params(
     folder: str = None,
     snippet: str = None,
@@ -621,19 +635,28 @@ def set_security_rule(
         raise typer.Exit(code=1)
 
     try:
+        # Parse comma-separated list options
+        parsed_src_zones = parse_comma_separated_list(source_zones)
+        parsed_dst_zones = parse_comma_separated_list(destination_zones)
+        parsed_src_addrs = parse_comma_separated_list(source_addresses) if source_addresses else ["any"]
+        parsed_dst_addrs = parse_comma_separated_list(destination_addresses) if destination_addresses else ["any"]
+        parsed_apps = parse_comma_separated_list(applications) if applications else ["any"]
+        parsed_svcs = parse_comma_separated_list(services) if services else ["any"]
+        parsed_tags = parse_comma_separated_list(tags) if tags else []
+
         # Validate and create security rule
         rule = SecurityRule(
             folder=location_value,
             name=name,
-            source_zones=source_zones,
-            destination_zones=destination_zones,
-            source_addresses=source_addresses or ["any"],
-            destination_addresses=destination_addresses or ["any"],
-            applications=applications or ["any"],
-            service=services or ["any"],
+            source_zones=parsed_src_zones,
+            destination_zones=parsed_dst_zones,
+            source_addresses=parsed_src_addrs,
+            destination_addresses=parsed_dst_addrs,
+            applications=parsed_apps,
+            service=parsed_svcs,
             action=action,
             description=description or "",
-            tags=tags or [],
+            tags=parsed_tags,
             enabled=enabled,
             rulebase=rulebase,
             log_start=log_start,


### PR DESCRIPTION
## Summary
- **#150**: Tag `set` and `delete` commands now use `--name` option instead of positional argument, matching all other object commands
- **#151**: List-type options (`--members`, `--tags`, `--source-zones`, etc.) now support comma-separated values in addition to repeated flags

### Before
```bash
# Tag required positional arg (inconsistent)
scm set object tag my-tag --folder Texas --color Red
scm delete object tag my-tag --folder Texas

# Members required repeated flags
scm set object application-group --members web-browsing --members ssl
```

### After
```bash
# Tag uses --name like everything else
scm set object tag --name my-tag --folder Texas --color Red
scm delete object tag --name my-tag --folder Texas

# Both syntaxes now work
scm set object application-group --members web-browsing,ssl
scm set object application-group --members web-browsing --members ssl
```

Closes #150, closes #151

## Test plan
- [ ] `scm set object tag --name e2e-test --folder Texas --color Red` works
- [ ] `scm delete object tag --name e2e-test --folder Texas --force` works
- [ ] `scm set object application-group --members web-browsing,ssl --folder Texas --name test` works
- [ ] `scm set security rule --source-zones trust,untrust --destination-zones any ...` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)