### PR TITLE
feat: add --force flag to 16 remaining delete commands

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,14 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.8
+
+**Released:** March 10, 2026
+
+### Added
+
+- **Delete Confirmation Prompts**: Added `--force` flag and confirmation prompts to 16 remaining delete commands across identity (6), deployment (5), setup (4), and mobile-agent (1) modules. All delete commands now consistently require confirmation before proceeding.
+
 ## Version 1.0.7
 
 **Released:** March 10, 2026

--- a/docs/cli/deployment/bandwidth.md
+++ b/docs/cli/deployment/bandwidth.md
@@ -77,11 +77,12 @@ scm delete sase bandwidth [OPTIONS]
 | --- | --- | --- |
 | `--name TEXT` | Name of the bandwidth allocation to delete | Yes |
 | `--spn-name-list TEXT` | SPN names (comma-separated if multiple) | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete sase bandwidth-allocation --name Standard-Branch --spn-name-list "branch-spn-1"
+$ scm delete sase bandwidth-allocation --name Standard-Branch --spn-name-list "branch-spn-1" --force
 ---> 100%
 Deleted bandwidth allocation: Standard-Branch
 ```

--- a/docs/cli/deployment/bgp-routing.md
+++ b/docs/cli/deployment/bgp-routing.md
@@ -74,13 +74,19 @@ Reset BGP routing configuration to defaults.
 ### Syntax
 
 ```bash
-scm delete sase bgp-routing
+scm delete sase bgp-routing [OPTIONS]
 ```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete sase bgp-routing
+$ scm delete sase bgp-routing --force
 ---> 100%
 Reset BGP routing configuration to defaults
 ```

--- a/docs/cli/deployment/internal-dns-server.md
+++ b/docs/cli/deployment/internal-dns-server.md
@@ -71,11 +71,12 @@ scm delete sase internal-dns-server [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `--name TEXT` | Name of the DNS server entry to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete sase internal-dns-server --name corp-dns
+$ scm delete sase internal-dns-server --name corp-dns --force
 ---> 100%
 Deleted internal DNS server: corp-dns
 ```

--- a/docs/cli/deployment/remote-network.md
+++ b/docs/cli/deployment/remote-network.md
@@ -130,11 +130,12 @@ scm delete sase remote-network [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `--name TEXT` | Name of the remote network to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete sase remote-network --name branch-office-nyc
+$ scm delete sase remote-network --name branch-office-nyc --force
 ---> 100%
 Deleted remote network: branch-office-nyc
 ```

--- a/docs/cli/deployment/service-connection.md
+++ b/docs/cli/deployment/service-connection.md
@@ -104,11 +104,12 @@ scm delete sase service-connection [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `--name TEXT` | Name of the service connection to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete sase service-connection --name branch-office-1
+$ scm delete sase service-connection --name branch-office-1 --force
 ---> 100%
 Deleted service connection: branch-office-1
 ```

--- a/docs/cli/identity/authentication-profile.md
+++ b/docs/cli/identity/authentication-profile.md
@@ -97,6 +97,7 @@ scm delete identity authentication-profile [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -105,7 +106,8 @@ scm delete identity authentication-profile [OPTIONS]
 ```bash
 $ scm delete identity authentication-profile \
     --folder Texas \
-    --name corp-ldap-auth
+    --name corp-ldap-auth \
+    --force
 ---> 100%
 Deleted authentication-profile: corp-ldap-auth from folder Texas
 ```

--- a/docs/cli/identity/kerberos-server-profile.md
+++ b/docs/cli/identity/kerberos-server-profile.md
@@ -76,6 +76,7 @@ scm delete identity kerberos-server-profile [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -84,7 +85,8 @@ scm delete identity kerberos-server-profile [OPTIONS]
 ```bash
 $ scm delete identity kerberos-server-profile \
     --folder Texas \
-    --name corp-kerberos
+    --name corp-kerberos \
+    --force
 ---> 100%
 Deleted kerberos-server-profile: corp-kerberos from folder Texas
 ```

--- a/docs/cli/identity/ldap-server-profile.md
+++ b/docs/cli/identity/ldap-server-profile.md
@@ -110,6 +110,7 @@ scm delete identity ldap-server-profile [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -118,7 +119,8 @@ scm delete identity ldap-server-profile [OPTIONS]
 ```bash
 $ scm delete identity ldap-server-profile \
     --folder Texas \
-    --name corp-ldap
+    --name corp-ldap \
+    --force
 ---> 100%
 Deleted ldap-server-profile: corp-ldap from folder Texas
 ```

--- a/docs/cli/identity/radius-server-profile.md
+++ b/docs/cli/identity/radius-server-profile.md
@@ -97,6 +97,7 @@ scm delete identity radius-server-profile [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -105,7 +106,8 @@ scm delete identity radius-server-profile [OPTIONS]
 ```bash
 $ scm delete identity radius-server-profile \
     --folder Texas \
-    --name corp-radius
+    --name corp-radius \
+    --force
 ---> 100%
 Deleted radius-server-profile: corp-radius from folder Texas
 ```

--- a/docs/cli/identity/saml-server-profile.md
+++ b/docs/cli/identity/saml-server-profile.md
@@ -107,6 +107,7 @@ scm delete identity saml-server-profile [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -115,7 +116,8 @@ scm delete identity saml-server-profile [OPTIONS]
 ```bash
 $ scm delete identity saml-server-profile \
     --folder Texas \
-    --name corp-saml
+    --name corp-saml \
+    --force
 ---> 100%
 Deleted saml-server-profile: corp-saml from folder Texas
 ```

--- a/docs/cli/identity/tacacs-server-profile.md
+++ b/docs/cli/identity/tacacs-server-profile.md
@@ -97,6 +97,7 @@ scm delete identity tacacs-server-profile [OPTIONS]
 | `--folder TEXT` | Folder location | No\* |
 | `--snippet TEXT` | Snippet location | No\* |
 | `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
@@ -105,7 +106,8 @@ scm delete identity tacacs-server-profile [OPTIONS]
 ```bash
 $ scm delete identity tacacs-server-profile \
     --folder Texas \
-    --name corp-tacacs
+    --name corp-tacacs \
+    --force
 ---> 100%
 Deleted tacacs-server-profile: corp-tacacs from folder Texas
 ```

--- a/docs/cli/mobile-agent/auth-setting.md
+++ b/docs/cli/mobile-agent/auth-setting.md
@@ -104,13 +104,15 @@ scm delete mobile-agent auth-setting [OPTIONS]
 | --- | --- | --- |
 | `--folder TEXT` | Folder location | Yes |
 | `--name TEXT` | Name of the auth setting to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
 $ scm delete mobile-agent auth-setting \
     --folder "Mobile Users" \
-    --name "saml-auth"
+    --name "saml-auth" \
+    --force
 ---> 100%
 Deleted auth setting: saml-auth from folder Mobile Users
 ```

--- a/docs/cli/setup/folder.md
+++ b/docs/cli/setup/folder.md
@@ -82,11 +82,12 @@ scm delete setup folder [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `--name TEXT` | Name of the folder to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete setup folder --name Branch
+$ scm delete setup folder --name Branch --force
 ---> 100%
 Deleted folder: Branch
 ```

--- a/docs/cli/setup/label.md
+++ b/docs/cli/setup/label.md
@@ -64,11 +64,12 @@ scm delete setup label [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `--name TEXT` | Name of the label to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete setup label --name staging
+$ scm delete setup label --name staging --force
 ---> 100%
 Deleted label: staging
 ```

--- a/docs/cli/setup/snippet.md
+++ b/docs/cli/setup/snippet.md
@@ -78,11 +78,12 @@ scm delete setup snippet [OPTIONS]
 | Option | Description | Required |
 | --- | --- | --- |
 | `--name TEXT` | Name of the snippet to delete | Yes |
+| `--force` | Skip confirmation prompt | No |
 
 ### Example
 
 ```bash
-$ scm delete setup snippet --name "DNS-Best-Practice"
+$ scm delete setup snippet --name "DNS-Best-Practice" --force
 ---> 100%
 Deleted snippet: DNS-Best-Practice
 ```

--- a/docs/cli/setup/variable.md
+++ b/docs/cli/setup/variable.md
@@ -107,13 +107,14 @@ scm delete setup variable [OPTIONS]
 | `--folder TEXT` | Folder scope | No\* |
 | `--snippet TEXT` | Snippet scope | No\* |
 | `--device TEXT` | Device scope | No\* |
+| `--force` | Skip confirmation prompt | No |
 
 \* One of --folder, --snippet, or --device is required.
 
 ### Example
 
 ```bash
-$ scm delete setup variable --name "\$egress-max" --folder Texas
+$ scm delete setup variable --name "\$egress-max" --folder Texas --force
 ---> 100%
 Deleted variable: $egress-max from folder Texas
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.7"
+version = "1.0.8"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/commands/deployment.py
+++ b/src/scm_cli/commands/deployment.py
@@ -110,6 +110,7 @@ def backup_bandwidth_allocation():
 def delete_bandwidth_allocation(
     name: str = NAME_OPTION,
     spn_name_list: str = typer.Option(..., "--spn-name-list", help="SPN names (comma-separated if multiple)"),
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a bandwidth allocation.
 
@@ -127,6 +128,9 @@ def delete_bandwidth_allocation(
         if isinstance(spn_name_list, list):
             typer.echo("Error: --spn-name-list must be a comma-separated string (e.g., --spn-name-list foo,bar)", err=True)
             raise typer.Exit(code=1)
+
+        if not force:
+            typer.confirm(f"Delete bandwidth allocation '{name}'?", abort=True)
 
         # Convert comma-separated string to list
         spn_list = ([spn.strip() for spn in spn_name_list.split(",")] if "," in spn_name_list else [spn_name_list.strip()]) if isinstance(spn_name_list, str) else spn_name_list
@@ -424,6 +428,7 @@ def backup_service_connection():
 @delete_app.command("service-connection")
 def delete_service_connection(
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a service connection.
 
@@ -433,6 +438,8 @@ def delete_service_connection(
 
     """
     try:
+        if not force:
+            typer.confirm(f"Delete service connection '{name}'?", abort=True)
         result = scm_client.delete_service_connection(name=name)
         if result:
             typer.echo(f"Deleted service connection: {name}")
@@ -755,6 +762,7 @@ def backup_remote_network():
 @delete_app.command("remote-network")
 def delete_remote_network(
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a remote network.
 
@@ -764,6 +772,8 @@ def delete_remote_network(
 
     """
     try:
+        if not force:
+            typer.confirm(f"Delete remote network '{name}'?", abort=True)
         result = scm_client.delete_remote_network(
             name=name,
         )
@@ -1046,7 +1056,9 @@ BGP_WITHDRAW_STATIC_OPTION = typer.Option(False, "--withdraw-static-route", help
 
 
 @delete_app.command("bgp-routing")
-def delete_bgp_routing():
+def delete_bgp_routing(
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+):
     """Reset BGP routing configuration to defaults.
 
     Example:
@@ -1057,6 +1069,8 @@ def delete_bgp_routing():
 
     """
     try:
+        if not force:
+            typer.confirm("Reset BGP routing configuration to defaults?", abort=True)
         result = scm_client.delete_bgp_routing()
         if result:
             typer.echo("Reset BGP routing configuration to defaults")
@@ -1222,6 +1236,7 @@ def backup_internal_dns_server():
 @delete_app.command("internal-dns-server")
 def delete_internal_dns_server(
     name: str = DNS_NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete an internal DNS server.
 
@@ -1231,6 +1246,8 @@ def delete_internal_dns_server(
 
     """
     try:
+        if not force:
+            typer.confirm(f"Delete internal DNS server '{name}'?", abort=True)
         result = scm_client.delete_internal_dns_server(name=name)
         if result:
             typer.echo(f"Deleted internal DNS server: {name}")

--- a/src/scm_cli/commands/identity.py
+++ b/src/scm_cli/commands/identity.py
@@ -222,6 +222,7 @@ def delete_authentication_profile(
     snippet: str | None = SNIPPET_OPTION,
     device: str | None = DEVICE_OPTION,
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete an authentication profile.
 
@@ -230,6 +231,8 @@ def delete_authentication_profile(
     """
     try:
         location_type, location_value = validate_location_params(folder, snippet, device)
+        if not force:
+            typer.confirm(f"Delete authentication profile '{name}' from {location_type} '{location_value}'?", abort=True)
         result = scm_client.delete_authentication_profile(name=name, **{location_type: location_value})
 
         if result:
@@ -467,6 +470,7 @@ def delete_kerberos_server_profile(
     snippet: str | None = SNIPPET_OPTION,
     device: str | None = DEVICE_OPTION,
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a Kerberos server profile.
 
@@ -475,6 +479,8 @@ def delete_kerberos_server_profile(
     """
     try:
         location_type, location_value = validate_location_params(folder, snippet, device)
+        if not force:
+            typer.confirm(f"Delete Kerberos server profile '{name}' from {location_type} '{location_value}'?", abort=True)
         result = scm_client.delete_kerberos_server_profile(name=name, **{location_type: location_value})
 
         if result:
@@ -733,6 +739,7 @@ def delete_ldap_server_profile(
     snippet: str | None = SNIPPET_OPTION,
     device: str | None = DEVICE_OPTION,
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete an LDAP server profile.
 
@@ -741,6 +748,8 @@ def delete_ldap_server_profile(
     """
     try:
         location_type, location_value = validate_location_params(folder, snippet, device)
+        if not force:
+            typer.confirm(f"Delete LDAP server profile '{name}' from {location_type} '{location_value}'?", abort=True)
         result = scm_client.delete_ldap_server_profile(name=name, **{location_type: location_value})
 
         if result:
@@ -994,6 +1003,7 @@ def delete_radius_server_profile(
     snippet: str | None = SNIPPET_OPTION,
     device: str | None = DEVICE_OPTION,
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a RADIUS server profile.
 
@@ -1002,6 +1012,8 @@ def delete_radius_server_profile(
     """
     try:
         location_type, location_value = validate_location_params(folder, snippet, device)
+        if not force:
+            typer.confirm(f"Delete RADIUS server profile '{name}' from {location_type} '{location_value}'?", abort=True)
         result = scm_client.delete_radius_server_profile(name=name, **{location_type: location_value})
 
         if result:
@@ -1262,6 +1274,7 @@ def delete_saml_server_profile(
     snippet: str | None = SNIPPET_OPTION,
     device: str | None = DEVICE_OPTION,
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a SAML server profile.
 
@@ -1270,6 +1283,8 @@ def delete_saml_server_profile(
     """
     try:
         location_type, location_value = validate_location_params(folder, snippet, device)
+        if not force:
+            typer.confirm(f"Delete SAML server profile '{name}' from {location_type} '{location_value}'?", abort=True)
         result = scm_client.delete_saml_server_profile(name=name, **{location_type: location_value})
 
         if result:
@@ -1522,6 +1537,7 @@ def delete_tacacs_server_profile(
     snippet: str | None = SNIPPET_OPTION,
     device: str | None = DEVICE_OPTION,
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a TACACS+ server profile.
 
@@ -1530,6 +1546,8 @@ def delete_tacacs_server_profile(
     """
     try:
         location_type, location_value = validate_location_params(folder, snippet, device)
+        if not force:
+            typer.confirm(f"Delete TACACS+ server profile '{name}' from {location_type} '{location_value}'?", abort=True)
         result = scm_client.delete_tacacs_server_profile(name=name, **{location_type: location_value})
 
         if result:

--- a/src/scm_cli/commands/mobile_agent.py
+++ b/src/scm_cli/commands/mobile_agent.py
@@ -321,6 +321,7 @@ def backup_auth_setting(
 def delete_auth_setting(
     folder: str = FOLDER_OPTION,
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete an auth setting.
 
@@ -330,6 +331,8 @@ def delete_auth_setting(
 
     """
     try:
+        if not force:
+            typer.confirm(f"Delete auth setting '{name}' from folder '{folder}'?", abort=True)
         result = scm_client.delete_auth_setting(folder=folder, name=name)
         if result:
             typer.echo(f"Deleted auth setting: {name} from folder {folder}")

--- a/src/scm_cli/commands/setup.py
+++ b/src/scm_cli/commands/setup.py
@@ -253,12 +253,15 @@ def show_folder(
 @delete_app.command("folder")
 def delete_folder(
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a folder.
 
     Example: scm delete setup folder --name Branch
     """
     try:
+        if not force:
+            typer.confirm(f"Delete folder '{name}'?", abort=True)
         result = scm_client.delete_folder(name=name)
 
         if result:
@@ -443,12 +446,15 @@ def show_label(
 @delete_app.command("label")
 def delete_label(
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a label.
 
     Example: scm delete setup label --name staging
     """
     try:
+        if not force:
+            typer.confirm(f"Delete label '{name}'?", abort=True)
         result = scm_client.delete_label(name=name)
 
         if result:
@@ -645,12 +651,15 @@ def show_snippet(
 @delete_app.command("snippet")
 def delete_snippet(
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a snippet.
 
     Example: scm delete setup snippet --name "DNS-Best-Practice"
     """
     try:
+        if not force:
+            typer.confirm(f"Delete snippet '{name}'?", abort=True)
         result = scm_client.delete_snippet(name=name)
 
         if result:
@@ -863,6 +872,7 @@ def delete_variable(
     folder: str | None = FOLDER_OPTION,
     snippet: str | None = SNIPPET_OPTION,
     device: str | None = DEVICE_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     r"""Delete a variable.
 
@@ -870,6 +880,8 @@ def delete_variable(
     """
     try:
         container_type, container_value = validate_container_params(folder, snippet, device)
+        if not force:
+            typer.confirm(f"Delete variable '{name}' from {container_type} '{container_value}'?", abort=True)
         result = scm_client.delete_variable(name=name, folder=folder, snippet=snippet, device=device)
 
         if result:

--- a/tests/test_deployment_commands.py
+++ b/tests/test_deployment_commands.py
@@ -137,6 +137,7 @@ class TestBandwidthAllocationCommands:
                 "test-allocation",
                 "--spn-name-list",
                 "spn1",
+                "--force",
             ],
         )
 
@@ -166,6 +167,7 @@ class TestBandwidthAllocationCommands:
                 "test-allocation",
                 "--spn-name-list",
                 "spn1",
+                "--force",
             ],
         )
 
@@ -367,7 +369,7 @@ class TestBGPRoutingCommands:
         test_app = typer.Typer()
         test_app.command()(delete_bgp_routing)
 
-        result = runner.invoke(test_app, [])
+        result = runner.invoke(test_app, ["--force"])
 
         assert result.exit_code == 0
         assert "Reset BGP routing" in result.stdout
@@ -509,7 +511,7 @@ class TestInternalDNSServerCommands:
         test_app = typer.Typer()
         test_app.command()(delete_internal_dns_server)
 
-        result = runner.invoke(test_app, ["--name", "corp-dns"])
+        result = runner.invoke(test_app, ["--name", "corp-dns", "--force"])
 
         assert result.exit_code == 0
         assert "Deleted internal DNS server" in result.stdout

--- a/tests/test_identity_commands.py
+++ b/tests/test_identity_commands.py
@@ -104,7 +104,7 @@ class TestAuthenticationProfileCommands:
         test_app = typer.Typer()
         test_app.command()(delete_authentication_profile)
 
-        result = runner.invoke(test_app, ["--folder", "Texas", "--name", "test-auth"])
+        result = runner.invoke(test_app, ["--folder", "Texas", "--name", "test-auth", "--force"])
         assert result.exit_code == 0
         assert "Deleted authentication profile" in result.output
 

--- a/tests/test_mobile_agent_commands.py
+++ b/tests/test_mobile_agent_commands.py
@@ -341,7 +341,7 @@ class TestAuthSettingCommands:
 
         result = runner.invoke(
             test_app,
-            ["--folder", "Mobile Users", "--name", "saml-auth"],
+            ["--folder", "Mobile Users", "--name", "saml-auth", "--force"],
         )
 
         assert result.exit_code == 0
@@ -361,7 +361,7 @@ class TestAuthSettingCommands:
 
         result = runner.invoke(
             test_app,
-            ["--folder", "Mobile Users", "--name", "nonexistent"],
+            ["--folder", "Mobile Users", "--name", "nonexistent", "--force"],
         )
 
         assert result.exit_code == 1

--- a/tests/test_setup_commands.py
+++ b/tests/test_setup_commands.py
@@ -119,7 +119,7 @@ class TestFolderCommands:
         test_app = typer.Typer()
         test_app.command()(delete_folder)
 
-        result = runner.invoke(test_app, ["--name", "Texas"])
+        result = runner.invoke(test_app, ["--name", "Texas", "--force"])
 
         assert result.exit_code == 0
         assert "Deleted folder" in result.stdout
@@ -179,7 +179,7 @@ class TestLabelCommands:
         test_app = typer.Typer()
         test_app.command()(delete_label)
 
-        result = runner.invoke(test_app, ["--name", "staging"])
+        result = runner.invoke(test_app, ["--name", "staging", "--force"])
 
         assert result.exit_code == 0
         assert "Deleted label" in result.stdout
@@ -239,7 +239,7 @@ class TestSnippetCommands:
         test_app = typer.Typer()
         test_app.command()(delete_snippet)
 
-        result = runner.invoke(test_app, ["--name", "Web-Security"])
+        result = runner.invoke(test_app, ["--name", "Web-Security", "--force"])
 
         assert result.exit_code == 0
         assert "Deleted snippet" in result.stdout
@@ -300,7 +300,7 @@ class TestVariableCommands:
         test_app = typer.Typer()
         test_app.command()(delete_variable)
 
-        result = runner.invoke(test_app, ["--name", "$egress-max", "--folder", "Texas"])
+        result = runner.invoke(test_app, ["--name", "$egress-max", "--folder", "Texas", "--force"])
 
         assert result.exit_code == 0
         assert "Deleted variable" in result.stdout


### PR DESCRIPTION
## Summary
- Added `--force` flag and confirmation prompts to 16 remaining delete commands across identity (6), deployment (5), setup (4), and mobile-agent (1) modules
- All delete commands now consistently require confirmation before proceeding
- Version bump to 1.0.8

Closes #3

## Changes
- **identity.py**: authentication-profile, kerberos-server-profile, ldap-server-profile, radius-server-profile, saml-server-profile, tacacs-server-profile
- **deployment.py**: bandwidth-allocation, service-connection, remote-network, bgp-routing, internal-dns-server
- **setup.py**: folder, label, snippet, variable
- **mobile_agent.py**: auth-setting
- Updated all corresponding tests to pass `--force`
- Updated 16 doc pages with `--force` option and examples
- Release notes for v1.0.8

## Test plan
- [x] All 767 tests pass locally
- [x] ruff check clean
- [x] ruff format clean
- [x] mypy clean
- [x] mkdocs build --strict passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)