### PR TITLE
refactor: extract validate_location_params to shared utility

### DIFF
--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,18 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.15
+
+**Released:** March 11, 2026
+
+### Changed
+
+- **Deduplicate Location Validation**: Extracted `validate_location_params()` from 5 command modules (objects, network, security, identity, mobile_agent) into `utils/__init__.py` as the single canonical definition with correct `str | None` type hints and `Raises:` docstring.
+
+### Added
+
+- **Utils Tests**: Added unit tests for `validate_location_params()` covering all valid inputs, error cases, and return types.
+
 ## Version 1.0.14
 
 **Released:** March 11, 2026

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.0.14"
+version = "1.0.15"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/commands/identity.py
+++ b/src/scm_cli/commands/identity.py
@@ -13,6 +13,7 @@ import typer
 import yaml
 from pydantic import ValidationError
 
+from ..utils import validate_location_params
 from ..utils.sdk_client import scm_client
 from ..utils.validators import (
     AuthenticationProfile,
@@ -60,31 +61,6 @@ ALLOW_LIST_OPTION = typer.Option(None, "--allow-list", help="Allow list entries"
 # =============================================================================================================================================================================================
 # HELPER FUNCTIONS
 # =============================================================================================================================================================================================
-
-
-def validate_location_params(folder: str | None = None, snippet: str | None = None, device: str | None = None) -> tuple[str, str]:
-    """Validate that exactly one location parameter is provided.
-
-    Returns:
-        tuple: (location_type, location_value)
-
-    """
-    location_count = sum(1 for loc in [folder, snippet, device] if loc is not None)
-
-    if location_count == 0:
-        typer.echo("Error: One of --folder, --snippet, or --device must be specified", err=True)
-        raise typer.Exit(code=1)
-    elif location_count > 1:
-        typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
-        raise typer.Exit(code=1)
-
-    if folder:
-        return "folder", folder
-    elif snippet:
-        return "snippet", snippet
-    else:
-        assert device is not None
-        return "device", device
 
 
 def get_default_backup_filename(object_type: str, location_type: str, location_value: str) -> str:

--- a/src/scm_cli/commands/mobile_agent.py
+++ b/src/scm_cli/commands/mobile_agent.py
@@ -11,6 +11,7 @@ import typer
 import yaml
 from pydantic import ValidationError
 
+from ..utils import validate_location_params
 from ..utils.config import load_from_yaml, settings
 from ..utils.context import get_current_context
 from ..utils.sdk_client import scm_client
@@ -33,36 +34,6 @@ def show_context_info() -> None:
                 "[INFO] No context set, using environment variables or default settings",
                 err=True,
             )
-
-
-def validate_location_params(folder: str = None, snippet: str = None, device: str = None) -> tuple[str, str]:
-    """Validate that exactly one location parameter is provided.
-
-    Returns:
-        tuple: (location_type, location_value)
-
-    Raise:
-        typer.Exit: If validation fails
-
-    """
-    location_count = sum(1 for loc in [folder, snippet, device] if loc is not None)
-
-    if location_count == 0:
-        typer.echo("Error: One of --folder, --snippet, or --device must be specified", err=True)
-        raise typer.Exit(code=1)
-    elif location_count > 1:
-        typer.echo(
-            "Error: Only one of --folder, --snippet, or --device can be specified",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    if folder:
-        return "folder", folder
-    elif snippet:
-        return "snippet", snippet
-    else:
-        return "device", device
 
 
 def get_default_backup_filename(object_type: str, location_type: str, location_value: str) -> str:

--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -13,6 +13,7 @@ import typer
 import yaml
 from pydantic import ValidationError
 
+from ..utils import validate_location_params
 from ..utils.config import load_from_yaml
 from ..utils.sdk_client import scm_client
 from ..utils.validators import (
@@ -235,35 +236,6 @@ IKE_ENCRYPTION_OPTION = typer.Option(..., "--encryption", help="Encryption algor
 # =============================================================================================================================================================================================
 # HELPER FUNCTIONS
 # =============================================================================================================================================================================================
-
-
-def validate_location_params(folder: str | None = None, snippet: str | None = None, device: str | None = None) -> tuple[str, str]:
-    """Validate that exactly one location parameter is provided.
-
-    Returns:
-        tuple: (location_type, location_value)
-
-    """
-    location_count = sum(1 for loc in [folder, snippet, device] if loc is not None)
-
-    if location_count == 0:
-        typer.echo("Error: One of --folder, --snippet, or --device must be specified", err=True)
-        raise typer.Exit(code=1)
-    elif location_count > 1:
-        typer.echo(
-            "Error: Only one of --folder, --snippet, or --device can be specified",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    if folder:
-        return "folder", folder
-    elif snippet:
-        return "snippet", snippet
-    else:
-        assert device is not None
-        return "device", device
-
 
 QOS_PROFILE_ALLOWED_FOLDERS = ["Remote Networks", "Service Connections"]
 

--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -11,7 +11,7 @@ import typer
 import yaml
 
 # Removed unused import: from the `..utils.config` import load_from_yaml
-from ..utils import parse_comma_separated_list
+from ..utils import parse_comma_separated_list, validate_location_params
 from ..utils.config import settings
 from ..utils.context import get_current_context
 from ..utils.sdk_client import scm_client
@@ -412,36 +412,6 @@ LOAD_DEVICE_OPTION = typer.Option(
 # =============================================================================================================================================================================================
 # HELPER FUNCTIONS
 # =============================================================================================================================================================================================
-
-
-def validate_location_params(folder: str = None, snippet: str = None, device: str = None) -> tuple[str, str]:
-    """Validate that exactly one location parameter is provided.
-
-    Returns:
-        tuple: (location_type, location_value)
-
-    Raises:
-        typer.Exit: If validation fails
-
-    """
-    location_count = sum(1 for loc in [folder, snippet, device] if loc is not None)
-
-    if location_count == 0:
-        typer.echo("Error: One of --folder, --snippet, or --device must be specified", err=True)
-        raise typer.Exit(code=1)
-    elif location_count > 1:
-        typer.echo(
-            "Error: Only one of --folder, --snippet, or --device can be specified",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    if folder:
-        return "folder", folder
-    elif snippet:
-        return "snippet", snippet
-    else:
-        return "device", device
 
 
 def get_default_backup_filename(object_type: str, location_type: str, location_value: str) -> str:

--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -12,7 +12,7 @@ from typing import Any
 import typer
 import yaml
 
-from ..utils import parse_comma_separated_list
+from ..utils import parse_comma_separated_list, validate_location_params
 from ..utils.sdk_client import scm_client
 from ..utils.validators import (
     AntiSpywareProfile,
@@ -218,37 +218,6 @@ URL_PROFILE_ALLOW_OPTION = typer.Option(None, "--allow", help="URL categories to
 # =============================================================================================================================================================================================
 # HELPER FUNCTIONS
 # =============================================================================================================================================================================================
-
-
-def validate_location_params(
-    folder: str = None,
-    snippet: str = None,
-    device: str = None,
-) -> tuple[str, str]:
-    """Validate that exactly one location parameter is provided.
-
-    Returns:
-        tuple: (location_type, location_value)
-
-    """
-    location_count = sum(1 for loc in [folder, snippet, device] if loc is not None)
-
-    if location_count == 0:
-        typer.echo("Error: One of --folder, --snippet, or --device must be specified", err=True)
-        raise typer.Exit(code=1)
-    elif location_count > 1:
-        typer.echo(
-            "Error: Only one of --folder, --snippet, or --device can be specified",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    if folder:
-        return "folder", folder
-    elif snippet:
-        return "snippet", snippet
-    else:
-        return "device", device
 
 
 def get_default_backup_filename(

--- a/src/scm_cli/utils/__init__.py
+++ b/src/scm_cli/utils/__init__.py
@@ -1,5 +1,7 @@
 """Utility modules for the pan-scm-cli tool."""
 
+import typer
+
 
 def parse_comma_separated_list(values: list[str]) -> list[str]:
     """Split comma-separated values in list options.
@@ -48,3 +50,38 @@ def format_container_location(obj: dict, include_rulebase: str | None = None) ->
         location_parts.append(f"Rulebase '{include_rulebase}'")
 
     return " / ".join(location_parts)
+
+
+def validate_location_params(
+    folder: str | None = None,
+    snippet: str | None = None,
+    device: str | None = None,
+) -> tuple[str, str]:
+    """Validate that exactly one location parameter is provided.
+
+    Returns:
+        tuple: (location_type, location_value)
+
+    Raises:
+        typer.Exit: If validation fails.
+
+    """
+    location_count = sum(1 for loc in [folder, snippet, device] if loc is not None)
+
+    if location_count == 0:
+        typer.echo("Error: One of --folder, --snippet, or --device must be specified", err=True)
+        raise typer.Exit(code=1)
+    elif location_count > 1:
+        typer.echo(
+            "Error: Only one of --folder, --snippet, or --device can be specified",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    if folder:
+        return "folder", folder
+    elif snippet:
+        return "snippet", snippet
+    else:
+        assert device is not None
+        return "device", device

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,53 @@
+"""Tests for scm_cli.utils shared utility functions."""
+
+import pytest
+from click.exceptions import Exit
+
+from scm_cli.utils import validate_location_params
+
+
+class TestValidateLocationParams:
+    """Tests for validate_location_params utility function."""
+
+    def test_folder_only(self):
+        """Return ('folder', value) when only folder is provided."""
+        result = validate_location_params(folder="Shared")
+        assert result == ("folder", "Shared")
+
+    def test_snippet_only(self):
+        """Return ('snippet', value) when only snippet is provided."""
+        result = validate_location_params(snippet="my-snippet")
+        assert result == ("snippet", "my-snippet")
+
+    def test_device_only(self):
+        """Return ('device', value) when only device is provided."""
+        result = validate_location_params(device="fw-01")
+        assert result == ("device", "fw-01")
+
+    def test_no_location_raises_exit(self):
+        """Raise typer.Exit when no location is provided."""
+        with pytest.raises(Exit):
+            validate_location_params()
+
+    def test_multiple_locations_raises_exit(self):
+        """Raise typer.Exit when multiple locations are provided."""
+        with pytest.raises(Exit):
+            validate_location_params(folder="Shared", snippet="my-snippet")
+
+    def test_all_three_raises_exit(self):
+        """Raise typer.Exit when all three locations are provided."""
+        with pytest.raises(Exit):
+            validate_location_params(folder="Shared", snippet="my-snippet", device="fw-01")
+
+    def test_folder_and_device_raises_exit(self):
+        """Raise typer.Exit when folder and device are provided."""
+        with pytest.raises(Exit):
+            validate_location_params(folder="Shared", device="fw-01")
+
+    def test_return_type(self):
+        """Return a tuple of two strings."""
+        result = validate_location_params(folder="Shared")
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], str)
+        assert isinstance(result[1], str)


### PR DESCRIPTION
## Summary
- Extract `validate_location_params()` from 5 command modules (objects, network, security, identity, mobile_agent) into `utils/__init__.py`
- Fix type hints (`str = None` → `str | None = None`) and docstring (`Raise:` → `Raises:`)
- Add 8 unit tests for the shared function
- Bump version to v1.0.15

Closes #187

## Test plan
- [x] All 817 existing tests pass (29 skipped)
- [x] 8 new `test_utils.py` tests pass
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy` clean
- [x] `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)