### PR TITLE
fix: resolve mypy errors, enforce type checking in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
           poetry run ruff format --check src/
 
       - name: Type check
-        continue-on-error: true
         run: |
           poetry run mypy src/
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,15 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.5
+
+**Released:** March 9, 2026
+
+### Fixed
+
+- **Type Safety**: Resolved all 13 mypy type errors in `network.py` — IKE crypto profile, IKE gateway, and IPsec crypto profile model construction now uses correct typed kwargs.
+- **CI Enforcement**: mypy type checking now blocks PRs (removed `continue-on-error`).
+
 ## Version 1.0.4
 
 **Released:** March 9, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.4"
+version = "1.0.5"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -409,18 +409,19 @@ def set_ike_crypto_profile(
     """Create or update an IKE crypto profile."""
     try:
         location_type, location_value = validate_location_params(folder, snippet, device)
-        profile_data = {"name": name, "hash": hash, "dh_group": dh_group, "encryption": encryption, location_type: location_value}
-        if lifetime_seconds is not None:
-            profile_data["lifetime_seconds"] = lifetime_seconds
-        if lifetime_minutes is not None:
-            profile_data["lifetime_minutes"] = lifetime_minutes
-        if lifetime_hours is not None:
-            profile_data["lifetime_hours"] = lifetime_hours
-        if lifetime_days is not None:
-            profile_data["lifetime_days"] = lifetime_days
-        if authentication_multiple is not None:
-            profile_data["authentication_multiple"] = authentication_multiple
-        validated_profile = IKECryptoProfile(**profile_data)
+        location_kwargs = {location_type: location_value}
+        validated_profile = IKECryptoProfile(
+            name=name,
+            hash=hash,
+            dh_group=dh_group,
+            encryption=encryption,
+            lifetime_seconds=lifetime_seconds,
+            lifetime_minutes=lifetime_minutes,
+            lifetime_hours=lifetime_hours,
+            lifetime_days=lifetime_days,
+            authentication_multiple=authentication_multiple,
+            **location_kwargs,
+        )
         sdk_data = validated_profile.to_sdk_model()
         result = scm_client.create_ike_crypto_profile(sdk_data)
         action = result.pop("__action__", "created")
@@ -939,10 +940,11 @@ def set_ike_gateway(
             raise typer.Exit(code=1)
 
         # Build protocol
+        protocol: dict[str, Any]
         if protocol_json:
             protocol = json.loads(protocol_json)
         else:
-            protocol: dict[str, Any] = {"version": protocol_version}
+            protocol = {"version": protocol_version}
             if protocol_version in ("ikev1", "ikev2-preferred"):
                 ikev1_config: dict[str, Any] = {}
                 if ike_crypto_profile:
@@ -1653,12 +1655,20 @@ def set_ipsec_crypto_profile(
     try:
         profile = IPSecCryptoProfile(
             folder=folder,
+            snippet=None,
+            device=None,
             name=name,
             esp_encryption=esp_encryption,
             esp_authentication=esp_authentication,
             dh_group=dh_group,
             lifetime_seconds=lifetime_seconds,
+            lifetime_minutes=None,
             lifetime_hours=lifetime_hours,
+            lifetime_days=None,
+            lifesize_kb=None,
+            lifesize_mb=None,
+            lifesize_gb=None,
+            lifesize_tb=None,
         )
 
         sdk_data = profile.to_sdk_model()


### PR DESCRIPTION
## Summary
- Fix 13 mypy errors in `network.py` (3 root causes):
  - `IKECryptoProfile`: use explicit kwargs instead of `**dict` unpacking (fixes 4 `arg-type` errors)
  - IKE gateway `protocol` variable: pre-declare type annotation to avoid `no-redef` (fixes 1 error)
  - `IPSecCryptoProfile`: pass all optional kwargs explicitly (fixes 8 `call-arg` errors)
- Remove `continue-on-error: true` from mypy CI step — type checking now enforced on PRs

## Test plan
- [x] `mypy src/scm_cli/` — 0 errors (was 13)
- [x] 758 tests pass
- [x] Ruff lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)