### PR TITLE
refactor: extract shared error handling decorator

### DIFF
--- a/src/scm_cli/commands/objects.py
+++ b/src/scm_cli/commands/objects.py
@@ -14,6 +14,7 @@ import yaml
 from ..utils import parse_comma_separated_list, validate_location_params
 from ..utils.config import settings
 from ..utils.context import get_current_context
+from ..utils.decorators import handle_command_errors
 from ..utils.sdk_client import scm_client
 from ..utils.validators import (
     Address,
@@ -502,6 +503,7 @@ def backup_address_group(
 
 
 @delete_app.command("address-group")
+@handle_command_errors("deleting address group")
 def delete_address_group(
     folder: str = FOLDER_OPTION,
     name: str = NAME_OPTION,
@@ -518,14 +520,10 @@ def delete_address_group(
         confirm = typer.confirm(f"Delete address group '{name}' from folder '{folder}'?")
         if not confirm:
             raise typer.Abort()
-    try:
-        result = scm_client.delete_address_group(folder=folder, name=name)
-        if result:
-            typer.echo(f"Deleted address group: {name} from folder {folder}")
-        return result
-    except Exception as e:
-        typer.echo(f"Error deleting address group: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.delete_address_group(folder=folder, name=name)
+    if result:
+        typer.echo(f"Deleted address group: {name} from folder {folder}")
+    return result
 
 
 @load_app.command("address-group", help="Load address groups from a YAML file.")
@@ -897,6 +895,7 @@ def backup_address(
 
 
 @delete_app.command("address")
+@handle_command_errors("deleting address")
 def delete_address(
     folder: str = FOLDER_OPTION,
     name: str = NAME_OPTION,
@@ -913,14 +912,10 @@ def delete_address(
         confirm = typer.confirm(f"Delete address '{name}' from folder '{folder}'?")
         if not confirm:
             raise typer.Abort()
-    try:
-        result = scm_client.delete_address(folder=folder, name=name)
-        if result:
-            typer.echo(f"Deleted address: {name} from folder {folder}")
-        return result
-    except Exception as e:
-        typer.echo(f"Error deleting address: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.delete_address(folder=folder, name=name)
+    if result:
+        typer.echo(f"Deleted address: {name} from folder {folder}")
+    return result
 
 
 @load_app.command("address", help="Load addresses from a YAML file.")
@@ -1309,6 +1304,7 @@ def backup_application(
 
 
 @delete_app.command("application")
+@handle_command_errors("deleting application")
 def delete_application(
     folder: str = FOLDER_OPTION,
     name: str = NAME_OPTION,
@@ -1325,14 +1321,10 @@ def delete_application(
         confirm = typer.confirm(f"Delete application '{name}' from folder '{folder}'?")
         if not confirm:
             raise typer.Abort()
-    try:
-        result = scm_client.delete_application(folder=folder, name=name)
-        if result:
-            typer.echo(f"Deleted application: {name} from folder {folder}")
-        return result
-    except Exception as e:
-        typer.echo(f"Error deleting application: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.delete_application(folder=folder, name=name)
+    if result:
+        typer.echo(f"Deleted application: {name} from folder {folder}")
+    return result
 
 
 @load_app.command("application", help="Load applications from a YAML file.")
@@ -1747,6 +1739,7 @@ def backup_application_group(
 
 
 @delete_app.command("application-group")
+@handle_command_errors("deleting application group")
 def delete_application_group(
     folder: str = FOLDER_OPTION,
     name: str = NAME_OPTION,
@@ -1763,14 +1756,10 @@ def delete_application_group(
         confirm = typer.confirm(f"Delete application group '{name}' from folder '{folder}'?")
         if not confirm:
             raise typer.Abort()
-    try:
-        result = scm_client.delete_application_group(folder=folder, name=name)
-        if result:
-            typer.echo(f"Deleted application group: {name} from folder {folder}")
-        return result
-    except Exception as e:
-        typer.echo(f"Error deleting application group: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.delete_application_group(folder=folder, name=name)
+    if result:
+        typer.echo(f"Deleted application group: {name} from folder {folder}")
+    return result
 
 
 @load_app.command("application-group", help="Load application groups from a YAML file.")
@@ -2067,6 +2056,7 @@ def backup_application_filter(
 
 
 @delete_app.command("application-filter")
+@handle_command_errors("deleting application filter")
 def delete_application_filter(
     folder: str = FOLDER_OPTION,
     name: str = NAME_OPTION,
@@ -2083,14 +2073,10 @@ def delete_application_filter(
         confirm = typer.confirm(f"Delete application filter '{name}' from folder '{folder}'?")
         if not confirm:
             raise typer.Abort()
-    try:
-        result = scm_client.delete_application_filter(folder=folder, name=name)
-        if result:
-            typer.echo(f"Deleted application filter: {name} from folder {folder}")
-        return result
-    except Exception as e:
-        typer.echo(f"Error deleting application filter: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.delete_application_filter(folder=folder, name=name)
+    if result:
+        typer.echo(f"Deleted application filter: {name} from folder {folder}")
+    return result
 
 
 @load_app.command("application-filter", help="Load application filters from a YAML file.")

--- a/src/scm_cli/utils/decorators.py
+++ b/src/scm_cli/utils/decorators.py
@@ -1,0 +1,34 @@
+"""Shared decorators for scm-cli command modules."""
+
+import functools
+
+import typer
+
+
+def handle_command_errors(operation: str):
+    """Wrap a command function with standardized error handling.
+
+    Catches all exceptions (except typer.Exit and typer.Abort) and prints
+    a formatted error message to stderr before exiting with code 1.
+
+    Args:
+    ----
+        operation: Human-readable description of the operation, used in error
+            messages (e.g., "deleting address", "listing zones").
+
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except (typer.Exit, typer.Abort, SystemExit):
+                raise
+            except Exception as e:
+                typer.echo(f"Error {operation}: {str(e)}", err=True)
+                raise typer.Exit(code=1) from e
+
+        return wrapper
+
+    return decorator

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,0 +1,122 @@
+"""Tests for shared command decorators."""
+
+import typer
+from typer.testing import CliRunner
+
+from scm_cli.utils.decorators import handle_command_errors
+
+runner = CliRunner()
+
+
+def test_success_passthrough():
+    """Decorator passes through return value on success."""
+    app = typer.Typer()
+
+    @app.command()
+    @handle_command_errors("testing")
+    def cmd():
+        typer.echo("ok")
+
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert "ok" in result.output
+
+
+def test_exception_caught_and_formatted():
+    """Decorator catches exceptions and prints formatted error to stderr."""
+    app = typer.Typer()
+
+    @app.command()
+    @handle_command_errors("creating widget")
+    def cmd():
+        raise RuntimeError("connection refused")
+
+    result = runner.invoke(app, [])
+    assert result.exit_code == 1
+    assert "Error creating widget: connection refused" in result.output
+
+
+def test_typer_exit_passthrough():
+    """Decorator does not catch typer.Exit."""
+    app = typer.Typer()
+
+    @app.command()
+    @handle_command_errors("testing")
+    def cmd():
+        raise typer.Exit(code=42)
+
+    result = runner.invoke(app, [])
+    assert result.exit_code == 42
+
+
+def test_typer_abort_passthrough():
+    """Decorator does not catch typer.Abort."""
+    app = typer.Typer()
+
+    @app.command()
+    @handle_command_errors("testing")
+    def cmd():
+        raise typer.Abort()
+
+    result = runner.invoke(app, [])
+    assert result.exit_code == 1
+    assert "Aborted" in result.output
+
+
+def test_preserves_function_name():
+    """Decorator preserves the wrapped function's name."""
+
+    @handle_command_errors("testing")
+    def my_fancy_command():
+        pass
+
+    assert my_fancy_command.__name__ == "my_fancy_command"
+
+
+def test_with_arguments():
+    """Decorator works with commands that have arguments."""
+    app = typer.Typer()
+
+    @app.command()
+    @handle_command_errors("greeting")
+    def cmd(name: str = typer.Argument(...)):
+        typer.echo(f"hello {name}")
+
+    result = runner.invoke(app, ["world"])
+    assert result.exit_code == 0
+    assert "hello world" in result.output
+
+
+def test_with_options():
+    """Decorator works with commands that have options."""
+    app = typer.Typer()
+
+    @app.command()
+    @handle_command_errors("greeting")
+    def cmd(name: str = typer.Option("default", "--name")):
+        typer.echo(f"hello {name}")
+
+    result = runner.invoke(app, ["--name", "test"])
+    assert result.exit_code == 0
+    assert "hello test" in result.output
+
+
+def _make_raising_app(exc_class):
+    """Helper to create a Typer app that raises a specific exception."""
+    app = typer.Typer()
+
+    @app.command()
+    @handle_command_errors("processing")
+    def cmd():
+        raise exc_class("specific error")
+
+    return app
+
+
+def test_various_exception_types():
+    """Decorator handles different exception types consistently."""
+    for exc_class in [ValueError, TypeError, KeyError, IOError]:
+        app = _make_raising_app(exc_class)
+        result = runner.invoke(app, [])
+        assert result.exit_code == 1
+        assert "Error processing" in result.output


### PR DESCRIPTION
Closes #203 (partial — decorator extraction + proof of concept)

## Summary

- New `@handle_command_errors(operation)` decorator in `src/scm_cli/utils/decorators.py`
- Catches all exceptions (except `typer.Exit`/`typer.Abort`) and prints formatted error to stderr
- Applied to 5 delete commands in `objects.py` as proof of concept, removing duplicated try-except blocks
- 8 unit tests for the decorator covering success, error, passthrough, and edge cases

## Remaining work

The remaining ~383 try-except blocks can be incrementally converted in follow-up PRs.

## Test plan

- [x] `poetry run pytest tests/test_decorators.py -v` — 8/8 pass
- [x] `poetry run pytest tests/test_objects_commands.py -v` — no new failures (5 pre-existing)
- [x] `poetry run ruff check` — clean