### PR TITLE
fix: bugfix bundle v1.0.10 (#008-#011)

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,16 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.10
+
+**Released:** March 10, 2026
+
+### Fixed
+
+- **Syslog Server Profile Delete**: Fixed `delete_syslog_server_profile()` to use fetch→delete-by-ID pattern instead of name-based deletion, matching the pattern used by all other delete methods.
+- **Comma Parsing Consistency**: Replaced 3 manual `.split(",")` calls in `set_service` and `set_service_group` with `parse_comma_separated_list()` for consistent comma-separated value handling.
+- **SDK Documentation Navigation**: Added 6 missing SDK Reference doc links to mkdocs.yml navigation (objects, network, security, deployment, setup, mobile-agent).
+
 ## Version 1.0.9
 
 **Released:** March 10, 2026

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
           - Service Group: cli/objects/service-group.md
           - Syslog Server Profile: cli/objects/syslog-server-profile.md
           - Tag: cli/objects/tag.md
+          - SDK Reference: cli/objects/sdk-objects.md
       - Network:
           - Aggregate Interface: cli/network/aggregate-interface.md
           - BGP Address Family Profile: cli/network/bgp-address-family-profile.md
@@ -119,6 +120,7 @@ nav:
           - Security Zone: cli/network/security-zone.md
           - Tunnel Interface: cli/network/tunnel-interface.md
           - VLAN Interface: cli/network/vlan-interface.md
+          - SDK Reference: cli/network/sdk-network.md
       - Security:
           - Anti-Spyware Profile: cli/security/anti-spyware-profile.md
           - App Override Rule: cli/security/app-override-rule.md
@@ -131,6 +133,7 @@ nav:
           - URL Category: cli/security/url-category.md
           - Vulnerability Protection Profile: cli/security/vulnerability-protection-profile.md
           - WildFire Antivirus Profile: cli/security/wildfire-antivirus-profile.md
+          - SDK Reference: cli/security/sdk-security.md
       - Deployment:
           - Bandwidth Allocation: cli/deployment/bandwidth.md
           - BGP Routing: cli/deployment/bgp-routing.md
@@ -138,12 +141,14 @@ nav:
           - Network Location: cli/deployment/network-location.md
           - Remote Network: cli/deployment/remote-network.md
           - Service Connection: cli/deployment/service-connection.md
+          - SDK Reference: cli/deployment/sdk-deployment.md
       - Setup:
           - Device: cli/setup/device.md
           - Folder: cli/setup/folder.md
           - Label: cli/setup/label.md
           - Snippet: cli/setup/snippet.md
           - Variable: cli/setup/variable.md
+          - SDK Reference: cli/setup/sdk-setup.md
       - Identity:
           - Authentication Profile: cli/identity/authentication-profile.md
           - Kerberos Server Profile: cli/identity/kerberos-server-profile.md
@@ -154,6 +159,7 @@ nav:
       - Mobile Agent:
           - Agent Version: cli/mobile-agent/agent-version.md
           - Auth Setting: cli/mobile-agent/auth-setting.md
+          - SDK Reference: cli/mobile-agent/sdk-mobile-agent.md
       - Jobs: cli/jobs.md
       - Commit: cli/commit.md
       - Insights: cli/insights.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.9"
+version = "1.0.10"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -5725,7 +5725,7 @@ def set_service(
         # Parse tags if provided
         tag_list = None
         if tag:
-            tag_list = [t.strip() for t in tag.split(",") if t.strip()]
+            tag_list = parse_comma_separated_list([tag])
 
         # Validate using Pydantic model
         service_data: dict[str, Any] = {
@@ -6093,7 +6093,7 @@ def set_service_group(
     """Create or update a service group."""
     try:
         # Parse members
-        member_list = [m.strip() for m in members.split(",") if m.strip()]
+        member_list = parse_comma_separated_list([members])
         if not member_list:
             typer.echo("Error: At least one member must be provided", err=True)
             raise typer.Exit(code=1)
@@ -6101,7 +6101,7 @@ def set_service_group(
         # Parse tags if provided
         tag_list = None
         if tag:
-            tag_list = [t.strip() for t in tag.split(",") if t.strip()]
+            tag_list = parse_comma_separated_list([tag])
 
         # Validate using Pydantic model
         service_group_data: dict[str, Any] = {

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -4711,7 +4711,9 @@ class SCMClient:
             container_kwargs["device"] = device
 
         try:
-            self.client.syslog_server_profile.delete(name, **container_kwargs)
+            # Fetch first to get the ID, then delete by ID (consistent with other delete methods)
+            profile = self.client.syslog_server_profile.fetch(name=name, **container_kwargs)
+            self.client.syslog_server_profile.delete(str(profile.id))
             self.logger.info(f"Deleted syslog server profile: {name}")
         except Exception as e:
             location_value = folder or snippet or device or "unknown"

--- a/tests/test_objects_commands.py
+++ b/tests/test_objects_commands.py
@@ -1334,3 +1334,42 @@ class TestSyslogServerProfileUpsert:
 
         assert result.exit_code == 0
         assert "No changes needed" in result.stdout
+
+
+class TestCommaParsingConsistency:
+    """Test that set_service and set_service_group use parse_comma_separated_list."""
+
+    def test_set_service_parses_comma_tags(self, runner, monkeypatch):
+        """Tags with commas should be split correctly."""
+        from scm_cli.commands.objects import set_service
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured = {}
+
+        def mock_create(*args, **kwargs):
+            captured.update(kwargs)
+            return {"id": "svc-1", "name": kwargs.get("name"), "folder": kwargs.get("folder"), "__action__": "created"}
+
+        monkeypatch.setattr(scm_client, "create_service", mock_create)
+        test_app = typer.Typer()
+        test_app.command()(set_service)
+        result = runner.invoke(test_app, ["--folder", "Texas", "--name", "test-svc", "--protocol", "tcp", "--port", "80", "--tag", "web, production"])
+        assert result.exit_code == 0
+        assert captured.get("tag") == ["web", "production"]
+
+    def test_set_service_group_parses_comma_members(self, runner, monkeypatch):
+        """Members with commas should be split correctly."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured = {}
+
+        def mock_create(*args, **kwargs):
+            captured.update(kwargs)
+            return {"id": "sg-1", "name": kwargs.get("name"), "folder": kwargs.get("folder"), "__action__": "created"}
+
+        monkeypatch.setattr(scm_client, "create_service_group", mock_create)
+        test_app = typer.Typer()
+        test_app.command()(set_service_group)
+        result = runner.invoke(test_app, ["--folder", "Texas", "--name", "test-sg", "--members", "HTTP, HTTPS, SSH"])
+        assert result.exit_code == 0
+        assert captured.get("members") == ["HTTP", "HTTPS", "SSH"]


### PR DESCRIPTION
## Summary
- **#008**: `delete_syslog_server_profile()` refactored to fetch→delete-by-ID pattern
- **#009**: 3 manual `.split(",")` replaced with `parse_comma_separated_list()` in `set_service`/`set_service_group`
- **#010**: 6 missing SDK Reference doc links added to mkdocs.yml nav (objects, network, security, deployment, setup, mobile-agent)
- **#011**: `poetry update pan-scm-sdk` to refresh lock file

## Test plan
- [x] 755 tests pass (`pytest` — 0 failures)
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — 21 files already formatted
- [x] `mypy` — 0 errors in 21 source files
- [x] `mkdocs build --strict` — passes
- [x] New `TestCommaParsingConsistency` tests verify comma splitting works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)