### PR TITLE
fix: cleanup stale references and config mismatches

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -575,4 +575,4 @@ $ scm context test
 
 ---
 
-For more detailed information on each release, visit the [GitHub repository](https://github.com/cdot65/pan-scm-sdk/releases) or check the [commit history](https://github.com/cdot65/pan-scm-sdk/commits/main).
+For more detailed information on each release, visit the [GitHub repository](https://github.com/cdot65/pan-scm-cli/releases) or check the [commit history](https://github.com/cdot65/pan-scm-cli/commits/main).

--- a/docs/cli/objects/address.md
+++ b/docs/cli/objects/address.md
@@ -60,7 +60,7 @@ $ scm set object address \
     --name webserver \
     --ip-netmask 192.168.1.100/32 \
     --description "Web server" \
-    --tags ["server", "web"]
+    --tags server --tags web
 ---> 100%
 Created address: webserver in folder Texas
 ```

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.10
+python_version = 3.12
 warn_return_any = False
 warn_unused_configs = True
 disallow_untyped_defs = False

--- a/src/scm_cli/main.py
+++ b/src/scm_cli/main.py
@@ -302,7 +302,7 @@ def callback():
       - scm load network zone --file config/security_zones.yml
       - scm show object address --folder Texas --list
       - scm show object address --folder Texas --name webserver
-      - scm test-auth
+      - scm context test
 
     """
     pass


### PR DESCRIPTION
## Summary
Fixes 4 stale references and config mismatches found during scheduled review.

- Remove stale `scm test-auth` in main.py help text (replaced by `scm context test`)
- Update mypy.ini `python_version` from 3.10 to 3.12 (matches pyproject.toml)
- Fix invalid `--tags ["server", "web"]` syntax in address docs → `--tags server --tags web`
- Fix release-notes.md linking to pan-scm-sdk repo instead of pan-scm-cli

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)