### PR TITLE
chore: bump pan-scm-sdk ^0.12.2, v1.0.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ Always refer to the appropriate style guide when writing or modifying code to en
 
 ## Important Notes
 
-- The SDK version requires `pan-scm-sdk>=0.12.1` - verify compatibility when updating
+- The SDK version requires `pan-scm-sdk>=0.12.2` - verify compatibility when updating
 - Mock mode allows full testing without API credentials
 - Bulk operations use YAML files - see `examples/` for formats
 - All commands support `--mock` flag for testing

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,15 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.4
+
+**Released:** March 9, 2026
+
+### Changed
+
+- **SDK Dependency**: Bumped `pan-scm-sdk` from `^0.12.0` to `^0.12.2`, picking up AutoTagActions service implementation and DecryptionRule optional action field fix.
+- **Version Tracking**: `__version__` now sourced from package metadata via `importlib.metadata` instead of a hardcoded string.
+
 ## Version 1.0.3
 
 **Released:** March 9, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.3"
+version = "1.0.4"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"
@@ -11,7 +11,7 @@ python = ">=3.12,<3.14"
 typer = "^0.15.4"
 pyyaml = "^6.0.2"
 pydantic = "^2.11.5"
-pan-scm-sdk = "^0.12.0"
+pan-scm-sdk = "^0.12.2"
 dynaconf = "^3.2.11"
 
 [tool.poetry.group.dev.dependencies]

--- a/src/scm_cli/__init__.py
+++ b/src/scm_cli/__init__.py
@@ -1,6 +1,8 @@
 """pan-scm-cli: CLI for Palo Alto Networks Strata Cloud Manager."""
 
-__version__ = "0.3.0"
+from importlib.metadata import version
+
+__version__ = version("pan-scm-cli")
 
 from .main import app
 


### PR DESCRIPTION
## Summary
- Bump `pan-scm-sdk` dependency from `^0.12.0` to `^0.12.2`
- Fix stale `__version__` in `__init__.py` — now sourced dynamically from package metadata
- Update CLAUDE.md SDK version reference
- Bump version to 1.0.4

## SDK changelog (0.12.0 → 0.12.2)
- **v0.12.1**: AutoTagActions service fully implemented; DecryptionRule `action` field made optional
- **v0.12.2**: Lint fixes, docs standardization (no functional changes)

No CLI code changes needed — existing commands already use the SDK services correctly.

## Test plan
- [x] 758 tests pass
- [x] Ruff lint/format clean
- [x] `poetry install` pulls SDK 0.12.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)