### PR TITLE
docs: add docstring to mock_callable in client.py (#194)

### DIFF
--- a/src/scm_cli/client.py
+++ b/src/scm_cli/client.py
@@ -36,6 +36,18 @@ class MockSCMClient:
         """
 
         def mock_callable(*args, **kwargs):
+            """Simulate an SCM API call and return a mock success response.
+
+            Args:
+            ----
+                *args: Positional arguments passed to the mock call
+                **kwargs: Keyword arguments passed to the mock call
+
+            Returns:
+            -------
+                A dictionary with status and message keys
+
+            """
             logger.info(f"Mock SCM API call: {name}(*{args}, **{kwargs})")
             return {"status": "success", "message": f"Mock call to {name}"}
 


### PR DESCRIPTION
## Summary
- Add Google-style docstring to `mock_callable` nested function in `MockSCMClient.__getattr__`
- Only public function missing a docstring in the codebase

## Testing
- ruff check/format: pass
- mypy: pass

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)