### PR TITLE
docs: fix command name mismatches, add auto-tag-action docs (v1.0.12)

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,20 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.12
+
+**Released:** March 11, 2026
+
+### Fixed
+
+- **Security Zone Docs**: Fixed command name from `security-zone` to `zone` in all CLI examples in `docs/cli/network/security-zone.md`.
+- **Bandwidth Allocation Docs**: Fixed command name from `bandwidth` to `bandwidth-allocation` in syntax blocks in `docs/cli/deployment/bandwidth.md`.
+- **Docstring Typo**: Fixed `Returnas:` → `Returns:` in `validate_location_params()` docstring.
+
+### Added
+
+- **Auto Tag Action Documentation**: Added full CLI reference page for auto-tag-action commands (set, delete, load, show, backup).
+
 ## Version 1.0.11
 
 **Released:** March 11, 2026

--- a/docs/cli/deployment/bandwidth.md
+++ b/docs/cli/deployment/bandwidth.md
@@ -4,7 +4,7 @@ Bandwidth allocations control and optimize bandwidth usage across your SASE netw
 
 ## Overview
 
-The `bandwidth` commands allow you to:
+The `bandwidth-allocation` commands allow you to:
 
 - Create bandwidth allocations with guaranteed and maximum bandwidth limits
 - Assign allocations to specific Service Provider Networks (SPNs)
@@ -19,7 +19,7 @@ Create or update a bandwidth allocation.
 ### Syntax
 
 ```bash
-scm set sase bandwidth [OPTIONS]
+scm set sase bandwidth-allocation [OPTIONS]
 ```
 
 ### Options
@@ -68,7 +68,7 @@ Delete a bandwidth allocation from SCM.
 ### Syntax
 
 ```bash
-scm delete sase bandwidth [OPTIONS]
+scm delete sase bandwidth-allocation [OPTIONS]
 ```
 
 ### Options
@@ -94,7 +94,7 @@ Load multiple bandwidth allocations from a YAML file.
 ### Syntax
 
 ```bash
-scm load sase bandwidth [OPTIONS]
+scm load sase bandwidth-allocation [OPTIONS]
 ```
 
 ### Options
@@ -131,7 +131,7 @@ bandwidth_allocations:
 #### Load with Original Locations
 
 ```bash
-$ scm load sase bandwidth --file bandwidth-allocations.yml
+$ scm load sase bandwidth-allocation --file bandwidth-allocations.yml
 ---> 100%
 ✓ Loaded bandwidth allocation: Standard-Branch
 ✓ Loaded bandwidth allocation: HQ-Bandwidth
@@ -147,7 +147,7 @@ Display bandwidth allocation objects.
 ### Syntax
 
 ```bash
-scm show sase bandwidth [OPTIONS]
+scm show sase bandwidth-allocation [OPTIONS]
 ```
 
 ### Options

--- a/docs/cli/network/security-zone.md
+++ b/docs/cli/network/security-zone.md
@@ -4,7 +4,7 @@ Security zones are logical divisions of the network that define boundaries for t
 
 ## Overview
 
-The `security-zone` commands allow you to:
+The `zone` commands allow you to:
 
 - Create security zones with layer3, layer2, virtual-wire, or TAP mode
 - Update existing security zone configurations
@@ -28,7 +28,7 @@ Create or update a security zone.
 ### Syntax
 
 ```bash
-scm set network security-zone [OPTIONS]
+scm set network zone [OPTIONS]
 ```
 
 ### Options
@@ -49,7 +49,7 @@ scm set network security-zone [OPTIONS]
 #### Create a Layer3 Security Zone
 
 ```bash
-$ scm set network security-zone \
+$ scm set network zone \
     --folder Shared \
     --name Trust \
     --mode layer3 \
@@ -62,7 +62,7 @@ Created security zone: Trust in folder Shared
 #### Create a Virtual-Wire Security Zone
 
 ```bash
-$ scm set network security-zone \
+$ scm set network zone \
     --folder Shared \
     --name DMZ \
     --mode virtual-wire \
@@ -78,7 +78,7 @@ Delete a security zone from SCM.
 ### Syntax
 
 ```bash
-scm delete network security-zone [OPTIONS]
+scm delete network zone [OPTIONS]
 ```
 
 ### Options
@@ -92,7 +92,7 @@ scm delete network security-zone [OPTIONS]
 ### Example
 
 ```bash
-$ scm delete network security-zone --folder Shared --name DMZ --force
+$ scm delete network zone --folder Shared --name DMZ --force
 ---> 100%
 Deleted security zone: DMZ from folder Shared
 ```
@@ -104,7 +104,7 @@ Load multiple security zones from a YAML file.
 ### Syntax
 
 ```bash
-scm load network security-zone [OPTIONS]
+scm load network zone [OPTIONS]
 ```
 
 ### Options
@@ -156,7 +156,7 @@ security_zones:
 #### Load with Original Locations
 
 ```bash
-$ scm load network security-zone --file security-zones.yml
+$ scm load network zone --file security-zones.yml
 ---> 100%
 ✓ Loaded security zone: Trust
 ✓ Loaded security zone: Untrust
@@ -168,7 +168,7 @@ Successfully loaded 3 out of 3 security zones from 'security-zones.yml'
 #### Load with Folder Override
 
 ```bash
-$ scm load network security-zone --file security-zones.yml --folder Austin
+$ scm load network zone --file security-zones.yml --folder Austin
 ---> 100%
 ✓ Loaded security zone: Trust
 ✓ Loaded security zone: Untrust
@@ -189,7 +189,7 @@ Display security zone objects.
 ### Syntax
 
 ```bash
-scm show network security-zone [OPTIONS]
+scm show network zone [OPTIONS]
 ```
 
 ### Options
@@ -211,7 +211,7 @@ scm show network security-zone [OPTIONS]
 #### Show Specific Security Zone
 
 ```bash
-$ scm show network security-zone --folder Shared --name Trust
+$ scm show network zone --folder Shared --name Trust
 ---> 100%
 Security Zone: Trust
   Location: Folder 'Shared'
@@ -224,7 +224,7 @@ Security Zone: Trust
 #### List All Security Zones (Default Behavior)
 
 ```bash
-$ scm show network security-zone --folder Shared
+$ scm show network zone --folder Shared
 ---> 100%
 Security zones in folder 'Shared':
 ------------------------------------------------------------
@@ -249,7 +249,7 @@ Backup all security zone objects from a specified location to a YAML file.
 ### Syntax
 
 ```bash
-scm backup network security-zone [OPTIONS]
+scm backup network zone [OPTIONS]
 ```
 
 ### Options
@@ -268,7 +268,7 @@ scm backup network security-zone [OPTIONS]
 #### Backup from Folder
 
 ```bash
-$ scm backup network security-zone --folder Shared
+$ scm backup network zone --folder Shared
 ---> 100%
 Successfully backed up 5 security zones to security_zone_folder_shared_20240115_120530.yaml
 ```
@@ -276,7 +276,7 @@ Successfully backed up 5 security zones to security_zone_folder_shared_20240115_
 #### Backup with Custom Filename
 
 ```bash
-$ scm backup network security-zone --folder Shared --file shared-zones.yaml
+$ scm backup network zone --folder Shared --file shared-zones.yaml
 ---> 100%
 Successfully backed up 5 security zones to shared-zones.yaml
 ```

--- a/docs/cli/objects/auto-tag-action.md
+++ b/docs/cli/objects/auto-tag-action.md
@@ -1,0 +1,270 @@
+# Auto Tag Action
+
+Auto tag actions automatically apply tags to IP addresses based on log events, enabling dynamic security policy enforcement. The `scm` CLI provides commands to create, update, delete, show, backup, and load auto tag action configurations.
+
+## Overview
+
+The `auto-tag-action` commands allow you to:
+
+- Create auto tag actions that apply tags based on log events
+- Configure log type filters (traffic, threat, etc.)
+- Delete auto tag actions that are no longer needed
+- Bulk import auto tag actions from YAML files
+- Export auto tag actions for backup or migration
+
+## Set Auto Tag Action
+
+Create or update an auto tag action.
+
+### Syntax
+
+```bash
+scm set object auto-tag-action NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Name of the auto tag action (positional argument) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--description TEXT` | Description of the auto tag action | No |
+| `--log-type TEXT` | Log type (traffic, threat, etc.) | No |
+| `--filter TEXT` | Filter expression | No |
+| `--tags LIST` | Tags to apply | No |
+| `--send-to-panorama` | Send to Panorama | No |
+| `--quarantine` | Enable quarantine | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Create an Auto Tag Action for Threat Logs
+
+```bash
+$ scm set object auto-tag-action threat-block \
+    --folder Texas \
+    --log-type threat \
+    --filter "action eq block" \
+    --tags blocked \
+    --description "Tag IPs blocked by threat prevention"
+---> 100%
+Created auto tag action: threat-block in Texas
+```
+
+#### Update an Existing Auto Tag Action
+
+```bash
+$ scm set object auto-tag-action threat-block \
+    --folder Texas \
+    --log-type threat \
+    --filter "action eq block" \
+    --tags blocked --tags quarantined \
+    --description "Tag and quarantine blocked IPs"
+---> 100%
+Updated auto tag action: threat-block in Texas
+```
+
+## Delete Auto Tag Action
+
+Delete an auto tag action from SCM.
+
+### Syntax
+
+```bash
+scm delete object auto-tag-action NAME [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `NAME` | Name of the auto tag action to delete (positional argument) | Yes |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--force` | Skip confirmation prompt | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Example
+
+```bash
+$ scm delete object auto-tag-action threat-block --folder Texas --force
+---> 100%
+Deleted auto tag action: threat-block from Texas
+```
+
+## Load Auto Tag Actions
+
+Load multiple auto tag actions from a YAML file.
+
+### Syntax
+
+```bash
+scm load object auto-tag-action [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file TEXT` | Path to YAML file containing auto tag action definitions | Yes |
+| `--dry-run` | Preview changes without applying them | No |
+
+### YAML File Format
+
+```yaml
+---
+auto_tag_actions:
+  - name: threat-block
+    folder: Texas
+    description: "Tag IPs blocked by threat prevention"
+    log_type: threat
+    filter: "action eq block"
+    tags:
+      - blocked
+      - quarantined
+
+  - name: traffic-deny
+    folder: Texas
+    description: "Tag IPs with denied traffic"
+    log_type: traffic
+    filter: "action eq deny"
+    tags:
+      - denied
+```
+
+### Examples
+
+#### Load Auto Tag Actions
+
+```bash
+$ scm load object auto-tag-action --file auto-tag-actions.yml
+---> 100%
+Created auto tag action: threat-block in Texas
+Created auto tag action: traffic-deny in Texas
+
+Summary: Processed 2 auto tag actions
+```
+
+#### Dry Run Preview
+
+```bash
+$ scm load object auto-tag-action --file auto-tag-actions.yml --dry-run
+---> 100%
+[DRY RUN] Would create auto tag action: threat-block
+[DRY RUN] Would create auto tag action: traffic-deny
+
+Summary: Processed 2 auto tag actions
+```
+
+## Show Auto Tag Action
+
+Display auto tag action objects.
+
+### Syntax
+
+```bash
+scm show object auto-tag-action [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No\* |
+| `--snippet TEXT` | Snippet location | No\* |
+| `--device TEXT` | Device location | No\* |
+| `--name TEXT` | Name of a specific auto tag action | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+!!! note
+    When no `--name` is specified, all items are listed by default.
+
+### Examples
+
+#### Show Specific Auto Tag Action
+
+```bash
+$ scm show object auto-tag-action --folder Texas --name threat-block
+---> 100%
+Auto Tag Action: threat-block
+============================================================
+Location: Texas
+Description: Tag IPs blocked by threat prevention
+Log Type: threat
+Filter: action eq block
+Tags: blocked, quarantined
+```
+
+#### List All Auto Tag Actions
+
+```bash
+$ scm show object auto-tag-action --folder Texas
+---> 100%
+Auto Tag Actions:
+--------------------------------------------------------------------------------
+
+Name: threat-block
+Location: Texas
+Description: Tag IPs blocked by threat prevention
+Log Type: threat
+
+Name: traffic-deny
+Location: Texas
+Description: Tag IPs with denied traffic
+Log Type: traffic
+
+Total: 2 auto tag actions
+```
+
+## Backup Auto Tag Actions
+
+Backup all auto tag action objects from a specified location to a YAML file.
+
+### Syntax
+
+```bash
+scm backup object auto-tag-action [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup from | No\* |
+| `--snippet TEXT` | Snippet to backup from | No\* |
+| `--device TEXT` | Device to backup from | No\* |
+| `--file TEXT` | Output filename (defaults to auto-generated) | No |
+
+\* One of --folder, --snippet, or --device is required.
+
+### Examples
+
+#### Backup from Folder
+
+```bash
+$ scm backup object auto-tag-action --folder Texas
+---> 100%
+Backed up 3 auto tag actions to auto-tag-actions_texas_20240115_120530.yaml
+```
+
+#### Backup with Custom Filename
+
+```bash
+$ scm backup object auto-tag-action --folder Texas --file texas-auto-tags.yaml
+---> 100%
+Backed up 3 auto tag actions to texas-auto-tags.yaml
+```
+
+## Best Practices
+
+1. **Specific Filters**: Use precise filter expressions to avoid over-tagging.
+2. **Descriptive Names**: Name actions clearly to indicate their purpose and trigger conditions.
+3. **Tag Organization**: Create the referenced tags before creating auto tag actions.
+4. **Test with Dry Run**: Use `--dry-run` when loading configurations to preview changes before applying.
+5. **Backup Before Changes**: Always backup existing configurations before making bulk modifications.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
   - CLI Reference:
       - Overview: cli/index.md
       - Objects:
+          - Auto Tag Action: cli/objects/auto-tag-action.md
           - Address: cli/objects/address.md
           - Address Group: cli/objects/address-group.md
           - Application: cli/objects/application.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.11"
+version = "1.0.12"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -430,11 +430,12 @@ LOAD_DEVICE_OPTION = typer.Option(
 def validate_location_params(folder: str = None, snippet: str = None, device: str = None) -> tuple[str, str]:
     """Validate that exactly one location parameter is provided.
 
-    Returnas:
+    Returns:
         tuple: (location_type, location_value)
 
-    Raise:
+    Raises:
         typer.Exit: If validation fails
+
     """
     location_count = sum(1 for loc in [folder, snippet, device] if loc is not None)
 


### PR DESCRIPTION
## Summary
- **#001**: Fix `security-zone` → `zone` in security zone docs (10 occurrences), `bandwidth` → `bandwidth-allocation` in bandwidth docs (6 occurrences)
- **#002**: Add full CLI reference page for `auto-tag-action` commands (set, delete, load, show, backup) + mkdocs.yml nav entry
- **#007**: Fix `Returnas:` → `Returns:` and `Raise:` → `Raises:` docstring typos in `validate_location_params()`

## Test plan
- [x] 755 tests pass
- [x] `ruff check` — all passed
- [x] `ruff format --check` — 21 files formatted
- [x] `mypy` — 0 errors
- [x] `mkdocs build --strict` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)