### PR TITLE
fix: remediate remaining E2E bugs from verification testing

### DIFF
--- a/src/scm_cli/commands/commit.py
+++ b/src/scm_cli/commands/commit.py
@@ -82,8 +82,10 @@ def commit(
             typer.echo(f"Job ID: {job_id}")
 
             if sync:
-                status = result.get("status", "unknown")
+                status = result.get("result_str", result.get("status_str", result.get("status", "unknown")))
                 typer.echo(f"Status: {status}")
+                if result.get("details"):
+                    typer.echo(f"Details: {result.get('details')}")
         else:
             typer.echo("\nCommit initiated")
             job_id = result.get("job_id", "unknown")

--- a/src/scm_cli/commands/jobs.py
+++ b/src/scm_cli/commands/jobs.py
@@ -131,14 +131,15 @@ def wait_for_job(
         result = scm_client.wait_for_job(job_id=job_id, timeout=timeout)
 
         status = result.get("status_str", result.get("status", "unknown"))
-        typer.echo(f"\nJob {job_id} completed with status: {status}")
+        result_str = result.get("result_str", result.get("result", ""))
+        typer.echo(f"\nJob {job_id} completed with status: {status} (result: {result_str})")
         typer.echo("-" * 50)
         for key, value in result.items():
             if value is not None and value != [] and value != "":
                 typer.echo(f"  {key}: {value}")
 
         # Exit with error if job did not complete successfully
-        if status not in ("FIN", "OK", "completed"):
+        if result_str in ("FAIL", "PUSHABORT", "ABORTED"):
             raise typer.Exit(code=1)
 
     except typer.Exit:

--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -1219,7 +1219,7 @@ def set_anti_spyware_profile(
                     "name": "Block Critical and High",
                     "severity": ["critical", "high"],
                     "category": "any",
-                    "action": {"block": {}},
+                    "action": "block",
                     "packet_capture": "single-packet",
                 }
             ]
@@ -1230,7 +1230,7 @@ def set_anti_spyware_profile(
                     "name": "simple-critical",
                     "severity": ["critical"],
                     "category": "any",
-                    "action": {"block": {}},
+                    "action": "block",
                 }
             ]
 
@@ -3121,7 +3121,8 @@ def set_vulnerability_protection_profile(
                     "category": "any",
                     "host": "any",
                     "cve": ["any"],
-                    "action": {"alert": {}},
+                    "vendor_id": ["any"],
+                    "action": "alert",
                     "packet_capture": "single-packet",
                 }
             ]
@@ -3134,7 +3135,8 @@ def set_vulnerability_protection_profile(
                     "category": "any",
                     "host": "any",
                     "cve": ["any"],
-                    "action": {"default": {}},
+                    "vendor_id": ["any"],
+                    "action": "default",
                 }
             ]
 

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -967,8 +967,6 @@ class SCMClient:
                     data["protocol"] = protocol
 
                 self.logger.info(f"Creating new remote network '{name}' in folder '{folder}'")
-                # Remove folder from data dict; SDK create() receives it separately
-                data.pop("folder", None)
                 created = self.client.remote_network.create(data)
                 self.logger.info(f"Successfully created remote network '{name}' in folder '{folder}'")
                 result = json.loads(created.model_dump_json(exclude_unset=True))
@@ -2747,25 +2745,31 @@ class SCMClient:
             }
 
         try:
-            # Prepare the EDL data
-            edl_data = {
-                "folder": folder,
-                "name": name,
-                "type": type_config,
-            }
-
             # First, try to fetch the existing EDL
+            existing_edl = None
             try:
                 existing_edl = self.client.external_dynamic_list.fetch(name=name, folder=folder)
-                # Update existing EDL
-                edl_data["id"] = str(existing_edl.id)
-                result = self.client.external_dynamic_list.update(edl_data)
-            except Exception as e:
-                # If the HIP object doesn't exist, create a new one
-                self.logger.debug(f"EDL {name} not found, creating a new one", exc_info=e)
-                # EDL doesn't exist, create a new one
-                # Strip 'id' field since the SDK create model doesn't accept it
-                edl_data.pop("id", None)
+                self.logger.info(f"Found existing EDL '{name}' in folder '{folder}', updating...")
+            except NotFoundError:
+                self.logger.info(f"EDL '{name}' not found in folder '{folder}', creating new...")
+            except Exception as fetch_error:
+                # Log but continue - we'll try to create if fetch failed for other reasons
+                self.logger.warning(f"Error fetching EDL '{name}': {str(fetch_error)}")
+
+            if existing_edl:
+                # Update existing EDL by modifying the model object's attributes
+                existing_edl.type = type_config
+                result = self.client.external_dynamic_list.update(existing_edl)
+                response = json.loads(result.model_dump_json(exclude_unset=True))
+                response["__action__"] = "updated"
+                return response
+            else:
+                # Create a new EDL
+                edl_data = {
+                    "folder": folder,
+                    "name": name,
+                    "type": type_config,
+                }
                 result = self.client.external_dynamic_list.create(edl_data)
 
             # Convert SDK response to dict for compatibility
@@ -7155,11 +7159,8 @@ class SCMClient:
                 if log_setting:
                     existing_rule.log_setting = str(log_setting)
                 else:
-                    # Ensure existing log_setting is a string type or cleared
-                    if existing_rule.log_setting is not None and not isinstance(existing_rule.log_setting, str):
-                        existing_rule.log_setting = str(existing_rule.log_setting)
-                    elif not log_setting:
-                        existing_rule.log_setting = None
+                    # Clear log_setting - handle complex objects from API response
+                    existing_rule.log_setting = None
 
                 # Perform update
                 result = self.client.security_rule.update(existing_rule)
@@ -10117,6 +10118,25 @@ class SCMClient:
             if hasattr(result, "model_dump_json"):
                 return json.loads(result.model_dump_json(exclude_unset=True))
             return {"id": job_id, "status": str(result)}
+        except (ValidationError, ValueError) as e:
+            # SDK may fail to parse in-progress jobs with empty end_ts.
+            # Try extracting status from the raw API response.
+            self.logger.warning(f"SDK validation error for job {job_id}, attempting raw extraction: {e}")
+            try:
+                response = self.client._client.get(f"/config/operations/v1/jobs/{job_id}")  # noqa: SLF001
+                if hasattr(response, "json"):
+                    raw = response.json()
+                elif isinstance(response, dict):
+                    raw = response
+                else:
+                    raw = {"id": job_id, "status": "unknown", "error": str(e)}
+                # Normalize: API may nest data under "data" key
+                if "data" in raw and isinstance(raw["data"], list) and raw["data"]:
+                    return raw["data"][0]
+                return raw
+            except Exception:
+                # Last resort: return what we know
+                return {"id": job_id, "status": "unknown", "parse_error": str(e)}
         except Exception as e:
             self._handle_api_exception("getting status of", "", f"job {job_id}", e)
 
@@ -10146,16 +10166,30 @@ class SCMClient:
                 "details": "Configuration committed successfully",
             }
 
-        try:
-            result = self.client.wait_for_job(job_id=job_id, timeout=timeout)
-            if hasattr(result, "data") and result.data:
-                job_data = result.data[0]
-                return json.loads(job_data.model_dump_json(exclude_unset=True))
-            if hasattr(result, "model_dump_json"):
-                return json.loads(result.model_dump_json(exclude_unset=True))
-            return {"id": job_id, "status": str(result)}
-        except Exception as e:
-            self._handle_api_exception("waiting for", "", f"job {job_id}", e)
+        import time
+
+        terminal_results = {"OK", "FAIL", "PUSHABORT", "ABORTED"}
+        terminal_statuses = {"FIN"}
+
+        start = time.time()
+        poll_interval = 5
+
+        while True:
+            elapsed = time.time() - start
+            if elapsed >= timeout:
+                raise TimeoutError(f"Job {job_id} did not complete within {timeout}s")
+
+            job = self.get_job_status(job_id=job_id)
+            status = job.get("status_str", job.get("status", ""))
+            result_str = job.get("result_str", job.get("result", ""))
+
+            self.logger.info(f"Job {job_id} poll: status={status}, result={result_str}")
+
+            # Job is terminal when status is FIN, or result is a known terminal value
+            if status in terminal_statuses or result_str in terminal_results:
+                return job
+
+            time.sleep(min(poll_interval, max(0, timeout - elapsed)))
 
     # ----------------------------------------------------------------------------------- Commit -----------------------------------------------------------------------------------
 
@@ -10203,16 +10237,32 @@ class SCMClient:
             if admin:
                 commit_kwargs["admin"] = [admin]
 
-            result = self.client.commit(**commit_kwargs)
+            # Always commit asynchronously, then use our own wait_for_job if sync
+            async_kwargs = {k: v for k, v in commit_kwargs.items() if k not in ("sync", "timeout")}
+            async_kwargs["sync"] = False
+
+            result = self.client.commit(**async_kwargs)
+
+            # Extract job_id from the commit response
             if hasattr(result, "model_dump_json"):
-                return json.loads(result.model_dump_json(exclude_unset=True))
-            if isinstance(result, dict):
-                return result
-            return {
-                "success": True,
-                "job_id": str(result) if result else "unknown",
-                "status": "FIN" if sync else "PEND",
-            }
+                result_dict = json.loads(result.model_dump_json(exclude_unset=True))
+            elif isinstance(result, dict):
+                result_dict = result
+            else:
+                result_dict = {"job_id": str(result) if result else "unknown"}
+
+            job_id = str(result_dict.get("job_id", result_dict.get("id", result_dict.get("jobid", ""))))
+
+            if sync and job_id and job_id != "unknown":
+                # Use our own polling which handles all terminal states and empty end_ts
+                job_result = self.wait_for_job(job_id=job_id, timeout=timeout)
+                job_result["success"] = job_result.get("result_str", job_result.get("result", "")) == "OK"
+                job_result["job_id"] = job_id
+                return job_result
+
+            result_dict.setdefault("success", not sync)
+            result_dict.setdefault("job_id", job_id)
+            return result_dict
         except Exception as e:
             self._handle_api_exception("committing", ", ".join(folders), "configuration", e)
 

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -80,7 +80,6 @@ class ServiceConnection(BaseModel):
         """Convert CLI model to SDK model format."""
         model_data = {
             "name": self.name,
-            "folder": self.folder,
             "ipsec_tunnel": self.ipsec_tunnel,
             "region": self.region,
             "onboarding_type": self.onboarding_type,
@@ -207,7 +206,6 @@ class RemoteNetwork(BaseModel):
         """Convert CLI model to SDK model format."""
         model_data = {
             "name": self.name,
-            "folder": self.folder,
             "region": self.region,
             "license_type": self.license_type,
             "ecmp_load_balancing": self.ecmp_load_balancing,
@@ -3511,8 +3509,8 @@ class AntiSpywareProfile(BaseModel):
                     "reset-server",
                 ]
                 action = rule["action"]
-                if isinstance(action, dict) and "alert" in action:
-                    # It's an alert with packet capture
+                if isinstance(action, dict):
+                    # Dict format actions are accepted (e.g., from API responses)
                     pass
                 elif action not in valid_actions:
                     raise ValueError(f"Rule {idx}: Invalid action '{action}'")
@@ -3539,14 +3537,7 @@ class AntiSpywareProfile(BaseModel):
         if self.threat_exceptions:
             model_data["threat_exception"] = self.threat_exceptions
         if self.rules:
-            # Convert string actions to dict format required by API (e.g., "block" -> {"block": {}})
-            converted_rules = []
-            for rule in self.rules:
-                rule_copy = dict(rule)
-                if "action" in rule_copy and isinstance(rule_copy["action"], str):
-                    rule_copy["action"] = {rule_copy["action"]: {}}
-                converted_rules.append(rule_copy)
-            model_data["rules"] = converted_rules
+            model_data["rules"] = self.rules
         if self.mica_engine_spyware_enabled:
             model_data["mica_engine_spyware_enabled"] = self.mica_engine_spyware_enabled
         if self.cloud_inline_analysis is not None:
@@ -4533,13 +4524,10 @@ class VulnerabilityProtectionProfile(BaseModel):
         if self.threat_exceptions:
             model_data["threat_exception"] = self.threat_exceptions
         if self.rules:
-            # Convert string actions to dict format required by API (e.g., "default" -> {"default": {}})
-            # Also add default cve field if not specified
+            # Add default cve field if not specified
             converted_rules = []
             for rule in self.rules:
                 rule_copy = dict(rule)
-                if "action" in rule_copy and isinstance(rule_copy["action"], str):
-                    rule_copy["action"] = {rule_copy["action"]: {}}
                 if "cve" not in rule_copy:
                     rule_copy["cve"] = ["any"]
                 converted_rules.append(rule_copy)


### PR DESCRIPTION
## Summary
Fixes 6 remaining CLI bugs discovered during E2E verification testing (second round after PR #167).

### Fixes
- **EDL update**: proper fetch→update flow instead of falling through to create (`OBJECT_ALREADY_EXISTS`)
- **Security rule update**: handle `log_setting` type on re-submit (set to None when not provided)
- **Anti-spyware profile create**: revert action to string format — SDK converts internally, doesn't want dict
- **Vulnerability protection profile create**: revert action format + add `vendor_id: ["any"]` default
- **Jobs status**: handle empty `end_ts` with fallback to raw API call for in-progress jobs
- **Jobs wait**: custom polling loop with FAIL/PUSHABORT/ABORTED as terminal states
- **Commit --sync**: display `result_str` instead of raw status field
- **Remote network/service connection**: remove `folder` from `to_sdk_model()` (root cause fix for folder leak)

### Testing
- 758 unit tests pass, 0 new failures
- Ruff lint clean
- E2E verification pending merge

## Related
Follow-up to #166, #167. Addresses remaining failures from #158, #160, #161, #164, #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)