### PR TITLE
refactor: code consistency - dedup utility, delete confirms, emoji removal (v1.0.13)

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,16 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.13
+
+**Released:** March 11, 2026
+
+### Changed
+
+- **Deduplicate Utility Function**: Extracted `parse_comma_separated_list()` from objects.py and security.py into `utils/__init__.py` as the single canonical definition.
+- **Standardize Delete Confirmations**: Converted 23 network.py delete commands from manual confirm+Exit(0) pattern to `typer.confirm(..., abort=True)` matching all other modules.
+- **Remove Emoji Output**: Replaced 40 emoji-prefixed messages in objects.py with plain text to match the consistent style used in security.py, network.py, and deployment.py.
+
 ## Version 1.0.12
 
 **Released:** March 11, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.12"
+version = "1.0.13"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -343,10 +343,7 @@ def delete_ike_crypto_profile(
             typer.echo(f"IKE crypto profile '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete IKE crypto profile '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete IKE crypto profile '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_ike_crypto_profile(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted IKE crypto profile: {name} from {location_value}")
     except Exception as e:
@@ -560,10 +557,7 @@ def delete_aggregate_interface(
             typer.echo(f"Aggregate interface '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete aggregate interface '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete aggregate interface '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_aggregate_interface(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted aggregate interface: {name} from {location_value}")
     except Exception as e:
@@ -813,10 +807,7 @@ def delete_ike_gateway(
             typer.echo(f"IKE gateway '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete IKE gateway '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete IKE gateway '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_ike_gateway(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted IKE gateway: {name} from {location_value}")
     except Exception as e:
@@ -2231,10 +2222,7 @@ def delete_dhcp_interface(
             typer.echo(f"DHCP interface '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete DHCP interface '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete DHCP interface '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_dhcp_interface(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted DHCP interface: {name} from {location_value}")
     except Exception as e:
@@ -2450,10 +2438,7 @@ def delete_ethernet_interface(
             typer.echo(f"Ethernet interface '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete ethernet interface '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete ethernet interface '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_ethernet_interface(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted ethernet interface: {name} from {location_value}")
     except Exception as e:
@@ -2704,10 +2689,7 @@ def delete_layer2_subinterface(
             typer.echo(f"Layer2 subinterface '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete layer2 subinterface '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete layer2 subinterface '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_layer2_subinterface(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted layer2 subinterface: {name} from {location_value}")
     except Exception as e:
@@ -2923,10 +2905,7 @@ def delete_layer3_subinterface(
             typer.echo(f"Layer3 subinterface '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete layer3 subinterface '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete layer3 subinterface '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_layer3_subinterface(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted layer3 subinterface: {name} from {location_value}")
     except Exception as e:
@@ -3161,10 +3140,7 @@ def delete_loopback_interface(
             typer.echo(f"Loopback interface '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete loopback interface '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete loopback interface '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_loopback_interface(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted loopback interface: {name} from {location_value}")
     except Exception as e:
@@ -3392,10 +3368,7 @@ def delete_tunnel_interface(
             typer.echo(f"Tunnel interface '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete tunnel interface '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete tunnel interface '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_tunnel_interface(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted tunnel interface: {name} from {location_value}")
     except Exception as e:
@@ -3620,10 +3593,7 @@ def delete_vlan_interface(
             typer.echo(f"VLAN interface '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete VLAN interface '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete VLAN interface '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_vlan_interface(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted VLAN interface: {name} from {location_value}")
     except Exception as e:
@@ -3858,10 +3828,7 @@ def delete_bgp_address_family_profile(
             typer.echo(f"BGP address family profile '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete BGP address family profile '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete BGP address family profile '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_bgp_address_family_profile(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted BGP address family profile: {name} from {location_value}")
     except Exception as e:
@@ -4065,10 +4032,7 @@ def delete_bgp_auth_profile(
             typer.echo(f"BGP auth profile '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete BGP auth profile '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete BGP auth profile '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_bgp_auth_profile(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted BGP auth profile: {name} from {location_value}")
     except Exception as e:
@@ -4263,10 +4227,7 @@ def delete_ospf_auth_profile(
             typer.echo(f"OSPF auth profile '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete OSPF auth profile '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete OSPF auth profile '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_ospf_auth_profile(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted OSPF auth profile: {name} from {location_value}")
     except Exception as e:
@@ -4469,10 +4430,7 @@ def delete_route_access_list(
             typer.echo(f"Route access list '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete route access list '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete route access list '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_route_access_list(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted route access list: {name} from {location_value}")
     except Exception as e:
@@ -4677,10 +4635,7 @@ def delete_route_prefix_list(
             typer.echo(f"Route prefix list '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete route prefix list '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete route prefix list '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_route_prefix_list(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted route prefix list: {name} from {location_value}")
     except Exception as e:
@@ -4885,10 +4840,7 @@ def delete_bgp_filtering_profile(
             typer.echo(f"BGP filtering profile '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete BGP filtering profile '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete BGP filtering profile '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_bgp_filtering_profile(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted BGP filtering profile: {name} from {location_value}")
     except Exception as e:
@@ -5077,10 +5029,7 @@ def delete_bgp_redistribution_profile(
             typer.echo(f"BGP redistribution profile '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete BGP redistribution profile '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete BGP redistribution profile '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_bgp_redistribution_profile(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted BGP redistribution profile: {name} from {location_value}")
     except Exception as e:
@@ -5269,10 +5218,7 @@ def delete_bgp_route_map(
             typer.echo(f"BGP route map '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete BGP route map '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete BGP route map '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_bgp_route_map(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted BGP route map: {name} from {location_value}")
     except Exception as e:
@@ -5465,10 +5411,7 @@ def delete_bgp_route_map_redistribution(
             typer.echo(f"BGP route map redistribution '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete BGP route map redistribution '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete BGP route map redistribution '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_bgp_route_map_redistribution(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted BGP route map redistribution: {name} from {location_value}")
     except Exception as e:
@@ -5668,10 +5611,7 @@ def delete_dns_proxy(
             typer.echo(f"DNS proxy '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete DNS proxy '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete DNS proxy '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_dns_proxy(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted DNS proxy: {name} from {location_value}")
     except Exception as e:
@@ -5885,10 +5825,7 @@ def delete_pbf_rule(
             typer.echo(f"PBF rule '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete PBF rule '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete PBF rule '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_pbf_rule(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted PBF rule: {name} from {location_value}")
     except Exception as e:
@@ -6104,10 +6041,7 @@ def delete_qos_profile(
             typer.echo(f"QoS profile '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete QoS profile '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete QoS profile '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_qos_profile(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted QoS profile: {name} from {location_value}")
     except Exception as e:
@@ -6318,10 +6252,7 @@ def delete_qos_rule(
             typer.echo(f"QoS rule '{name}' not found", err=True)
             raise typer.Exit(code=1)
         if not force:
-            confirm = typer.confirm(f"Are you sure you want to delete QoS rule '{name}'?")
-            if not confirm:
-                typer.echo("Deletion cancelled")
-                raise typer.Exit(code=0)
+            typer.confirm(f"Delete QoS rule '{name}' from {location_type} '{location_value}'?", abort=True)
         scm_client.delete_qos_rule(name=name, folder=folder, snippet=snippet, device=device)
         typer.echo(f"Deleted QoS rule: {name} from {location_value}")
     except Exception as e:

--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -11,6 +11,7 @@ import typer
 import yaml
 
 # Removed unused import: from the `..utils.config` import load_from_yaml
+from ..utils import parse_comma_separated_list
 from ..utils.config import settings
 from ..utils.context import get_current_context
 from ..utils.sdk_client import scm_client
@@ -39,20 +40,6 @@ from ..utils.validators import (
 # ========================================================================================================================================================================================
 # HELPER FUNCTIONS
 # ========================================================================================================================================================================================
-
-
-def parse_comma_separated_list(values: list[str]) -> list[str]:
-    """Split comma-separated values in list options.
-
-    Allows both `--members a,b,c` and `--members a --members b --members c`.
-    """
-    result = []
-    for value in values:
-        for item in value.split(","):
-            stripped = item.strip()
-            if stripped:
-                result.append(stripped)
-    return result
 
 
 def show_context_info() -> None:
@@ -1149,11 +1136,11 @@ def set_address(
         action = result.pop("__action__", "created")
 
         if action == "created":
-            typer.echo(f"✅ Created address: {result['name']} in folder {result['folder']}")
+            typer.echo(f"Created address: {result['name']} in folder {result['folder']}")
         elif action == "updated":
-            typer.echo(f"✅ Updated address: {result['name']} in folder {result['folder']}")
+            typer.echo(f"Updated address: {result['name']} in folder {result['folder']}")
         elif action == "no_change":
-            typer.echo(f"ℹ️  No changes needed for address: {result['name']} in folder {result['folder']}")
+            typer.echo(f"No changes needed for address: {result['name']} in folder {result['folder']}")
 
         return result
     except Exception as e:
@@ -2996,7 +2983,7 @@ def load_external_dynamic_list(
                         **container_params,
                         **sdk_data,
                     )
-                    typer.echo(f"✓ Loaded external dynamic list: {edl.name}")
+                    typer.echo(f"Loaded external dynamic list: {edl.name}")
                     loaded_count += 1
                     results.append(
                         {
@@ -3007,7 +2994,7 @@ def load_external_dynamic_list(
                     )
             except Exception as e:
                 typer.echo(
-                    f"✗ Error with external dynamic list '{edl_config.get('name', 'unknown')}': {str(e)}",
+                    f"Error with external dynamic list '{edl_config.get('name', 'unknown')}': {str(e)}",
                     err=True,
                 )
                 results.append(
@@ -3528,7 +3515,7 @@ def load_hip_object(
                         **sdk_data,
                     )
 
-                    typer.echo(f"✓ Loaded HIP object: {hip_obj.name}")
+                    typer.echo(f"Loaded HIP object: {hip_obj.name}")
                     loaded_count += 1
                     results.append(
                         {
@@ -3539,7 +3526,7 @@ def load_hip_object(
                     )
             except Exception as e:
                 typer.echo(
-                    f"✗ Error with HIP object '{hip_data.get('name', 'unknown')}': {str(e)}",
+                    f"Error with HIP object '{hip_data.get('name', 'unknown')}': {str(e)}",
                     err=True,
                 )
                 results.append(
@@ -4090,7 +4077,7 @@ def load_hip_profile(
                         match=profile_sdk["match"],
                         description=profile_sdk.get("description"),
                     )
-                    typer.echo(f"✓ Loaded HIP profile: {profile.name}")
+                    typer.echo(f"Loaded HIP profile: {profile.name}")
                     loaded_count += 1
                     results.append(
                         {
@@ -4101,7 +4088,7 @@ def load_hip_profile(
                     )
             except Exception as e:
                 typer.echo(
-                    f"✗ Error with HIP profile '{profile_data.get('name', 'unknown')}': {str(e)}",
+                    f"Error with HIP profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                     err=True,
                 )
                 results.append(
@@ -4402,7 +4389,7 @@ def load_http_server_profile(
                         **container_params,
                         **profile_sdk,
                     )
-                    typer.echo(f"✓ Loaded HTTP server profile: {profile.name}")
+                    typer.echo(f"Loaded HTTP server profile: {profile.name}")
                     loaded_count += 1
                     results.append(
                         {
@@ -4413,7 +4400,7 @@ def load_http_server_profile(
                     )
             except Exception as e:
                 typer.echo(
-                    f"✗ Error with HTTP server profile '{profile_data.get('name', 'unknown')}': {str(e)}",
+                    f"Error with HTTP server profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                     err=True,
                 )
                 results.append(
@@ -4779,7 +4766,7 @@ def load_log_forwarding_profile(
                         match_list=profile.match_list,
                     )
 
-                    typer.echo(f"✓ Loaded log forwarding profile: {profile.name}")
+                    typer.echo(f"Loaded log forwarding profile: {profile.name}")
                     loaded_count += 1
                     results.append(
                         {
@@ -4790,7 +4777,7 @@ def load_log_forwarding_profile(
                     )
             except Exception as e:
                 typer.echo(
-                    f"✗ Error with log forwarding profile '{profile_data.get('name', 'unknown')}': {str(e)}",
+                    f"Error with log forwarding profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                     err=True,
                 )
                 results.append(
@@ -5648,7 +5635,7 @@ def load_service(
                         tag=service.tag,
                     )
 
-                    typer.echo(f"✓ Loaded service: {service.name}")
+                    typer.echo(f"Loaded service: {service.name}")
                     loaded_count += 1
                     results.append(
                         {
@@ -5660,7 +5647,7 @@ def load_service(
 
             except Exception as e:
                 typer.echo(
-                    f"✗ Error with service '{service_data.get('name', 'unknown')}': {str(e)}",
+                    f"Error with service '{service_data.get('name', 'unknown')}': {str(e)}",
                     err=True,
                 )
                 results.append(
@@ -5756,11 +5743,11 @@ def set_service(
             action = result.pop("__action__", "created")
 
             if action == "created":
-                typer.echo(f"✅ Created service: {name} in folder {folder}")
+                typer.echo(f"Created service: {name} in folder {folder}")
             elif action == "updated":
-                typer.echo(f"✅ Updated service: {name} in folder {folder}")
+                typer.echo(f"Updated service: {name} in folder {folder}")
             elif action == "no_change":
-                typer.echo(f"ℹ️  No changes needed for service: {name} in folder {folder}")
+                typer.echo(f"No changes needed for service: {name} in folder {folder}")
         else:
             typer.echo(f"Failed to create/update service '{name}'", err=True)
             raise typer.Exit(code=1)
@@ -6049,7 +6036,7 @@ def load_service_group(
                         tag=service_group.tag,
                     )
 
-                    typer.echo(f"✓ Loaded service group: {service_group.name}")
+                    typer.echo(f"Loaded service group: {service_group.name}")
                     loaded_count += 1
                     results.append(
                         {
@@ -6061,7 +6048,7 @@ def load_service_group(
 
             except Exception as e:
                 typer.echo(
-                    f"✗ Error with service group '{group_data.get('name', 'unknown')}': {str(e)}",
+                    f"Error with service group '{group_data.get('name', 'unknown')}': {str(e)}",
                     err=True,
                 )
                 results.append(
@@ -6319,7 +6306,7 @@ def delete_syslog_server_profile(
         typer.echo(f"Deleted syslog server profile: {name} from {container}")
 
     except Exception as e:
-        typer.echo(f"❌ Error deleting syslog server profile: {str(e)}", err=True)
+        typer.echo(f"Error deleting syslog server profile: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 
@@ -6395,7 +6382,7 @@ def load_syslog_server_profile(
                     # Create/update the profile
                     scm_client.create_syslog_server_profile(sdk_data)
 
-                    typer.echo(f"✓ Loaded syslog server profile: {profile.name}")
+                    typer.echo(f"Loaded syslog server profile: {profile.name}")
                     loaded_count += 1
                     results.append(
                         {
@@ -6407,7 +6394,7 @@ def load_syslog_server_profile(
 
             except Exception as e:
                 typer.echo(
-                    f"✗ Error with syslog server profile '{profile_data.get('name', 'unknown')}': {str(e)}",
+                    f"Error with syslog server profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                     err=True,
                 )
                 results.append(
@@ -6504,7 +6491,7 @@ def set_syslog_server_profile(
             typer.echo(f"No changes needed for syslog server profile: {name} in {container}")
 
     except Exception as e:
-        typer.echo(f"❌ Error creating/updating syslog server profile: {str(e)}", err=True)
+        typer.echo(f"Error creating/updating syslog server profile: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 
@@ -6724,7 +6711,7 @@ def delete_schedule(
         typer.echo(f"Deleted schedule: {name} from {container}")
 
     except Exception as e:
-        typer.echo(f"❌ Error deleting schedule: {str(e)}", err=True)
+        typer.echo(f"Error deleting schedule: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 
@@ -6767,13 +6754,13 @@ def load_schedule(
                 typer.echo(f"Created schedule: {schedule_data['name']} in {container}")
 
             except Exception as e:
-                typer.echo(f"❌ Error processing schedule: {str(e)}", err=True)
+                typer.echo(f"Error processing schedule: {str(e)}", err=True)
                 continue
 
-        typer.echo(f"\n✅ Summary: Processed {created_count} schedules")
+        typer.echo(f"\nSummary: Processed {created_count} schedules")
 
     except Exception as e:
-        typer.echo(f"❌ Error loading schedules: {str(e)}", err=True)
+        typer.echo(f"Error loading schedules: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 
@@ -6852,14 +6839,14 @@ def set_schedule(
 
         container = folder or snippet or device
         if action == "created":
-            typer.echo(f"✅ Created schedule: {name} in {container}")
+            typer.echo(f"Created schedule: {name} in {container}")
         elif action == "updated":
-            typer.echo(f"✅ Updated schedule: {name} in {container}")
+            typer.echo(f"Updated schedule: {name} in {container}")
         elif action == "no_change":
-            typer.echo(f"ℹ️  No changes needed for schedule: {name} in {container}")
+            typer.echo(f"No changes needed for schedule: {name} in {container}")
 
     except Exception as e:
-        typer.echo(f"❌ Error creating/updating schedule: {str(e)}", err=True)
+        typer.echo(f"Error creating/updating schedule: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 
@@ -7071,7 +7058,7 @@ def delete_tag(
         typer.echo(f"Deleted tag: {name} from {container}")
 
     except Exception as e:
-        typer.echo(f"❌ Error deleting tag: {str(e)}", err=True)
+        typer.echo(f"Error deleting tag: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 
@@ -7134,13 +7121,13 @@ def load_tag(
                 typer.echo(f"Created tag: {validated_tag.name} in {container}")
 
             except Exception as e:
-                typer.echo(f"❌ Error processing tag: {str(e)}", err=True)
+                typer.echo(f"Error processing tag: {str(e)}", err=True)
                 continue
 
-        typer.echo(f"\n✅ Summary: Processed {created_count} tags")
+        typer.echo(f"\nSummary: Processed {created_count} tags")
 
     except Exception as e:
-        typer.echo(f"❌ Error loading tags: {str(e)}", err=True)
+        typer.echo(f"Error loading tags: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 
@@ -7192,14 +7179,14 @@ def set_tag(
 
         container = folder or snippet or device
         if action == "created":
-            typer.echo(f"✅ Created tag: {name} in {container}")
+            typer.echo(f"Created tag: {name} in {container}")
         elif action == "updated":
-            typer.echo(f"✅ Updated tag: {name} in {container}")
+            typer.echo(f"Updated tag: {name} in {container}")
         elif action == "no_change":
-            typer.echo(f"ℹ️  No changes needed for tag: {name} in {container}")
+            typer.echo(f"No changes needed for tag: {name} in {container}")
 
     except Exception as e:
-        typer.echo(f"❌ Error creating/updating tag: {str(e)}", err=True)
+        typer.echo(f"Error creating/updating tag: {str(e)}", err=True)
         raise typer.Exit(code=1) from e
 
 

--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -12,6 +12,7 @@ from typing import Any
 import typer
 import yaml
 
+from ..utils import parse_comma_separated_list
 from ..utils.sdk_client import scm_client
 from ..utils.validators import (
     AntiSpywareProfile,
@@ -217,20 +218,6 @@ URL_PROFILE_ALLOW_OPTION = typer.Option(None, "--allow", help="URL categories to
 # ========================================================================================================================================================================================
 # HELPER FUNCTIONS
 # ========================================================================================================================================================================================
-
-
-def parse_comma_separated_list(values: list[str]) -> list[str]:
-    """Split comma-separated values in list options.
-
-    Allows both `--members a,b,c` and `--members a --members b --members c`.
-    """
-    result = []
-    for value in values:
-        for item in value.split(","):
-            stripped = item.strip()
-            if stripped:
-                result.append(stripped)
-    return result
 
 
 def validate_location_params(

--- a/src/scm_cli/utils/__init__.py
+++ b/src/scm_cli/utils/__init__.py
@@ -1,6 +1,27 @@
 """Utility modules for the pan-scm-cli tool."""
 
 
+def parse_comma_separated_list(values: list[str]) -> list[str]:
+    """Split comma-separated values in list options.
+
+    Allows both `--members a,b,c` and `--members a --members b --members c`.
+
+    Args:
+        values: List of string values, possibly containing commas.
+
+    Returns:
+        list[str]: Flattened list of stripped, non-empty values.
+
+    """
+    result = []
+    for value in values:
+        for item in value.split(","):
+            stripped = item.strip()
+            if stripped:
+                result.append(stripped)
+    return result
+
+
 def format_container_location(obj: dict, include_rulebase: str | None = None) -> str:
     """Format the container location (folder, snippet, or device) for display.
 


### PR DESCRIPTION
## Summary
- **#003**: Extract duplicate `parse_comma_separated_list()` from objects.py and security.py into `utils/__init__.py`
- **#004**: Standardize 23 network.py delete commands from manual confirm+Exit(0) to `typer.confirm(..., abort=True)` pattern
- **#005**: Remove 40 emoji-prefixed messages in objects.py, replaced with plain text matching other modules

## Test plan
- [x] 755 tests pass
- [x] `ruff check` — all passed
- [x] `ruff format --check` — 21 files formatted
- [x] `mypy` — 0 errors
- [x] `mkdocs build --strict` — passes
- [x] Zero emoji characters remaining in objects.py (verified with grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)