### PR TITLE
docs: add --force flag docs, bump v1.0.3

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,20 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.3
+
+**Released:** March 9, 2026
+
+### Added
+
+- **Delete Confirmation Prompts**: All delete commands now prompt for confirmation before proceeding. Use `--force` to skip the prompt for scripting and automation.
+
+### Fixed
+
+- **Stale References**: Removed deprecated `scm test-auth` reference from CLI help text (now `scm context test`).
+- **Config Mismatch**: Updated `mypy.ini` to target Python 3.12 (was incorrectly set to 3.10).
+- **Documentation**: Fixed CLI syntax in address docs, corrected repository link in release notes.
+
 ## Version 0.5.1
 
 **Released:** June 19, 2025

--- a/docs/cli/network/aggregate-interface.md
+++ b/docs/cli/network/aggregate-interface.md
@@ -78,13 +78,14 @@ scm delete network aggregate-interface NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network aggregate-interface ae1 --folder Texas
+$ scm delete network aggregate-interface ae1 --folder Texas --force
 ---> 100%
 Deleted aggregate interface: ae1 from folder Texas
 ```

--- a/docs/cli/network/bgp-address-family-profile.md
+++ b/docs/cli/network/bgp-address-family-profile.md
@@ -74,13 +74,14 @@ scm delete network bgp-address-family-profile NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network bgp-address-family-profile my-af-profile --folder Texas
+$ scm delete network bgp-address-family-profile my-af-profile --folder Texas --force
 ---> 100%
 Deleted BGP address family profile: my-af-profile from folder Texas
 ```

--- a/docs/cli/network/bgp-auth-profile.md
+++ b/docs/cli/network/bgp-auth-profile.md
@@ -74,13 +74,14 @@ scm delete network bgp-auth-profile NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network bgp-auth-profile my-bgp-auth --folder Texas
+$ scm delete network bgp-auth-profile my-bgp-auth --folder Texas --force
 ---> 100%
 Deleted BGP auth profile: my-bgp-auth from folder Texas
 ```

--- a/docs/cli/network/bgp-filtering-profile.md
+++ b/docs/cli/network/bgp-filtering-profile.md
@@ -74,13 +74,14 @@ scm delete network bgp-filtering-profile NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network bgp-filtering-profile my-filter --folder Texas
+$ scm delete network bgp-filtering-profile my-filter --folder Texas --force
 ---> 100%
 Deleted BGP filtering profile: my-filter from folder Texas
 ```

--- a/docs/cli/network/bgp-redistribution-profile.md
+++ b/docs/cli/network/bgp-redistribution-profile.md
@@ -74,13 +74,14 @@ scm delete network bgp-redistribution-profile NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network bgp-redistribution-profile my-redist --folder Texas
+$ scm delete network bgp-redistribution-profile my-redist --folder Texas --force
 ---> 100%
 Deleted BGP redistribution profile: my-redist from folder Texas
 ```

--- a/docs/cli/network/bgp-route-map-redistribution.md
+++ b/docs/cli/network/bgp-route-map-redistribution.md
@@ -76,13 +76,14 @@ scm delete network bgp-route-map-redistribution NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network bgp-route-map-redistribution my-redist-map --folder Texas
+$ scm delete network bgp-route-map-redistribution my-redist-map --folder Texas --force
 ---> 100%
 Deleted BGP route map redistribution: my-redist-map from folder Texas
 ```

--- a/docs/cli/network/bgp-route-map.md
+++ b/docs/cli/network/bgp-route-map.md
@@ -74,13 +74,14 @@ scm delete network bgp-route-map NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network bgp-route-map my-route-map --folder Texas
+$ scm delete network bgp-route-map my-route-map --folder Texas --force
 ---> 100%
 Deleted BGP route map: my-route-map from folder Texas
 ```

--- a/docs/cli/network/dhcp-interface.md
+++ b/docs/cli/network/dhcp-interface.md
@@ -75,13 +75,14 @@ scm delete network dhcp-interface NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network dhcp-interface ethernet1/1 --folder Texas
+$ scm delete network dhcp-interface ethernet1/1 --folder Texas --force
 ---> 100%
 Deleted DHCP interface: ethernet1/1 from folder Texas
 ```

--- a/docs/cli/network/ethernet-interface.md
+++ b/docs/cli/network/ethernet-interface.md
@@ -84,13 +84,14 @@ scm delete network ethernet-interface NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network ethernet-interface ethernet1/1 --folder Texas
+$ scm delete network ethernet-interface ethernet1/1 --folder Texas --force
 ---> 100%
 Deleted ethernet interface: ethernet1/1 from folder Texas
 ```

--- a/docs/cli/network/ike-crypto-profile.md
+++ b/docs/cli/network/ike-crypto-profile.md
@@ -87,13 +87,14 @@ scm delete network ike-crypto-profile NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network ike-crypto-profile my-ike-profile --folder Texas
+$ scm delete network ike-crypto-profile my-ike-profile --folder Texas --force
 ---> 100%
 Deleted IKE crypto profile: my-ike-profile from folder Texas
 ```

--- a/docs/cli/network/ike-gateway.md
+++ b/docs/cli/network/ike-gateway.md
@@ -100,13 +100,14 @@ scm delete network ike-gateway NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network ike-gateway my-gateway --folder Texas
+$ scm delete network ike-gateway my-gateway --folder Texas --force
 ---> 100%
 Deleted IKE gateway: my-gateway from folder Texas
 ```

--- a/docs/cli/network/ipsec-crypto-profile.md
+++ b/docs/cli/network/ipsec-crypto-profile.md
@@ -79,11 +79,12 @@ scm delete network ipsec-crypto-profile [OPTIONS]
 | --- | --- | --- |
 | `--name TEXT` | Profile name | Yes |
 | `--folder TEXT` | Folder location | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete network ipsec-crypto-profile --folder Texas --name my-ipsec-profile
+$ scm delete network ipsec-crypto-profile --folder Texas --name my-ipsec-profile --force
 ---> 100%
 Deleted IPsec crypto profile: my-ipsec-profile from folder Texas
 ```

--- a/docs/cli/network/layer2-subinterface.md
+++ b/docs/cli/network/layer2-subinterface.md
@@ -79,13 +79,14 @@ scm delete network layer2-subinterface NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network layer2-subinterface ethernet1/1.100 --folder Texas
+$ scm delete network layer2-subinterface ethernet1/1.100 --folder Texas --force
 ---> 100%
 Deleted layer2 subinterface: ethernet1/1.100 from folder Texas
 ```

--- a/docs/cli/network/layer3-subinterface.md
+++ b/docs/cli/network/layer3-subinterface.md
@@ -85,13 +85,14 @@ scm delete network layer3-subinterface NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network layer3-subinterface ethernet1/1.200 --folder Texas
+$ scm delete network layer3-subinterface ethernet1/1.200 --folder Texas --force
 ---> 100%
 Deleted layer3 subinterface: ethernet1/1.200 from folder Texas
 ```

--- a/docs/cli/network/loopback-interface.md
+++ b/docs/cli/network/loopback-interface.md
@@ -81,13 +81,14 @@ scm delete network loopback-interface NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network loopback-interface loopback.1 --folder Texas
+$ scm delete network loopback-interface loopback.1 --folder Texas --force
 ---> 100%
 Deleted loopback interface: loopback.1 from folder Texas
 ```

--- a/docs/cli/network/nat-rule.md
+++ b/docs/cli/network/nat-rule.md
@@ -88,11 +88,12 @@ scm delete network nat-rule [OPTIONS]
 | --- | --- | --- |
 | `--name TEXT` | Rule name | Yes |
 | `--folder TEXT` | Folder location | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete network nat-rule --folder Texas --name outbound-nat
+$ scm delete network nat-rule --folder Texas --name outbound-nat --force
 ---> 100%
 Deleted NAT rule: outbound-nat from folder Texas
 ```

--- a/docs/cli/network/ospf-auth-profile.md
+++ b/docs/cli/network/ospf-auth-profile.md
@@ -75,13 +75,14 @@ scm delete network ospf-auth-profile NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network ospf-auth-profile my-ospf-auth --folder Texas
+$ scm delete network ospf-auth-profile my-ospf-auth --folder Texas --force
 ---> 100%
 Deleted OSPF auth profile: my-ospf-auth from folder Texas
 ```

--- a/docs/cli/network/route-access-list.md
+++ b/docs/cli/network/route-access-list.md
@@ -75,13 +75,14 @@ scm delete network route-access-list NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network route-access-list my-acl --folder Texas
+$ scm delete network route-access-list my-acl --folder Texas --force
 ---> 100%
 Deleted route access list: my-acl from folder Texas
 ```

--- a/docs/cli/network/route-prefix-list.md
+++ b/docs/cli/network/route-prefix-list.md
@@ -75,13 +75,14 @@ scm delete network route-prefix-list NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network route-prefix-list my-prefix-list --folder Texas
+$ scm delete network route-prefix-list my-prefix-list --folder Texas --force
 ---> 100%
 Deleted route prefix list: my-prefix-list from folder Texas
 ```

--- a/docs/cli/network/security-zone.md
+++ b/docs/cli/network/security-zone.md
@@ -87,11 +87,12 @@ scm delete network security-zone [OPTIONS]
 | --- | --- | --- |
 | `--name TEXT` | Name of the security zone to delete | Yes |
 | `--folder TEXT` | Folder location | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete network security-zone --folder Shared --name DMZ
+$ scm delete network security-zone --folder Shared --name DMZ --force
 ---> 100%
 Deleted security zone: DMZ from folder Shared
 ```

--- a/docs/cli/network/tunnel-interface.md
+++ b/docs/cli/network/tunnel-interface.md
@@ -80,13 +80,14 @@ scm delete network tunnel-interface NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network tunnel-interface tunnel.1 --folder Texas
+$ scm delete network tunnel-interface tunnel.1 --folder Texas --force
 ---> 100%
 Deleted tunnel interface: tunnel.1 from folder Texas
 ```

--- a/docs/cli/network/vlan-interface.md
+++ b/docs/cli/network/vlan-interface.md
@@ -83,13 +83,14 @@ scm delete network vlan-interface NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete network vlan-interface vlan.100 --folder Texas
+$ scm delete network vlan-interface vlan.100 --folder Texas --force
 ---> 100%
 Deleted VLAN interface: vlan.100 from folder Texas
 ```

--- a/docs/cli/objects/address-group.md
+++ b/docs/cli/objects/address-group.md
@@ -88,11 +88,12 @@ scm delete object address-group [OPTIONS]
 | --- | --- | --- |
 | `--folder TEXT` | Folder containing the address group | Yes |
 | `--name TEXT` | Name of the address group to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete object address-group --folder Shared --name web-servers
+$ scm delete object address-group --folder Shared --name web-servers --force
 ---> 100%
 Deleted address group: web-servers from folder Shared
 ```

--- a/docs/cli/objects/address.md
+++ b/docs/cli/objects/address.md
@@ -105,11 +105,12 @@ scm delete object address [OPTIONS]
 | --- | --- | --- |
 | `--folder TEXT` | Folder containing the address object | Yes |
 | `--name TEXT` | Name of the address object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete object address --folder Texas --name webserver
+$ scm delete object address --folder Texas --name webserver --force
 ---> 100%
 Deleted address: webserver from folder Texas
 ```

--- a/docs/cli/objects/application-filter.md
+++ b/docs/cli/objects/application-filter.md
@@ -97,13 +97,14 @@ scm delete object application-filter [OPTIONS]
 | `--snippet TEXT` | Snippet containing the application filter object | No\* |
 | `--device TEXT` | Device containing the application filter object | No\* |
 | `--name TEXT` | Name of the application filter object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object application-filter --folder Texas --name high-risk-apps
+$ scm delete object application-filter --folder Texas --name high-risk-apps --force
 ---> 100%
 Deleted application filter: high-risk-apps from folder Texas
 ```

--- a/docs/cli/objects/application-group.md
+++ b/docs/cli/objects/application-group.md
@@ -81,13 +81,14 @@ scm delete object application-group [OPTIONS]
 | `--snippet TEXT` | Snippet containing the application group object | No\* |
 | `--device TEXT` | Device containing the application group object | No\* |
 | `--name TEXT` | Name of the application group object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object application-group --folder Texas --name business-apps
+$ scm delete object application-group --folder Texas --name business-apps --force
 ---> 100%
 Deleted application group: business-apps from folder Texas
 ```

--- a/docs/cli/objects/application.md
+++ b/docs/cli/objects/application.md
@@ -126,13 +126,14 @@ scm delete object application [OPTIONS]
 | `--snippet TEXT` | Snippet containing the application object | No\* |
 | `--device TEXT` | Device containing the application object | No\* |
 | `--name TEXT` | Name of the application object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object application --folder Texas --name custom-crm
+$ scm delete object application --folder Texas --name custom-crm --force
 ---> 100%
 Deleted application: custom-crm from folder Texas
 ```

--- a/docs/cli/objects/dynamic-user-group.md
+++ b/docs/cli/objects/dynamic-user-group.md
@@ -91,13 +91,14 @@ scm delete object dynamic-user-group [OPTIONS]
 | `--snippet TEXT` | Snippet containing the dynamic user group object | No\* |
 | `--device TEXT` | Device containing the dynamic user group object | No\* |
 | `--name TEXT` | Name of the dynamic user group object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object dynamic-user-group --folder Texas --name it-admins
+$ scm delete object dynamic-user-group --folder Texas --name it-admins --force
 ---> 100%
 Deleted dynamic user group: it-admins from folder Texas
 ```

--- a/docs/cli/objects/external-dynamic-list.md
+++ b/docs/cli/objects/external-dynamic-list.md
@@ -140,13 +140,14 @@ scm delete object external-dynamic-list [OPTIONS]
 | `--snippet TEXT` | Snippet containing the external dynamic list object | No\* |
 | `--device TEXT` | Device containing the external dynamic list object | No\* |
 | `--name TEXT` | Name of the external dynamic list object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object external-dynamic-list --folder Texas --name custom-threats
+$ scm delete object external-dynamic-list --folder Texas --name custom-threats --force
 ---> 100%
 Deleted external dynamic list: custom-threats from folder Texas
 ```

--- a/docs/cli/objects/hip-object.md
+++ b/docs/cli/objects/hip-object.md
@@ -118,13 +118,14 @@ scm delete object hip-object [OPTIONS]
 | `--snippet TEXT` | Snippet containing the HIP object | No\* |
 | `--device TEXT` | Device containing the HIP object | No\* |
 | `--name TEXT` | Name of the HIP object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object hip-object --folder Texas --name windows-patches
+$ scm delete object hip-object --folder Texas --name windows-patches --force
 ---> 100%
 Deleted HIP object: windows-patches from folder Texas
 ```

--- a/docs/cli/objects/hip-profile.md
+++ b/docs/cli/objects/hip-profile.md
@@ -93,13 +93,14 @@ scm delete object hip-profile [OPTIONS]
 | `--snippet TEXT` | Snippet containing the HIP profile object | No\* |
 | `--device TEXT` | Device containing the HIP profile object | No\* |
 | `--name TEXT` | Name of the HIP profile object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object hip-profile --folder Texas --name secure-endpoints
+$ scm delete object hip-profile --folder Texas --name secure-endpoints --force
 ---> 100%
 Deleted HIP profile: secure-endpoints from folder Texas
 ```

--- a/docs/cli/objects/http-server-profile.md
+++ b/docs/cli/objects/http-server-profile.md
@@ -110,13 +110,14 @@ scm delete object http-server-profile [OPTIONS]
 | `--snippet TEXT` | Snippet containing the HTTP server profile object | No\* |
 | `--device TEXT` | Device containing the HTTP server profile object | No\* |
 | `--name TEXT` | Name of the HTTP server profile object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object http-server-profile --folder Texas --name syslog-http
+$ scm delete object http-server-profile --folder Texas --name syslog-http --force
 ---> 100%
 Deleted HTTP server profile: syslog-http from folder Texas
 ```

--- a/docs/cli/objects/log-forwarding-profile.md
+++ b/docs/cli/objects/log-forwarding-profile.md
@@ -108,13 +108,14 @@ scm delete object log-forwarding-profile [OPTIONS]
 | `--snippet TEXT` | Snippet containing the log forwarding profile object | No\* |
 | `--device TEXT` | Device containing the log forwarding profile object | No\* |
 | `--name TEXT` | Name of the log forwarding profile object to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object log-forwarding-profile --folder Texas --name traffic-logs
+$ scm delete object log-forwarding-profile --folder Texas --name traffic-logs --force
 ---> 100%
 Deleted log forwarding profile: traffic-logs from folder Texas
 ```

--- a/docs/cli/objects/quarantined-device.md
+++ b/docs/cli/objects/quarantined-device.md
@@ -52,11 +52,12 @@ scm delete object quarantined-device HOST_ID
 | Option | Description | Required |
 | --- | --- | --- |
 | `HOST_ID` | Host ID of the device (positional) | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete object quarantined-device abc123
+$ scm delete object quarantined-device abc123 --force
 ---> 100%
 Deleted quarantined device: abc123
 ```

--- a/docs/cli/objects/region.md
+++ b/docs/cli/objects/region.md
@@ -78,13 +78,14 @@ scm delete object region NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object region us-west --folder Texas
+$ scm delete object region us-west --folder Texas --force
 ---> 100%
 Deleted region: us-west from folder Texas
 ```

--- a/docs/cli/objects/schedule.md
+++ b/docs/cli/objects/schedule.md
@@ -89,13 +89,14 @@ scm delete object schedule NAME [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object schedule business-hours --folder Texas
+$ scm delete object schedule business-hours --folder Texas --force
 ---> 100%
 Deleted schedule: business-hours from folder Texas
 ```

--- a/docs/cli/objects/service-group.md
+++ b/docs/cli/objects/service-group.md
@@ -94,13 +94,14 @@ scm delete object service-group [OPTIONS]
 | `--snippet TEXT` | Snippet containing the service group object | No\* |
 | `--device TEXT` | Device containing the service group object | No\* |
 | `--name TEXT` | Name of the service group to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object service-group --folder Texas --name web-services
+$ scm delete object service-group --folder Texas --name web-services --force
 ---> 100%
 Deleted service group: web-services from folder Texas
 ```

--- a/docs/cli/objects/service.md
+++ b/docs/cli/objects/service.md
@@ -112,13 +112,14 @@ scm delete object service [OPTIONS]
 | `--snippet TEXT` | Snippet containing the service object | No\* |
 | `--device TEXT` | Device containing the service object | No\* |
 | `--name TEXT` | Name of the service to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object service --folder Texas --name custom-web
+$ scm delete object service --folder Texas --name custom-web --force
 ---> 100%
 Deleted service: custom-web from folder Texas
 ```

--- a/docs/cli/objects/syslog-server-profile.md
+++ b/docs/cli/objects/syslog-server-profile.md
@@ -103,13 +103,14 @@ scm delete object syslog-server-profile [OPTIONS]
 | `--snippet TEXT` | Snippet containing the syslog server profile object | No\* |
 | `--device TEXT` | Device containing the syslog server profile object | No\* |
 | `--name TEXT` | Name of the syslog server profile to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object syslog-server-profile --folder Texas --name central-syslog
+$ scm delete object syslog-server-profile --folder Texas --name central-syslog --force
 ---> 100%
 Deleted syslog server profile: central-syslog from folder Texas
 ```

--- a/docs/cli/objects/tag.md
+++ b/docs/cli/objects/tag.md
@@ -108,13 +108,14 @@ scm delete object tag [OPTIONS]
 | `--snippet TEXT` | Snippet containing the tag object | No\* |
 | `--device TEXT` | Device containing the tag object | No\* |
 | `--name TEXT` | Name of the tag to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete object tag --folder Texas --name production
+$ scm delete object tag --folder Texas --name production --force
 ---> 100%
 Deleted tag: production from folder Texas
 ```

--- a/docs/cli/security/anti-spyware-profile.md
+++ b/docs/cli/security/anti-spyware-profile.md
@@ -89,6 +89,7 @@ scm delete security anti-spyware-profile [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -97,7 +98,8 @@ scm delete security anti-spyware-profile [OPTIONS]
 ```bash
 $ scm delete security anti-spyware-profile \
     --folder Texas \
-    --name strict-security
+    --name strict-security \
+    --force
 ---> 100%
 Deleted anti-spyware profile: strict-security from folder Texas
 ```

--- a/docs/cli/security/app-override-rule.md
+++ b/docs/cli/security/app-override-rule.md
@@ -142,6 +142,7 @@ scm delete security app-override-rule [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Rule name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -150,7 +151,8 @@ scm delete security app-override-rule [OPTIONS]
 ```bash
 $ scm delete security app-override-rule \
     --folder Texas \
-    --name override-https
+    --name override-https \
+    --force
 ---> 100%
 Deleted app override rule: override-https from folder Texas
 ```

--- a/docs/cli/security/authentication-rule.md
+++ b/docs/cli/security/authentication-rule.md
@@ -142,6 +142,7 @@ scm delete security authentication-rule [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Rule name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -150,7 +151,8 @@ scm delete security authentication-rule [OPTIONS]
 ```bash
 $ scm delete security authentication-rule \
     --folder Texas \
-    --name auth-web
+    --name auth-web \
+    --force
 ---> 100%
 Deleted authentication rule: auth-web from folder Texas
 ```

--- a/docs/cli/security/decryption-profile.md
+++ b/docs/cli/security/decryption-profile.md
@@ -102,6 +102,7 @@ scm delete security decryption-profile [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -110,7 +111,8 @@ scm delete security decryption-profile [OPTIONS]
 ```bash
 $ scm delete security decryption-profile \
     --folder Texas \
-    --name ssl-forward
+    --name ssl-forward \
+    --force
 ---> 100%
 Deleted decryption profile: ssl-forward from folder Texas
 ```

--- a/docs/cli/security/decryption-rule.md
+++ b/docs/cli/security/decryption-rule.md
@@ -141,6 +141,7 @@ scm delete security decryption-rule [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Rule name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -149,7 +150,8 @@ scm delete security decryption-rule [OPTIONS]
 ```bash
 $ scm delete security decryption-rule \
     --folder Texas \
-    --name no-decrypt-internal
+    --name no-decrypt-internal \
+    --force
 ---> 100%
 Deleted decryption rule: no-decrypt-internal from folder Texas
 ```

--- a/docs/cli/security/dns-security-profile.md
+++ b/docs/cli/security/dns-security-profile.md
@@ -77,6 +77,7 @@ scm delete security dns-security-profile [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -85,7 +86,8 @@ scm delete security dns-security-profile [OPTIONS]
 ```bash
 $ scm delete security dns-security-profile \
     --folder Texas \
-    --name dns-sec-default
+    --name dns-sec-default \
+    --force
 ---> 100%
 Deleted DNS security profile: dns-sec-default from folder Texas
 ```

--- a/docs/cli/security/rules.md
+++ b/docs/cli/security/rules.md
@@ -166,13 +166,15 @@ scm delete security rule [OPTIONS]
 | --- | --- | --- |
 | `--folder TEXT` | Folder containing the security rule | Yes |
 | `--name TEXT` | Name of the security rule to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
 $ scm delete security rule \
     --folder Shared \
-    --name "Allow-Internal-Web"
+    --name "Allow-Internal-Web" \
+    --force
 ---> 100%
 Deleted security rule: Allow-Internal-Web from folder Shared
 ```

--- a/docs/cli/security/url-access-profile.md
+++ b/docs/cli/security/url-access-profile.md
@@ -87,6 +87,7 @@ scm delete security url-access-profile [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -95,7 +96,8 @@ scm delete security url-access-profile [OPTIONS]
 ```bash
 $ scm delete security url-access-profile \
     --folder Texas \
-    --name strict-url
+    --name strict-url \
+    --force
 ---> 100%
 Deleted URL access profile: strict-url from folder Texas
 ```

--- a/docs/cli/security/url-category.md
+++ b/docs/cli/security/url-category.md
@@ -88,6 +88,7 @@ scm delete security url-category [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Category name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -96,7 +97,8 @@ scm delete security url-category [OPTIONS]
 ```bash
 $ scm delete security url-category \
     --folder Texas \
-    --name custom-block
+    --name custom-block \
+    --force
 ---> 100%
 Deleted URL category: custom-block from folder Texas
 ```

--- a/docs/cli/security/vulnerability-protection-profile.md
+++ b/docs/cli/security/vulnerability-protection-profile.md
@@ -77,6 +77,7 @@ scm delete security vulnerability-protection-profile [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -85,7 +86,8 @@ scm delete security vulnerability-protection-profile [OPTIONS]
 ```bash
 $ scm delete security vulnerability-protection-profile \
     --folder Texas \
-    --name strict-vuln
+    --name strict-vuln \
+    --force
 ---> 100%
 Deleted vulnerability protection profile: strict-vuln from folder Texas
 ```

--- a/docs/cli/security/wildfire-antivirus-profile.md
+++ b/docs/cli/security/wildfire-antivirus-profile.md
@@ -89,6 +89,7 @@ scm delete security wildfire-antivirus-profile [OPTIONS]
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
 | `--name TEXT` | Profile name to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -97,7 +98,8 @@ scm delete security wildfire-antivirus-profile [OPTIONS]
 ```bash
 $ scm delete security wildfire-antivirus-profile \
     --folder Texas \
-    --name wf-basic
+    --name wf-basic \
+    --force
 ---> 100%
 Deleted WildFire antivirus profile: wf-basic from folder Texas
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.2"
+version = "1.0.3"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Document `--force` flag on all 51 delete command doc pages (objects, security, network)
- Add `--force` to options tables and CLI examples
- Update release notes for v1.0.3
- Bump version to 1.0.3

## Test plan
- [x] `mkdocs build --strict` passes
- [x] All 758 tests pass
- [x] Ruff lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)