### PR TITLE
chore: update SDK reference to >=0.12.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ Always refer to the appropriate style guide when writing or modifying code to en
 
 ## Important Notes
 
-- The SDK version is pinned to `pan-scm-sdk==0.3.39` - verify compatibility when updating
+- The SDK version requires `pan-scm-sdk>=0.12.1` - verify compatibility when updating
 - Mock mode allows full testing without API credentials
 - Bulk operations use YAML files - see `examples/` for formats
 - All commands support `--mock` flag for testing


### PR DESCRIPTION
## Summary
- Update CLAUDE.md SDK version reference from `0.3.39` to `>=0.12.1`
- SDK 0.12.1 confirmed to fix:
  - **Decryption Rule** (#143): `action` field is now optional in `DecryptionRuleResponseModel`
  - **Auto-Tag Action** (#140): Module is no longer commented out

### Verified
```bash
$ scm show security decryption-rule --folder Texas
# Now returns 4 rules successfully (was crashing with ValidationError)

$ scm show object auto-tag-action --folder Texas
# Module loads (was crashing with AttributeError). Now returns API response format error (separate issue)
```

## Test plan
- [x] `scm show security decryption-rule --folder Texas` works
- [x] `scm show object auto-tag-action --folder Texas` no longer crashes with AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)