### PR TITLE
feat: Python 3.10+ support (v1.0.11)

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,15 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.11
+
+**Released:** March 11, 2026
+
+### Changed
+
+- **Python Version Support**: Lowered minimum Python version from 3.12 to 3.10, broadening compatibility for more environments.
+- **Ruff Target Version**: Updated ruff target-version from `py312` to `py310` to match the new minimum Python version.
+
 ## Version 1.0.10
 
 **Released:** March 10, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.10"
+version = "1.0.11"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"
 packages = [{ include = "scm_cli", from = "src" }]
 
 [tool.poetry.dependencies]
-python = ">=3.12,<3.14"
+python = ">=3.10,<3.14"
 typer = "^0.15.4"
 pyyaml = "^6.0.2"
 pydantic = "^2.11.5"
@@ -46,7 +46,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py310"
 line-length = 192
 
 [tool.ruff.lint]


### PR DESCRIPTION
## Summary
- Lower minimum Python version from 3.12 to 3.10 in pyproject.toml
- Update ruff target-version from py312 to py310 to match

## Test plan
- [x] `ruff check` — all checks passed
- [x] `ruff format --check` — 21 files already formatted
- [x] `mypy` — 0 errors in 21 source files
- [x] `pytest` — 755 passed, 0 failed
- [x] `mkdocs build --strict` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)