### PR TITLE
refactor: apply @handle_command_errors to all security.py functions

### DIFF
--- a/src/scm_cli/commands/security.py
+++ b/src/scm_cli/commands/security.py
@@ -13,6 +13,7 @@ import typer
 import yaml
 
 from ..utils import parse_comma_separated_list, validate_location_params
+from ..utils.decorators import handle_command_errors
 from ..utils.sdk_client import scm_client
 from ..utils.validators import (
     AntiSpywareProfile,
@@ -251,6 +252,7 @@ def get_default_backup_filename(
 
 
 @backup_app.command("rule")
+@handle_command_errors("backing up security rules")
 def backup_security_rule(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -281,64 +283,57 @@ def backup_security_rule(
     if not file:
         file = get_default_backup_filename("security-rules", location_type, location_value, rulebase)
 
-    try:
-        # List all security rules with exact_match=True using kwargs pattern
-        kwargs = {location_type: location_value}
-        rules = scm_client.list_security_rules(**kwargs, rulebase=rulebase, exact_match=True)
+    # List all security rules with exact_match=True using kwargs pattern
+    kwargs = {location_type: location_value}
+    rules = scm_client.list_security_rules(**kwargs, rulebase=rulebase, exact_match=True)
 
-        if not rules:
-            typer.echo(f"No security rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
-            return
+    if not rules:
+        typer.echo(f"No security rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
+        return
 
-        # Convert SDK models to dictionaries, excluding unset values
-        backup_data = []
-        for rule in rules:
-            # The list method already returns dicts with exclude_unset=True
-            rule_dict = rule.copy()
-            # Remove system fields that shouldn't be in backup
-            rule_dict.pop("id", None)
+    # Convert SDK models to dictionaries, excluding unset values
+    backup_data = []
+    for rule in rules:
+        # The list method already returns dicts with exclude_unset=True
+        rule_dict = rule.copy()
+        # Remove system fields that shouldn't be in backup
+        rule_dict.pop("id", None)
 
-            # Convert SDK format back to CLI format for consistency
-            # Map SDK field names to CLI field names
-            if "from_" in rule_dict:
-                rule_dict["source_zones"] = rule_dict.pop("from_", [])
-            if "to_" in rule_dict:
-                rule_dict["destination_zones"] = rule_dict.pop("to_", [])
-            if "source" in rule_dict:
-                rule_dict["source_addresses"] = rule_dict.pop("source", [])
-            if "destination" in rule_dict:
-                rule_dict["destination_addresses"] = rule_dict.pop("destination", [])
-            if "application" in rule_dict:
-                rule_dict["applications"] = rule_dict.pop("application", [])
+        # Convert SDK format back to CLI format for consistency
+        # Map SDK field names to CLI field names
+        if "from_" in rule_dict:
+            rule_dict["source_zones"] = rule_dict.pop("from_", [])
+        if "to_" in rule_dict:
+            rule_dict["destination_zones"] = rule_dict.pop("to_", [])
+        if "source" in rule_dict:
+            rule_dict["source_addresses"] = rule_dict.pop("source", [])
+        if "destination" in rule_dict:
+            rule_dict["destination_addresses"] = rule_dict.pop("destination", [])
+        if "application" in rule_dict:
+            rule_dict["applications"] = rule_dict.pop("application", [])
 
-            # Convert disabled to enabled for CLI consistency
-            if "disabled" in rule_dict:
-                rule_dict["enabled"] = not rule_dict.pop("disabled", False)
+        # Convert disabled to enabled for CLI consistency
+        if "disabled" in rule_dict:
+            rule_dict["enabled"] = not rule_dict.pop("disabled", False)
 
-            # Add rulebase info
-            rule_dict["rulebase"] = rulebase
+        # Add rulebase info
+        rule_dict["rulebase"] = rulebase
 
-            backup_data.append(rule_dict)
+        backup_data.append(rule_dict)
 
-        # Create the YAML structure
-        yaml_data = {"security_rules": backup_data}
+    # Create the YAML structure
+    yaml_data = {"security_rules": backup_data}
 
-        # Write to YAML file
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    # Write to YAML file
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} security rules to {file}")
-        return file
-
-    except NotImplementedError as e:
-        typer.echo(f"Error: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        typer.echo(f"Error backing up security rules: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} security rules to {file}")
+    return file
 
 
 @delete_app.command("rule")
+@handle_command_errors("deleting security rule")
 def delete_security_rule(
     folder: str = typer.Option(None, "--folder", help="Folder containing the security rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the security rule"),
@@ -368,30 +363,27 @@ def delete_security_rule(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        # For now, SDK only supports folder
-        if location_type != "folder":
-            typer.echo(
-                f"Error: Deleting security rules from {location_type} is not yet supported by the SDK",
-                err=True,
-            )
-            raise typer.Exit(code=1)
+    # For now, SDK only supports folder
+    if location_type != "folder":
+        typer.echo(
+            f"Error: Deleting security rules from {location_type} is not yet supported by the SDK",
+            err=True,
+        )
+        raise typer.Exit(code=1)
 
-        result = scm_client.delete_security_rule(folder=location_value, name=name, rulebase=rulebase)
-        if result:
-            typer.echo(f"Deleted security rule: {name} from {location_type} {location_value} rulebase {rulebase}")
-        else:
-            typer.echo(
-                f"Security rule not found: {name} in {location_type} {location_value}",
-                err=True,
-            )
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting security rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.delete_security_rule(folder=location_value, name=name, rulebase=rulebase)
+    if result:
+        typer.echo(f"Deleted security rule: {name} from {location_type} {location_value} rulebase {rulebase}")
+    else:
+        typer.echo(
+            f"Security rule not found: {name} in {location_type} {location_value}",
+            err=True,
+        )
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("rule", help="Load security rules from a YAML file.")
+@handle_command_errors("loading security rules")
 def load_security_rule(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -415,132 +407,128 @@ def load_security_rule(
         scm load security rule --file config/security_rules.yml --dry-run
 
     """
-    try:
-        # Validate container override parameters
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
-            typer.echo(
-                "Error: Only one of --folder, --snippet, or --device can be specified",
-                err=True,
-            )
-            raise typer.Exit(code=1)
+    # Validate container override parameters
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo(
+            "Error: Only one of --folder, --snippet, or --device can be specified",
+            err=True,
+        )
+        raise typer.Exit(code=1)
 
-        # Validate file exists
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    # Validate file exists
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
 
-        # Load YAML data using the same pattern as other commands
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
+    # Load YAML data using the same pattern as other commands
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
 
-        if not raw_data or "security_rules" not in raw_data:
-            typer.echo("No security rules found in file", err=True)
-            raise typer.Exit(code=1)
+    if not raw_data or "security_rules" not in raw_data:
+        typer.echo("No security rules found in file", err=True)
+        raise typer.Exit(code=1)
 
-        rules = raw_data["security_rules"]
-        if not isinstance(rules, list):
-            rules = [rules]
+    rules = raw_data["security_rules"]
+    if not isinstance(rules, list):
+        rules = [rules]
 
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            # Show override information if applicable
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(rules))
-            return []
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        # Show override information if applicable
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(rules))
+        return []
 
-        # Apply each security rule
-        results = []
-        created_count = 0
-        updated_count = 0
+    # Apply each security rule
+    results = []
+    created_count = 0
+    updated_count = 0
 
-        for rule_data in rules:
-            try:
-                # Apply container override if specified
-                if folder:
-                    rule_data["folder"] = folder
-                    rule_data.pop("snippet", None)
-                    rule_data.pop("device", None)
-                elif snippet:
-                    rule_data["snippet"] = snippet
-                    rule_data.pop("folder", None)
-                    rule_data.pop("device", None)
-                elif device:
-                    rule_data["device"] = device
-                    rule_data.pop("folder", None)
-                    rule_data.pop("snippet", None)
+    for rule_data in rules:
+        try:
+            # Apply container override if specified
+            if folder:
+                rule_data["folder"] = folder
+                rule_data.pop("snippet", None)
+                rule_data.pop("device", None)
+            elif snippet:
+                rule_data["snippet"] = snippet
+                rule_data.pop("folder", None)
+                rule_data.pop("device", None)
+            elif device:
+                rule_data["device"] = device
+                rule_data.pop("folder", None)
+                rule_data.pop("snippet", None)
 
-                # Validate using the Pydantic model
-                rule = SecurityRule(**rule_data)
+            # Validate using the Pydantic model
+            rule = SecurityRule(**rule_data)
 
-                # For now, SDK only supports folder
-                if hasattr(rule, "snippet") and rule.snippet:
-                    typer.echo(
-                        f"Warning: Creating security rules in snippets is not yet supported by the SDK. Skipping rule '{rule.name}'",
-                        err=True,
-                    )
-                    continue
-                elif hasattr(rule, "device") and rule.device:
-                    typer.echo(
-                        f"Warning: Creating security rules on devices is not yet supported by the SDK. Skipping rule '{rule.name}'",
-                        err=True,
-                    )
-                    continue
-
-                # Call the SDK client to create the security rule
-                sdk_data = rule.to_sdk_model()
-                result = scm_client.create_security_rule(
-                    folder=sdk_data["folder"],
-                    name=sdk_data["name"],
-                    source_zones=sdk_data["source_zones"],
-                    destination_zones=sdk_data["destination_zones"],
-                    source_addresses=sdk_data["source_addresses"],
-                    destination_addresses=sdk_data["destination_addresses"],
-                    applications=sdk_data["applications"],
-                    services=rule.service,  # Use the service field from the model
-                    action=sdk_data["action"],
-                    description=sdk_data["description"],
-                    tags=sdk_data["tags"],
-                    enabled=sdk_data["enabled"],
-                    rulebase=sdk_data["rulebase"],
-                    log_start=rule.log_start or False,
-                    log_end=rule.log_end or False,
-                    log_setting=rule.log_setting,
-                )
-
-                results.append(result)
-
-                # Track if created or updated based on response
-                if "created" in str(result).lower():
-                    created_count += 1
-                else:
-                    updated_count += 1
-
-            except Exception as e:
+            # For now, SDK only supports folder
+            if hasattr(rule, "snippet") and rule.snippet:
                 typer.echo(
-                    f"Error processing security rule '{rule_data.get('name', 'unknown')}': {str(e)}",
+                    f"Warning: Creating security rules in snippets is not yet supported by the SDK. Skipping rule '{rule.name}'",
                     err=True,
                 )
-                # Continue processing other rules
+                continue
+            elif hasattr(rule, "device") and rule.device:
+                typer.echo(
+                    f"Warning: Creating security rules on devices is not yet supported by the SDK. Skipping rule '{rule.name}'",
+                    err=True,
+                )
                 continue
 
-        # Display summary with counts
-        typer.echo(f"Successfully processed {len(results)} security rule(s):")
-        if created_count > 0:
-            typer.echo(f"  - Created: {created_count}")
-        if updated_count > 0:
-            typer.echo(f"  - Updated: {updated_count}")
+            # Call the SDK client to create the security rule
+            sdk_data = rule.to_sdk_model()
+            result = scm_client.create_security_rule(
+                folder=sdk_data["folder"],
+                name=sdk_data["name"],
+                source_zones=sdk_data["source_zones"],
+                destination_zones=sdk_data["destination_zones"],
+                source_addresses=sdk_data["source_addresses"],
+                destination_addresses=sdk_data["destination_addresses"],
+                applications=sdk_data["applications"],
+                services=rule.service,  # Use the service field from the model
+                action=sdk_data["action"],
+                description=sdk_data["description"],
+                tags=sdk_data["tags"],
+                enabled=sdk_data["enabled"],
+                rulebase=sdk_data["rulebase"],
+                log_start=rule.log_start or False,
+                log_end=rule.log_end or False,
+                log_setting=rule.log_setting,
+            )
 
-        return results
+            results.append(result)
 
-    except Exception as e:
-        typer.echo(f"Error loading security rules: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+            # Track if created or updated based on response
+            if "created" in str(result).lower():
+                created_count += 1
+            else:
+                updated_count += 1
+
+        except Exception as e:
+            typer.echo(
+                f"Error processing security rule '{rule_data.get('name', 'unknown')}': {str(e)}",
+                err=True,
+            )
+            # Continue processing other rules
+            continue
+
+    # Display summary with counts
+    typer.echo(f"Successfully processed {len(results)} security rule(s):")
+    if created_count > 0:
+        typer.echo(f"  - Created: {created_count}")
+    if updated_count > 0:
+        typer.echo(f"  - Updated: {updated_count}")
+
+    return results
 
 
 @set_app.command("rule")
+@handle_command_errors("creating security rule")
 def set_security_rule(
     folder: str = typer.Option(None, "--folder", help="Folder path for the security rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path for the security rule"),
@@ -596,79 +584,75 @@ def set_security_rule(
         )
         raise typer.Exit(code=1)
 
-    try:
-        # Parse comma-separated list options
-        parsed_src_zones = parse_comma_separated_list(source_zones)
-        parsed_dst_zones = parse_comma_separated_list(destination_zones)
-        parsed_src_addrs = parse_comma_separated_list(source_addresses) if source_addresses else ["any"]
-        parsed_dst_addrs = parse_comma_separated_list(destination_addresses) if destination_addresses else ["any"]
-        parsed_apps = parse_comma_separated_list(applications) if applications else ["any"]
-        parsed_svcs = parse_comma_separated_list(services) if services else ["any"]
-        parsed_tags = parse_comma_separated_list(tags) if tags else []
+    # Parse comma-separated list options
+    parsed_src_zones = parse_comma_separated_list(source_zones)
+    parsed_dst_zones = parse_comma_separated_list(destination_zones)
+    parsed_src_addrs = parse_comma_separated_list(source_addresses) if source_addresses else ["any"]
+    parsed_dst_addrs = parse_comma_separated_list(destination_addresses) if destination_addresses else ["any"]
+    parsed_apps = parse_comma_separated_list(applications) if applications else ["any"]
+    parsed_svcs = parse_comma_separated_list(services) if services else ["any"]
+    parsed_tags = parse_comma_separated_list(tags) if tags else []
 
-        # Validate and create security rule
-        rule = SecurityRule(
-            folder=location_value,
-            name=name,
-            source_zones=parsed_src_zones,
-            destination_zones=parsed_dst_zones,
-            source_addresses=parsed_src_addrs,
-            destination_addresses=parsed_dst_addrs,
-            applications=parsed_apps,
-            service=parsed_svcs,
-            action=action,
-            description=description or "",
-            tags=parsed_tags,
-            enabled=enabled,
-            rulebase=rulebase,
-            log_start=log_start,
-            log_end=log_end,
-            log_setting=log_setting,
-            # Add optional fields with defaults
-            tag=None,
-            source_user=None,
-            source_hip=None,
-            destination_hip=None,
-            category=None,
-            negate_source=None,
-            negate_destination=None,
-        )
+    # Validate and create security rule
+    rule = SecurityRule(
+        folder=location_value,
+        name=name,
+        source_zones=parsed_src_zones,
+        destination_zones=parsed_dst_zones,
+        source_addresses=parsed_src_addrs,
+        destination_addresses=parsed_dst_addrs,
+        applications=parsed_apps,
+        service=parsed_svcs,
+        action=action,
+        description=description or "",
+        tags=parsed_tags,
+        enabled=enabled,
+        rulebase=rulebase,
+        log_start=log_start,
+        log_end=log_end,
+        log_setting=log_setting,
+        # Add optional fields with defaults
+        tag=None,
+        source_user=None,
+        source_hip=None,
+        destination_hip=None,
+        category=None,
+        negate_source=None,
+        negate_destination=None,
+    )
 
-        # Call SDK client to create the rule
-        result = scm_client.create_security_rule(
-            folder=rule.folder,
-            name=rule.name,
-            source_zones=rule.source_zones,
-            destination_zones=rule.destination_zones,
-            source_addresses=rule.source_addresses,
-            destination_addresses=rule.destination_addresses,
-            applications=rule.applications,
-            services=rule.service,
-            action=rule.action,
-            description=rule.description or "",
-            tags=rule.tags,
-            enabled=rule.enabled,
-            rulebase=rule.rulebase,
-            log_start=rule.log_start or False,
-            log_end=rule.log_end or False,
-            log_setting=rule.log_setting,
-        )
+    # Call SDK client to create the rule
+    result = scm_client.create_security_rule(
+        folder=rule.folder,
+        name=rule.name,
+        source_zones=rule.source_zones,
+        destination_zones=rule.destination_zones,
+        source_addresses=rule.source_addresses,
+        destination_addresses=rule.destination_addresses,
+        applications=rule.applications,
+        services=rule.service,
+        action=rule.action,
+        description=rule.description or "",
+        tags=rule.tags,
+        enabled=rule.enabled,
+        rulebase=rule.rulebase,
+        log_start=rule.log_start or False,
+        log_end=rule.log_end or False,
+        log_setting=rule.log_setting,
+    )
 
-        # Format and display output
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created security rule: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated security rule: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for security rule: {result['name']} in {location_type} {location_value}")
-
-    except Exception as e:
-        typer.echo(f"Error creating security rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    # Format and display output
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created security rule: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated security rule: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for security rule: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("rule")
+@handle_command_errors("showing security rule")
 def show_security_rule(
     folder: str = typer.Option(None, "--folder", help="Folder containing the security rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the security rule"),
@@ -703,196 +687,191 @@ def show_security_rule(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            # For now, SDK only supports folder for get operations
-            if location_type != "folder":
-                typer.echo(
-                    f"Error: Getting security rules from {location_type} is not yet supported by the SDK",
-                    err=True,
-                )
-                raise typer.Exit(code=1)
+    if name:
+        # For now, SDK only supports folder for get operations
+        if location_type != "folder":
+            typer.echo(
+                f"Error: Getting security rules from {location_type} is not yet supported by the SDK",
+                err=True,
+            )
+            raise typer.Exit(code=1)
 
-            # Get a specific security rule by name
-            rule = scm_client.get_security_rule(folder=location_value, name=name, rulebase=rulebase)
+        # Get a specific security rule by name
+        rule = scm_client.get_security_rule(folder=location_value, name=name, rulebase=rulebase)
 
-            typer.echo(f"\nSecurity Rule: {rule.get('name', 'N/A')}")
-            typer.echo("=" * 80)
+        typer.echo(f"\nSecurity Rule: {rule.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+
+        # Display container location (folder, snippet, or device) and rulebase
+        if rule.get("folder"):
+            typer.echo(f"Location: Folder '{rule['folder']}' / Rulebase '{rulebase}'")
+        elif rule.get("snippet"):
+            typer.echo(f"Location: Snippet '{rule['snippet']}' / Rulebase '{rulebase}'")
+        elif rule.get("device"):
+            typer.echo(f"Location: Device '{rule['device']}' / Rulebase '{rulebase}'")
+        else:
+            typer.echo(f"Location: N/A / Rulebase '{rulebase}'")
+
+        typer.echo(f"Action: {rule.get('action', 'N/A')}")
+
+        # Display source zones
+        source_zones = rule.get("from_", [])
+        typer.echo(f"Source Zones: {', '.join(source_zones) if source_zones else 'any'}")
+
+        # Display destination zones
+        dest_zones = rule.get("to_", [])
+        typer.echo(f"Destination Zones: {', '.join(dest_zones) if dest_zones else 'any'}")
+
+        # Display source addresses
+        source_addrs = rule.get("source", [])
+        typer.echo(f"Source Addresses: {', '.join(source_addrs) if source_addrs else 'any'}")
+
+        # Display destination addresses
+        dest_addrs = rule.get("destination", [])
+        typer.echo(f"Destination Addresses: {', '.join(dest_addrs) if dest_addrs else 'any'}")
+
+        # Display applications
+        apps = rule.get("application", [])
+        typer.echo(f"Applications: {', '.join(apps) if apps else 'any'}")
+
+        # Display services
+        services = rule.get("service", [])
+        typer.echo(f"Services: {', '.join(services) if services else 'any'}")
+
+        # Display categories
+        categories = rule.get("category", [])
+        if categories:
+            typer.echo(f"Categories: {', '.join(categories)}")
+
+        # Display description if present
+        if rule.get("description"):
+            typer.echo(f"Description: {rule['description']}")
+
+        # Display tags if present
+        tags = rule.get("tag", [])
+        if tags:
+            typer.echo(f"Tags: {', '.join(tags)}")
+
+        # Display enabled/disabled status
+        disabled = rule.get("disabled", False)
+        typer.echo(f"Status: {'Disabled' if disabled else 'Enabled'}")
+
+        # Display logging settings
+        if rule.get("log_start"):
+            typer.echo("Log Start: Yes")
+        if rule.get("log_end"):
+            typer.echo("Log End: Yes")
+
+        # Display log forwarding profile if present
+        if rule.get("log_setting"):
+            typer.echo(f"Log Forwarding Profile: {rule['log_setting']}")
+
+        # Display security profiles if present
+        profile_setting = rule.get("profile_setting")
+        if profile_setting:
+            typer.echo("Security Profiles:")
+            if profile_setting.get("group"):
+                typer.echo(f"  Profile Group: {', '.join(profile_setting['group'])}")
+            else:
+                # Individual profiles
+                for profile_type in [
+                    "antivirus",
+                    "anti_spyware",
+                    "vulnerability",
+                    "url_filtering",
+                    "file_blocking",
+                    "data_filtering",
+                    "wildfire_analysis",
+                ]:
+                    if profile_setting.get(profile_type):
+                        profile_name = profile_type.replace("_", " ").title()
+                        typer.echo(f"  {profile_name}: {profile_setting[profile_type]}")
+
+        # Display ID if present
+        if rule.get("id"):
+            typer.echo(f"ID: {rule['id']}")
+
+        return rule
+
+    else:
+        # Default behavior: list all
+        # List all security rules in the specified container and rulebase (default behavior)
+        kwargs = {location_type: location_value}
+        rules = scm_client.list_security_rules(
+            **kwargs,
+            rulebase=rulebase,
+            exclude_folders=exclude_folder or None,
+            exclude_snippets=exclude_snippet or None,
+            exclude_devices=exclude_device or None,
+        )
+
+        if not rules:
+            typer.echo(f"No security rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
+            return
+
+        typer.echo(f"\nSecurity Rules in {location_type} '{location_value}' rulebase '{rulebase}':")
+        typer.echo("=" * 80)
+
+        for rule in rules:
+            # Display rule information
+            typer.echo(f"Name: {rule.get('name', 'N/A')}")
 
             # Display container location (folder, snippet, or device) and rulebase
             if rule.get("folder"):
-                typer.echo(f"Location: Folder '{rule['folder']}' / Rulebase '{rulebase}'")
+                typer.echo(f"  Location: Folder '{rule['folder']}' / Rulebase '{rulebase}'")
             elif rule.get("snippet"):
-                typer.echo(f"Location: Snippet '{rule['snippet']}' / Rulebase '{rulebase}'")
+                typer.echo(f"  Location: Snippet '{rule['snippet']}' / Rulebase '{rulebase}'")
             elif rule.get("device"):
-                typer.echo(f"Location: Device '{rule['device']}' / Rulebase '{rulebase}'")
+                typer.echo(f"  Location: Device '{rule['device']}' / Rulebase '{rulebase}'")
             else:
-                typer.echo(f"Location: N/A / Rulebase '{rulebase}'")
+                typer.echo(f"  Location: N/A / Rulebase '{rulebase}'")
 
-            typer.echo(f"Action: {rule.get('action', 'N/A')}")
+            typer.echo(f"  Action: {rule.get('action', 'N/A')}")
 
             # Display source zones
             source_zones = rule.get("from_", [])
-            typer.echo(f"Source Zones: {', '.join(source_zones) if source_zones else 'any'}")
+            typer.echo(f"  Source Zones: {', '.join(source_zones) if source_zones else 'any'}")
 
             # Display destination zones
             dest_zones = rule.get("to_", [])
-            typer.echo(f"Destination Zones: {', '.join(dest_zones) if dest_zones else 'any'}")
+            typer.echo(f"  Destination Zones: {', '.join(dest_zones) if dest_zones else 'any'}")
 
             # Display source addresses
             source_addrs = rule.get("source", [])
-            typer.echo(f"Source Addresses: {', '.join(source_addrs) if source_addrs else 'any'}")
+            typer.echo(f"  Source Addresses: {', '.join(source_addrs) if source_addrs else 'any'}")
 
             # Display destination addresses
             dest_addrs = rule.get("destination", [])
-            typer.echo(f"Destination Addresses: {', '.join(dest_addrs) if dest_addrs else 'any'}")
+            typer.echo(f"  Destination Addresses: {', '.join(dest_addrs) if dest_addrs else 'any'}")
 
             # Display applications
             apps = rule.get("application", [])
-            typer.echo(f"Applications: {', '.join(apps) if apps else 'any'}")
+            typer.echo(f"  Applications: {', '.join(apps) if apps else 'any'}")
 
             # Display services
             services = rule.get("service", [])
-            typer.echo(f"Services: {', '.join(services) if services else 'any'}")
-
-            # Display categories
-            categories = rule.get("category", [])
-            if categories:
-                typer.echo(f"Categories: {', '.join(categories)}")
+            typer.echo(f"  Services: {', '.join(services) if services else 'any'}")
 
             # Display description if present
             if rule.get("description"):
-                typer.echo(f"Description: {rule['description']}")
+                typer.echo(f"  Description: {rule['description']}")
 
             # Display tags if present
             tags = rule.get("tag", [])
             if tags:
-                typer.echo(f"Tags: {', '.join(tags)}")
+                typer.echo(f"  Tags: {', '.join(tags)}")
 
             # Display enabled/disabled status
             disabled = rule.get("disabled", False)
-            typer.echo(f"Status: {'Disabled' if disabled else 'Enabled'}")
-
-            # Display logging settings
-            if rule.get("log_start"):
-                typer.echo("Log Start: Yes")
-            if rule.get("log_end"):
-                typer.echo("Log End: Yes")
-
-            # Display log forwarding profile if present
-            if rule.get("log_setting"):
-                typer.echo(f"Log Forwarding Profile: {rule['log_setting']}")
-
-            # Display security profiles if present
-            profile_setting = rule.get("profile_setting")
-            if profile_setting:
-                typer.echo("Security Profiles:")
-                if profile_setting.get("group"):
-                    typer.echo(f"  Profile Group: {', '.join(profile_setting['group'])}")
-                else:
-                    # Individual profiles
-                    for profile_type in [
-                        "antivirus",
-                        "anti_spyware",
-                        "vulnerability",
-                        "url_filtering",
-                        "file_blocking",
-                        "data_filtering",
-                        "wildfire_analysis",
-                    ]:
-                        if profile_setting.get(profile_type):
-                            profile_name = profile_type.replace("_", " ").title()
-                            typer.echo(f"  {profile_name}: {profile_setting[profile_type]}")
+            typer.echo(f"  Status: {'Disabled' if disabled else 'Enabled'}")
 
             # Display ID if present
             if rule.get("id"):
-                typer.echo(f"ID: {rule['id']}")
+                typer.echo(f"  ID: {rule['id']}")
 
-            return rule
+            typer.echo("-" * 80)
 
-        else:
-            # Default behavior: list all
-            # List all security rules in the specified container and rulebase (default behavior)
-            kwargs = {location_type: location_value}
-            rules = scm_client.list_security_rules(
-                **kwargs,
-                rulebase=rulebase,
-                exclude_folders=exclude_folder or None,
-                exclude_snippets=exclude_snippet or None,
-                exclude_devices=exclude_device or None,
-            )
-
-            if not rules:
-                typer.echo(f"No security rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
-                return
-
-            typer.echo(f"\nSecurity Rules in {location_type} '{location_value}' rulebase '{rulebase}':")
-            typer.echo("=" * 80)
-
-            for rule in rules:
-                # Display rule information
-                typer.echo(f"Name: {rule.get('name', 'N/A')}")
-
-                # Display container location (folder, snippet, or device) and rulebase
-                if rule.get("folder"):
-                    typer.echo(f"  Location: Folder '{rule['folder']}' / Rulebase '{rulebase}'")
-                elif rule.get("snippet"):
-                    typer.echo(f"  Location: Snippet '{rule['snippet']}' / Rulebase '{rulebase}'")
-                elif rule.get("device"):
-                    typer.echo(f"  Location: Device '{rule['device']}' / Rulebase '{rulebase}'")
-                else:
-                    typer.echo(f"  Location: N/A / Rulebase '{rulebase}'")
-
-                typer.echo(f"  Action: {rule.get('action', 'N/A')}")
-
-                # Display source zones
-                source_zones = rule.get("from_", [])
-                typer.echo(f"  Source Zones: {', '.join(source_zones) if source_zones else 'any'}")
-
-                # Display destination zones
-                dest_zones = rule.get("to_", [])
-                typer.echo(f"  Destination Zones: {', '.join(dest_zones) if dest_zones else 'any'}")
-
-                # Display source addresses
-                source_addrs = rule.get("source", [])
-                typer.echo(f"  Source Addresses: {', '.join(source_addrs) if source_addrs else 'any'}")
-
-                # Display destination addresses
-                dest_addrs = rule.get("destination", [])
-                typer.echo(f"  Destination Addresses: {', '.join(dest_addrs) if dest_addrs else 'any'}")
-
-                # Display applications
-                apps = rule.get("application", [])
-                typer.echo(f"  Applications: {', '.join(apps) if apps else 'any'}")
-
-                # Display services
-                services = rule.get("service", [])
-                typer.echo(f"  Services: {', '.join(services) if services else 'any'}")
-
-                # Display description if present
-                if rule.get("description"):
-                    typer.echo(f"  Description: {rule['description']}")
-
-                # Display tags if present
-                tags = rule.get("tag", [])
-                if tags:
-                    typer.echo(f"  Tags: {', '.join(tags)}")
-
-                # Display enabled/disabled status
-                disabled = rule.get("disabled", False)
-                typer.echo(f"  Status: {'Disabled' if disabled else 'Enabled'}")
-
-                # Display ID if present
-                if rule.get("id"):
-                    typer.echo(f"  ID: {rule['id']}")
-
-                typer.echo("-" * 80)
-
-            return rules
-
-    except Exception as e:
-        typer.echo(f"Error showing security rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return rules
 
 
 # =============================================================================================================================================================================================
@@ -901,6 +880,7 @@ def show_security_rule(
 
 
 @backup_app.command("anti-spyware-profile")
+@handle_command_errors("backing up anti-spyware profiles")
 def backup_anti_spyware_profile(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -930,41 +910,37 @@ def backup_anti_spyware_profile(
     if not file:
         file = get_default_backup_filename("anti-spyware-profiles", location_type, location_value)
 
-    try:
-        # List all anti-spyware profiles with exact_match=True using kwargs pattern
-        kwargs = {location_type: location_value}
-        profiles = scm_client.list_anti_spyware_profiles(**kwargs, exact_match=True)
+    # List all anti-spyware profiles with exact_match=True using kwargs pattern
+    kwargs = {location_type: location_value}
+    profiles = scm_client.list_anti_spyware_profiles(**kwargs, exact_match=True)
 
-        if not profiles:
-            typer.echo(f"No anti-spyware profiles found in {location_type} '{location_value}'")
-            return
+    if not profiles:
+        typer.echo(f"No anti-spyware profiles found in {location_type} '{location_value}'")
+        return
 
-        # Convert SDK models to dictionaries, excluding unset values
-        backup_data = []
-        for profile in profiles:
-            # The list method already returns dicts with exclude_unset=True
-            profile_dict = profile.copy()
-            # Remove system fields that shouldn't be in backup
-            profile_dict.pop("id", None)
+    # Convert SDK models to dictionaries, excluding unset values
+    backup_data = []
+    for profile in profiles:
+        # The list method already returns dicts with exclude_unset=True
+        profile_dict = profile.copy()
+        # Remove system fields that shouldn't be in backup
+        profile_dict.pop("id", None)
 
-            backup_data.append(profile_dict)
+        backup_data.append(profile_dict)
 
-        # Create the YAML structure
-        yaml_data = {"anti_spyware_profiles": backup_data}
+    # Create the YAML structure
+    yaml_data = {"anti_spyware_profiles": backup_data}
 
-        # Write to YAML file
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    # Write to YAML file
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} anti-spyware profiles to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up anti-spyware profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} anti-spyware profiles to {file}")
+    return file
 
 
 @delete_app.command("anti-spyware-profile")
+@handle_command_errors("deleting anti-spyware profile")
 def delete_anti_spyware_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the anti-spyware profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the anti-spyware profile"),
@@ -993,23 +969,20 @@ def delete_anti_spyware_profile(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_anti_spyware_profile(**kwargs, name=name)
-        if result:
-            typer.echo(f"Deleted anti-spyware profile: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(
-                f"Anti-spyware profile not found: {name} in {location_type} {location_value}",
-                err=True,
-            )
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting anti-spyware profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_anti_spyware_profile(**kwargs, name=name)
+    if result:
+        typer.echo(f"Deleted anti-spyware profile: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(
+            f"Anti-spyware profile not found: {name} in {location_type} {location_value}",
+            err=True,
+        )
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("anti-spyware-profile", help="Load anti-spyware profiles from a YAML file.")
+@handle_command_errors("loading anti-spyware profiles")
 def load_anti_spyware_profile(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -1033,111 +1006,107 @@ def load_anti_spyware_profile(
         scm load security anti-spyware-profile --file config/anti_spyware_profiles.yml --dry-run
 
     """
-    try:
-        # Validate container override parameters
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+    # Validate container override parameters
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo(
+            "Error: Only one of --folder, --snippet, or --device can be specified",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # Validate file exists
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
+
+    # Load YAML data using the same pattern as other commands
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
+
+    if not raw_data or "anti_spyware_profiles" not in raw_data:
+        typer.echo("No anti-spyware profiles found in file", err=True)
+        raise typer.Exit(code=1)
+
+    profiles = raw_data["anti_spyware_profiles"]
+    if not isinstance(profiles, list):
+        profiles = [profiles]
+
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        # Show override information if applicable
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(profiles))
+        return []
+
+    # Apply each anti-spyware profile
+    results = []
+    created_count = 0
+    updated_count = 0
+
+    for profile_data in profiles:
+        try:
+            # Apply container override if specified
+            if folder:
+                profile_data["folder"] = folder
+                profile_data.pop("snippet", None)
+                profile_data.pop("device", None)
+            elif snippet:
+                profile_data["snippet"] = snippet
+                profile_data.pop("folder", None)
+                profile_data.pop("device", None)
+            elif device:
+                profile_data["device"] = device
+                profile_data.pop("folder", None)
+                profile_data.pop("snippet", None)
+
+            # Validate using the Pydantic model
+            profile = AntiSpywareProfile(**profile_data)
+
+            # Call the SDK client to create the anti-spyware profile
+            sdk_data = profile.to_sdk_model()
+
+            # Extract container params
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
+
+            result = scm_client.create_anti_spyware_profile(**container_kwargs, **sdk_data)
+
+            results.append(result)
+
+            # Track if created or updated based on response
+            if "created" in str(result).lower():
+                created_count += 1
+            else:
+                updated_count += 1
+
+        except Exception as e:
             typer.echo(
-                "Error: Only one of --folder, --snippet, or --device can be specified",
+                f"Error processing anti-spyware profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                 err=True,
             )
-            raise typer.Exit(code=1)
+            # Continue processing other profiles
+            continue
 
-        # Validate file exists
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    # Display summary with counts
+    typer.echo(f"Successfully processed {len(results)} anti-spyware profile(s):")
+    if created_count > 0:
+        typer.echo(f"  - Created: {created_count}")
+    if updated_count > 0:
+        typer.echo(f"  - Updated: {updated_count}")
 
-        # Load YAML data using the same pattern as other commands
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
-
-        if not raw_data or "anti_spyware_profiles" not in raw_data:
-            typer.echo("No anti-spyware profiles found in file", err=True)
-            raise typer.Exit(code=1)
-
-        profiles = raw_data["anti_spyware_profiles"]
-        if not isinstance(profiles, list):
-            profiles = [profiles]
-
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            # Show override information if applicable
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(profiles))
-            return []
-
-        # Apply each anti-spyware profile
-        results = []
-        created_count = 0
-        updated_count = 0
-
-        for profile_data in profiles:
-            try:
-                # Apply container override if specified
-                if folder:
-                    profile_data["folder"] = folder
-                    profile_data.pop("snippet", None)
-                    profile_data.pop("device", None)
-                elif snippet:
-                    profile_data["snippet"] = snippet
-                    profile_data.pop("folder", None)
-                    profile_data.pop("device", None)
-                elif device:
-                    profile_data["device"] = device
-                    profile_data.pop("folder", None)
-                    profile_data.pop("snippet", None)
-
-                # Validate using the Pydantic model
-                profile = AntiSpywareProfile(**profile_data)
-
-                # Call the SDK client to create the anti-spyware profile
-                sdk_data = profile.to_sdk_model()
-
-                # Extract container params
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
-
-                result = scm_client.create_anti_spyware_profile(**container_kwargs, **sdk_data)
-
-                results.append(result)
-
-                # Track if created or updated based on response
-                if "created" in str(result).lower():
-                    created_count += 1
-                else:
-                    updated_count += 1
-
-            except Exception as e:
-                typer.echo(
-                    f"Error processing anti-spyware profile '{profile_data.get('name', 'unknown')}': {str(e)}",
-                    err=True,
-                )
-                # Continue processing other profiles
-                continue
-
-        # Display summary with counts
-        typer.echo(f"Successfully processed {len(results)} anti-spyware profile(s):")
-        if created_count > 0:
-            typer.echo(f"  - Created: {created_count}")
-        if updated_count > 0:
-            typer.echo(f"  - Updated: {updated_count}")
-
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading anti-spyware profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    return results
 
 
 @set_app.command("anti-spyware-profile")
+@handle_command_errors("creating anti-spyware profile")
 def set_anti_spyware_profile(
     folder: str = typer.Option(None, "--folder", help="Folder path for the anti-spyware profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path for the anti-spyware profile"),
@@ -1174,74 +1143,70 @@ def set_anti_spyware_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        # Validate and create anti-spyware profile
-        profile_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-        }
+    # Validate and create anti-spyware profile
+    profile_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+    }
 
-        if description:
-            profile_data["description"] = description
-        if cloud_inline_analysis:
-            profile_data["cloud_inline_analysis"] = cloud_inline_analysis
+    if description:
+        profile_data["description"] = description
+    if cloud_inline_analysis:
+        profile_data["cloud_inline_analysis"] = cloud_inline_analysis
 
-        # Add a default rule if requested or if no rules specified
-        if block_critical_high:
-            profile_data["rules"] = [
-                {
-                    "name": "Block Critical and High",
-                    "severity": ["critical", "high"],
-                    "category": "any",
-                    "action": "block",
-                    "packet_capture": "single-packet",
-                }
-            ]
-        else:
-            # Add a minimal default rule to satisfy SDK requirements
-            profile_data["rules"] = [
-                {
-                    "name": "simple-critical",
-                    "severity": ["critical"],
-                    "category": "any",
-                    "action": "block",
-                }
-            ]
+    # Add a default rule if requested or if no rules specified
+    if block_critical_high:
+        profile_data["rules"] = [
+            {
+                "name": "Block Critical and High",
+                "severity": ["critical", "high"],
+                "category": "any",
+                "action": "block",
+                "packet_capture": "single-packet",
+            }
+        ]
+    else:
+        # Add a minimal default rule to satisfy SDK requirements
+        profile_data["rules"] = [
+            {
+                "name": "simple-critical",
+                "severity": ["critical"],
+                "category": "any",
+                "action": "block",
+            }
+        ]
 
-        # AntiSpywareProfile expects specific field types
-        # Ensure all fields have the correct types
-        typed_profile_data = profile_data.copy()
-        profile = AntiSpywareProfile(**typed_profile_data)
+    # AntiSpywareProfile expects specific field types
+    # Ensure all fields have the correct types
+    typed_profile_data = profile_data.copy()
+    profile = AntiSpywareProfile(**typed_profile_data)
 
-        # Call SDK client to create the profile
-        sdk_data = profile.to_sdk_model()
+    # Call SDK client to create the profile
+    sdk_data = profile.to_sdk_model()
 
-        # Extract container params
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    # Extract container params
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_anti_spyware_profile(**container_kwargs, **sdk_data)
+    result = scm_client.create_anti_spyware_profile(**container_kwargs, **sdk_data)
 
-        # Format and display output
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created anti-spyware profile: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated anti-spyware profile: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for anti-spyware profile: {result['name']} in {location_type} {location_value}")
-
-    except Exception as e:
-        typer.echo(f"Error creating anti-spyware profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    # Format and display output
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created anti-spyware profile: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated anti-spyware profile: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for anti-spyware profile: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("anti-spyware-profile")
+@handle_command_errors("showing anti-spyware profile")
 def show_anti_spyware_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the anti-spyware profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the anti-spyware profile"),
@@ -1264,134 +1229,129 @@ def show_anti_spyware_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            # Get a specific anti-spyware profile by name
-            kwargs = {location_type: location_value}
-            profile = scm_client.get_anti_spyware_profile(**kwargs, name=name)
+    if name:
+        # Get a specific anti-spyware profile by name
+        kwargs = {location_type: location_value}
+        profile = scm_client.get_anti_spyware_profile(**kwargs, name=name)
 
-            typer.echo(f"\nAnti-Spyware Profile: {profile.get('name', 'N/A')}")
-            typer.echo("=" * 80)
+        typer.echo(f"\nAnti-Spyware Profile: {profile.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+
+        # Display container location (folder, snippet, or device)
+        if profile.get("folder"):
+            typer.echo(f"Location: Folder '{profile['folder']}'")
+        elif profile.get("snippet"):
+            typer.echo(f"Location: Snippet '{profile['snippet']}'")
+        elif profile.get("device"):
+            typer.echo(f"Location: Device '{profile['device']}'")
+
+        # Display description if present
+        if profile.get("description"):
+            typer.echo(f"Description: {profile['description']}")
+
+        # Display rules in detail
+        if profile.get("rules"):
+            typer.echo(f"\nRules ({len(profile['rules'])}):")
+            for idx, rule in enumerate(profile["rules"], 1):
+                typer.echo(f"  Rule {idx}: {rule.get('name', 'Unnamed')}")
+                if rule.get("severity"):
+                    severity = rule["severity"] if isinstance(rule["severity"], list) else [rule["severity"]]
+                    typer.echo(f"    Severity: {', '.join(severity)}")
+                typer.echo(f"    Action: {rule.get('action', 'N/A')}")
+                if rule.get("category"):
+                    typer.echo(f"    Category: {rule['category']}")
+                if rule.get("threat_name"):
+                    typer.echo(f"    Threat Name: {rule['threat_name']}")
+                if rule.get("packet_capture"):
+                    typer.echo(f"    Packet Capture: {rule['packet_capture']}")
+
+        # Display cloud inline analysis setting
+        if "cloud_inline_analysis" in profile:
+            typer.echo(f"\nCloud Inline Analysis: {'Enabled' if profile['cloud_inline_analysis'] else 'Disabled'}")
+
+        # Display threat exceptions in detail
+        if profile.get("threat_exception"):
+            typer.echo(f"\nThreat Exceptions ({len(profile['threat_exception'])}):")
+            for idx, exception in enumerate(profile["threat_exception"], 1):
+                typer.echo(f"  Exception {idx}:")
+                if exception.get("name"):
+                    typer.echo(f"    Name: {exception['name']}")
+                if exception.get("packet_capture"):
+                    typer.echo(f"    Packet Capture: {exception['packet_capture']}")
+                if exception.get("action"):
+                    typer.echo(f"    Action: {exception['action']}")
+                if exception.get("exempt_ip"):
+                    typer.echo(f"    Exempt IPs: {', '.join(exception['exempt_ip'])}")
+
+        # Display MICA engine settings if present
+        if profile.get("mica_engine_spyware_enabled"):
+            typer.echo("\nMICA Engine Settings:")
+            for setting in profile["mica_engine_spyware_enabled"]:
+                if setting.get("name"):
+                    typer.echo(f"  - {setting['name']}")
+                    if setting.get("inline_policy_action"):
+                        typer.echo(f"    Inline Policy Action: {setting['inline_policy_action']}")
+
+        # Display ID if present
+        if profile.get("id"):
+            typer.echo(f"\nID: {profile['id']}")
+
+        return profile
+
+    else:
+        # Default behavior: list all
+        # List all anti-spyware profiles in the specified container (default behavior)
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_anti_spyware_profiles(**kwargs, exact_match=False)
+
+        if not profiles:
+            typer.echo(f"No anti-spyware profiles found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nAnti-Spyware Profiles in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for profile in profiles:
+            # Display profile information
+            typer.echo(f"Name: {profile.get('name', 'N/A')}")
 
             # Display container location (folder, snippet, or device)
             if profile.get("folder"):
-                typer.echo(f"Location: Folder '{profile['folder']}'")
+                typer.echo(f"  Location: Folder '{profile['folder']}'")
             elif profile.get("snippet"):
-                typer.echo(f"Location: Snippet '{profile['snippet']}'")
+                typer.echo(f"  Location: Snippet '{profile['snippet']}'")
             elif profile.get("device"):
-                typer.echo(f"Location: Device '{profile['device']}'")
+                typer.echo(f"  Location: Device '{profile['device']}'")
 
             # Display description if present
             if profile.get("description"):
-                typer.echo(f"Description: {profile['description']}")
+                typer.echo(f"  Description: {profile['description']}")
 
-            # Display rules in detail
+            # Display rules if present
             if profile.get("rules"):
-                typer.echo(f"\nRules ({len(profile['rules'])}):")
-                for idx, rule in enumerate(profile["rules"], 1):
-                    typer.echo(f"  Rule {idx}: {rule.get('name', 'Unnamed')}")
-                    if rule.get("severity"):
-                        severity = rule["severity"] if isinstance(rule["severity"], list) else [rule["severity"]]
-                        typer.echo(f"    Severity: {', '.join(severity)}")
-                    typer.echo(f"    Action: {rule.get('action', 'N/A')}")
-                    if rule.get("category"):
-                        typer.echo(f"    Category: {rule['category']}")
-                    if rule.get("threat_name"):
-                        typer.echo(f"    Threat Name: {rule['threat_name']}")
-                    if rule.get("packet_capture"):
-                        typer.echo(f"    Packet Capture: {rule['packet_capture']}")
+                typer.echo(f"  Rules: {len(profile['rules'])} configured")
+                for rule in profile["rules"]:
+                    typer.echo(f"    - {rule.get('name', 'Unnamed')}: {rule.get('action', 'N/A')}")
 
             # Display cloud inline analysis setting
-            if "cloud_inline_analysis" in profile:
-                typer.echo(f"\nCloud Inline Analysis: {'Enabled' if profile['cloud_inline_analysis'] else 'Disabled'}")
+            if profile.get("cloud_inline_analysis"):
+                typer.echo("  Cloud Inline Analysis: Enabled")
 
-            # Display threat exceptions in detail
+            # Display threat exceptions if present
             if profile.get("threat_exception"):
-                typer.echo(f"\nThreat Exceptions ({len(profile['threat_exception'])}):")
-                for idx, exception in enumerate(profile["threat_exception"], 1):
-                    typer.echo(f"  Exception {idx}:")
-                    if exception.get("name"):
-                        typer.echo(f"    Name: {exception['name']}")
-                    if exception.get("packet_capture"):
-                        typer.echo(f"    Packet Capture: {exception['packet_capture']}")
-                    if exception.get("action"):
-                        typer.echo(f"    Action: {exception['action']}")
-                    if exception.get("exempt_ip"):
-                        typer.echo(f"    Exempt IPs: {', '.join(exception['exempt_ip'])}")
+                typer.echo(f"  Threat Exceptions: {len(profile['threat_exception'])}")
 
             # Display MICA engine settings if present
             if profile.get("mica_engine_spyware_enabled"):
-                typer.echo("\nMICA Engine Settings:")
-                for setting in profile["mica_engine_spyware_enabled"]:
-                    if setting.get("name"):
-                        typer.echo(f"  - {setting['name']}")
-                        if setting.get("inline_policy_action"):
-                            typer.echo(f"    Inline Policy Action: {setting['inline_policy_action']}")
+                typer.echo("  MICA Engine: Configured")
 
             # Display ID if present
             if profile.get("id"):
-                typer.echo(f"\nID: {profile['id']}")
+                typer.echo(f"  ID: {profile['id']}")
 
-            return profile
+            typer.echo("-" * 80)
 
-        else:
-            # Default behavior: list all
-            # List all anti-spyware profiles in the specified container (default behavior)
-            kwargs = {location_type: location_value}
-            profiles = scm_client.list_anti_spyware_profiles(**kwargs, exact_match=False)
-
-            if not profiles:
-                typer.echo(f"No anti-spyware profiles found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nAnti-Spyware Profiles in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for profile in profiles:
-                # Display profile information
-                typer.echo(f"Name: {profile.get('name', 'N/A')}")
-
-                # Display container location (folder, snippet, or device)
-                if profile.get("folder"):
-                    typer.echo(f"  Location: Folder '{profile['folder']}'")
-                elif profile.get("snippet"):
-                    typer.echo(f"  Location: Snippet '{profile['snippet']}'")
-                elif profile.get("device"):
-                    typer.echo(f"  Location: Device '{profile['device']}'")
-
-                # Display description if present
-                if profile.get("description"):
-                    typer.echo(f"  Description: {profile['description']}")
-
-                # Display rules if present
-                if profile.get("rules"):
-                    typer.echo(f"  Rules: {len(profile['rules'])} configured")
-                    for rule in profile["rules"]:
-                        typer.echo(f"    - {rule.get('name', 'Unnamed')}: {rule.get('action', 'N/A')}")
-
-                # Display cloud inline analysis setting
-                if profile.get("cloud_inline_analysis"):
-                    typer.echo("  Cloud Inline Analysis: Enabled")
-
-                # Display threat exceptions if present
-                if profile.get("threat_exception"):
-                    typer.echo(f"  Threat Exceptions: {len(profile['threat_exception'])}")
-
-                # Display MICA engine settings if present
-                if profile.get("mica_engine_spyware_enabled"):
-                    typer.echo("  MICA Engine: Configured")
-
-                # Display ID if present
-                if profile.get("id"):
-                    typer.echo(f"  ID: {profile['id']}")
-
-                typer.echo("-" * 80)
-
-            return profiles
-
-    except Exception as e:
-        typer.echo(f"Error showing anti-spyware profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return profiles
 
 
 # =============================================================================================================================================================================================
@@ -1400,6 +1360,7 @@ def show_anti_spyware_profile(
 
 
 @backup_app.command("decryption-profile")
+@handle_command_errors("backing up decryption profiles")
 def backup_decryption_profile(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -1429,41 +1390,37 @@ def backup_decryption_profile(
     if not file:
         file = get_default_backup_filename("decryption-profiles", location_type, location_value)
 
-    try:
-        # List all decryption profiles with exact_match=True using kwargs pattern
-        kwargs = {location_type: location_value}
-        profiles = scm_client.list_decryption_profiles(**kwargs, exact_match=True)
+    # List all decryption profiles with exact_match=True using kwargs pattern
+    kwargs = {location_type: location_value}
+    profiles = scm_client.list_decryption_profiles(**kwargs, exact_match=True)
 
-        if not profiles:
-            typer.echo(f"No decryption profiles found in {location_type} '{location_value}'")
-            return
+    if not profiles:
+        typer.echo(f"No decryption profiles found in {location_type} '{location_value}'")
+        return
 
-        # Convert SDK models to dictionaries, excluding unset values
-        backup_data = []
-        for profile in profiles:
-            # The list method already returns dicts with exclude_unset=True
-            profile_dict = profile.copy()
-            # Remove system fields that shouldn't be in backup
-            profile_dict.pop("id", None)
+    # Convert SDK models to dictionaries, excluding unset values
+    backup_data = []
+    for profile in profiles:
+        # The list method already returns dicts with exclude_unset=True
+        profile_dict = profile.copy()
+        # Remove system fields that shouldn't be in backup
+        profile_dict.pop("id", None)
 
-            backup_data.append(profile_dict)
+        backup_data.append(profile_dict)
 
-        # Create the YAML structure
-        yaml_data = {"decryption_profiles": backup_data}
+    # Create the YAML structure
+    yaml_data = {"decryption_profiles": backup_data}
 
-        # Write to YAML file
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    # Write to YAML file
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} decryption profiles to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up decryption profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} decryption profiles to {file}")
+    return file
 
 
 @delete_app.command("decryption-profile")
+@handle_command_errors("deleting decryption profile")
 def delete_decryption_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the decryption profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the decryption profile"),
@@ -1492,23 +1449,20 @@ def delete_decryption_profile(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_decryption_profile(**kwargs, name=name)
-        if result:
-            typer.echo(f"Deleted decryption profile: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(
-                f"Decryption profile not found: {name} in {location_type} {location_value}",
-                err=True,
-            )
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting decryption profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_decryption_profile(**kwargs, name=name)
+    if result:
+        typer.echo(f"Deleted decryption profile: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(
+            f"Decryption profile not found: {name} in {location_type} {location_value}",
+            err=True,
+        )
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("decryption-profile", help="Load decryption profiles from a YAML file.")
+@handle_command_errors("loading decryption profiles")
 def load_decryption_profile(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -1532,111 +1486,107 @@ def load_decryption_profile(
         scm load security decryption-profile --file config/decryption_profiles.yml --dry-run
 
     """
-    try:
-        # Validate container override parameters
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+    # Validate container override parameters
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo(
+            "Error: Only one of --folder, --snippet, or --device can be specified",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # Validate file exists
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
+
+    # Load YAML data using the same pattern as other commands
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
+
+    if not raw_data or "decryption_profiles" not in raw_data:
+        typer.echo("No decryption profiles found in file", err=True)
+        raise typer.Exit(code=1)
+
+    profiles = raw_data["decryption_profiles"]
+    if not isinstance(profiles, list):
+        profiles = [profiles]
+
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        # Show override information if applicable
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(profiles))
+        return []
+
+    # Apply each decryption profile
+    results = []
+    created_count = 0
+    updated_count = 0
+
+    for profile_data in profiles:
+        try:
+            # Apply container override if specified
+            if folder:
+                profile_data["folder"] = folder
+                profile_data.pop("snippet", None)
+                profile_data.pop("device", None)
+            elif snippet:
+                profile_data["snippet"] = snippet
+                profile_data.pop("folder", None)
+                profile_data.pop("device", None)
+            elif device:
+                profile_data["device"] = device
+                profile_data.pop("folder", None)
+                profile_data.pop("snippet", None)
+
+            # Validate using the Pydantic model
+            profile = DecryptionProfile(**profile_data)
+
+            # Call the SDK client to create the decryption profile
+            sdk_data = profile.to_sdk_model()
+
+            # Extract container params
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
+
+            result = scm_client.create_decryption_profile(**container_kwargs, **sdk_data)
+
+            results.append(result)
+
+            # Track if created or updated based on response
+            if "created" in str(result).lower():
+                created_count += 1
+            else:
+                updated_count += 1
+
+        except Exception as e:
             typer.echo(
-                "Error: Only one of --folder, --snippet, or --device can be specified",
+                f"Error processing decryption profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                 err=True,
             )
-            raise typer.Exit(code=1)
+            # Continue processing other profiles
+            continue
 
-        # Validate file exists
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    # Display summary with counts
+    typer.echo(f"Successfully processed {len(results)} decryption profile(s):")
+    if created_count > 0:
+        typer.echo(f"  - Created: {created_count}")
+    if updated_count > 0:
+        typer.echo(f"  - Updated: {updated_count}")
 
-        # Load YAML data using the same pattern as other commands
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
-
-        if not raw_data or "decryption_profiles" not in raw_data:
-            typer.echo("No decryption profiles found in file", err=True)
-            raise typer.Exit(code=1)
-
-        profiles = raw_data["decryption_profiles"]
-        if not isinstance(profiles, list):
-            profiles = [profiles]
-
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            # Show override information if applicable
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(profiles))
-            return []
-
-        # Apply each decryption profile
-        results = []
-        created_count = 0
-        updated_count = 0
-
-        for profile_data in profiles:
-            try:
-                # Apply container override if specified
-                if folder:
-                    profile_data["folder"] = folder
-                    profile_data.pop("snippet", None)
-                    profile_data.pop("device", None)
-                elif snippet:
-                    profile_data["snippet"] = snippet
-                    profile_data.pop("folder", None)
-                    profile_data.pop("device", None)
-                elif device:
-                    profile_data["device"] = device
-                    profile_data.pop("folder", None)
-                    profile_data.pop("snippet", None)
-
-                # Validate using the Pydantic model
-                profile = DecryptionProfile(**profile_data)
-
-                # Call the SDK client to create the decryption profile
-                sdk_data = profile.to_sdk_model()
-
-                # Extract container params
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
-
-                result = scm_client.create_decryption_profile(**container_kwargs, **sdk_data)
-
-                results.append(result)
-
-                # Track if created or updated based on response
-                if "created" in str(result).lower():
-                    created_count += 1
-                else:
-                    updated_count += 1
-
-            except Exception as e:
-                typer.echo(
-                    f"Error processing decryption profile '{profile_data.get('name', 'unknown')}': {str(e)}",
-                    err=True,
-                )
-                # Continue processing other profiles
-                continue
-
-        # Display summary with counts
-        typer.echo(f"Successfully processed {len(results)} decryption profile(s):")
-        if created_count > 0:
-            typer.echo(f"  - Created: {created_count}")
-        if updated_count > 0:
-            typer.echo(f"  - Updated: {updated_count}")
-
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading decryption profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    return results
 
 
 @set_app.command("decryption-profile")
+@handle_command_errors("creating decryption profile")
 def set_decryption_profile(
     folder: str = typer.Option(None, "--folder", help="Folder path for the decryption profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path for the decryption profile"),
@@ -1692,62 +1642,55 @@ def set_decryption_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        # Build profile data
-        profile_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-        }
+    # Build profile data
+    profile_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+    }
 
-        # Add optional description
-        if description:
-            profile_data["description"] = description
+    # Add optional description
+    if description:
+        profile_data["description"] = description
 
-        # Parse JSON strings for proxy settings
-        if ssl_forward_proxy:
-            profile_data["ssl_forward_proxy"] = json.loads(ssl_forward_proxy)
-        if ssl_inbound_proxy:
-            profile_data["ssl_inbound_proxy"] = json.loads(ssl_inbound_proxy)
-        if ssl_no_proxy:
-            profile_data["ssl_no_proxy"] = json.loads(ssl_no_proxy)
-        if ssl_protocol_settings:
-            profile_data["ssl_protocol_settings"] = json.loads(ssl_protocol_settings)
+    # Parse JSON strings for proxy settings
+    if ssl_forward_proxy:
+        profile_data["ssl_forward_proxy"] = json.loads(ssl_forward_proxy)
+    if ssl_inbound_proxy:
+        profile_data["ssl_inbound_proxy"] = json.loads(ssl_inbound_proxy)
+    if ssl_no_proxy:
+        profile_data["ssl_no_proxy"] = json.loads(ssl_no_proxy)
+    if ssl_protocol_settings:
+        profile_data["ssl_protocol_settings"] = json.loads(ssl_protocol_settings)
 
-        # Validate using the Pydantic model
-        profile = DecryptionProfile(**profile_data)
+    # Validate using the Pydantic model
+    profile = DecryptionProfile(**profile_data)
 
-        # Call SDK client to create the profile
-        sdk_data = profile.to_sdk_model()
+    # Call SDK client to create the profile
+    sdk_data = profile.to_sdk_model()
 
-        # Extract container params
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    # Extract container params
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_decryption_profile(**container_kwargs, **sdk_data)
+    result = scm_client.create_decryption_profile(**container_kwargs, **sdk_data)
 
-        # Format and display output
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created decryption profile: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated decryption profile: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for decryption profile: {result['name']} in {location_type} {location_value}")
-
-    except json.JSONDecodeError as e:
-        typer.echo(f"Error parsing JSON settings: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        typer.echo(f"Error creating decryption profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    # Format and display output
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created decryption profile: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated decryption profile: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for decryption profile: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("decryption-profile")
+@handle_command_errors("showing decryption profile")
 def show_decryption_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the decryption profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the decryption profile"),
@@ -1770,123 +1713,118 @@ def show_decryption_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            # Get a specific decryption profile by name
-            kwargs = {location_type: location_value}
-            profile = scm_client.get_decryption_profile(**kwargs, name=name)
+    if name:
+        # Get a specific decryption profile by name
+        kwargs = {location_type: location_value}
+        profile = scm_client.get_decryption_profile(**kwargs, name=name)
 
-            typer.echo(f"\nDecryption Profile: {profile.get('name', 'N/A')}")
-            typer.echo("=" * 80)
+        typer.echo(f"\nDecryption Profile: {profile.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+
+        # Display container location (folder, snippet, or device)
+        if profile.get("folder"):
+            typer.echo(f"Location: Folder '{profile['folder']}'")
+        elif profile.get("snippet"):
+            typer.echo(f"Location: Snippet '{profile['snippet']}'")
+        elif profile.get("device"):
+            typer.echo(f"Location: Device '{profile['device']}'")
+
+        # Display description if present
+        if profile.get("description"):
+            typer.echo(f"Description: {profile['description']}")
+
+        # Display SSL Forward Proxy settings
+        if profile.get("ssl_forward_proxy"):
+            typer.echo("\nSSL Forward Proxy Settings:")
+            proxy = profile["ssl_forward_proxy"]
+            for key, value in proxy.items():
+                key_display = key.replace("_", " ").title()
+                typer.echo(f"  {key_display}: {value}")
+
+        # Display SSL Inbound Proxy settings
+        if profile.get("ssl_inbound_proxy"):
+            typer.echo("\nSSL Inbound Proxy Settings:")
+            proxy = profile["ssl_inbound_proxy"]
+            for key, value in proxy.items():
+                key_display = key.replace("_", " ").title()
+                typer.echo(f"  {key_display}: {value}")
+
+        # Display SSL No Proxy settings
+        if profile.get("ssl_no_proxy"):
+            typer.echo("\nSSL No Proxy Settings:")
+            proxy = profile["ssl_no_proxy"]
+            for key, value in proxy.items():
+                key_display = key.replace("_", " ").title()
+                typer.echo(f"  {key_display}: {value}")
+
+        # Display SSL Protocol Settings
+        if profile.get("ssl_protocol_settings"):
+            typer.echo("\nSSL Protocol Settings:")
+            settings = profile["ssl_protocol_settings"]
+            for key, value in settings.items():
+                key_display = key.replace("_", " ").title()
+                typer.echo(f"  {key_display}: {value}")
+
+        # Display ID if present
+        if profile.get("id"):
+            typer.echo(f"\nID: {profile['id']}")
+
+        return profile
+
+    else:
+        # Default behavior: list all
+        # List all decryption profiles in the specified container (default behavior)
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_decryption_profiles(**kwargs, exact_match=False)
+
+        if not profiles:
+            typer.echo(f"No decryption profiles found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nDecryption Profiles in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for profile in profiles:
+            # Display profile information
+            typer.echo(f"Name: {profile.get('name', 'N/A')}")
 
             # Display container location (folder, snippet, or device)
             if profile.get("folder"):
-                typer.echo(f"Location: Folder '{profile['folder']}'")
+                typer.echo(f"  Location: Folder '{profile['folder']}'")
             elif profile.get("snippet"):
-                typer.echo(f"Location: Snippet '{profile['snippet']}'")
+                typer.echo(f"  Location: Snippet '{profile['snippet']}'")
             elif profile.get("device"):
-                typer.echo(f"Location: Device '{profile['device']}'")
+                typer.echo(f"  Location: Device '{profile['device']}'")
 
             # Display description if present
             if profile.get("description"):
-                typer.echo(f"Description: {profile['description']}")
+                typer.echo(f"  Description: {profile['description']}")
 
-            # Display SSL Forward Proxy settings
+            # Display proxy types configured
+            proxy_types = []
             if profile.get("ssl_forward_proxy"):
-                typer.echo("\nSSL Forward Proxy Settings:")
-                proxy = profile["ssl_forward_proxy"]
-                for key, value in proxy.items():
-                    key_display = key.replace("_", " ").title()
-                    typer.echo(f"  {key_display}: {value}")
-
-            # Display SSL Inbound Proxy settings
+                proxy_types.append("SSL Forward Proxy")
             if profile.get("ssl_inbound_proxy"):
-                typer.echo("\nSSL Inbound Proxy Settings:")
-                proxy = profile["ssl_inbound_proxy"]
-                for key, value in proxy.items():
-                    key_display = key.replace("_", " ").title()
-                    typer.echo(f"  {key_display}: {value}")
-
-            # Display SSL No Proxy settings
+                proxy_types.append("SSL Inbound Proxy")
             if profile.get("ssl_no_proxy"):
-                typer.echo("\nSSL No Proxy Settings:")
-                proxy = profile["ssl_no_proxy"]
-                for key, value in proxy.items():
-                    key_display = key.replace("_", " ").title()
-                    typer.echo(f"  {key_display}: {value}")
+                proxy_types.append("SSL No Proxy")
 
-            # Display SSL Protocol Settings
+            if proxy_types:
+                typer.echo(f"  Proxy Types: {', '.join(proxy_types)}")
+
+            # Display SSL protocol settings if present
             if profile.get("ssl_protocol_settings"):
-                typer.echo("\nSSL Protocol Settings:")
                 settings = profile["ssl_protocol_settings"]
-                for key, value in settings.items():
-                    key_display = key.replace("_", " ").title()
-                    typer.echo(f"  {key_display}: {value}")
+                if "min_version" in settings or "max_version" in settings:
+                    typer.echo(f"  SSL Versions: {settings.get('min_version', 'N/A')} - {settings.get('max_version', 'N/A')}")
 
             # Display ID if present
             if profile.get("id"):
-                typer.echo(f"\nID: {profile['id']}")
+                typer.echo(f"  ID: {profile['id']}")
 
-            return profile
+            typer.echo("-" * 80)
 
-        else:
-            # Default behavior: list all
-            # List all decryption profiles in the specified container (default behavior)
-            kwargs = {location_type: location_value}
-            profiles = scm_client.list_decryption_profiles(**kwargs, exact_match=False)
-
-            if not profiles:
-                typer.echo(f"No decryption profiles found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nDecryption Profiles in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for profile in profiles:
-                # Display profile information
-                typer.echo(f"Name: {profile.get('name', 'N/A')}")
-
-                # Display container location (folder, snippet, or device)
-                if profile.get("folder"):
-                    typer.echo(f"  Location: Folder '{profile['folder']}'")
-                elif profile.get("snippet"):
-                    typer.echo(f"  Location: Snippet '{profile['snippet']}'")
-                elif profile.get("device"):
-                    typer.echo(f"  Location: Device '{profile['device']}'")
-
-                # Display description if present
-                if profile.get("description"):
-                    typer.echo(f"  Description: {profile['description']}")
-
-                # Display proxy types configured
-                proxy_types = []
-                if profile.get("ssl_forward_proxy"):
-                    proxy_types.append("SSL Forward Proxy")
-                if profile.get("ssl_inbound_proxy"):
-                    proxy_types.append("SSL Inbound Proxy")
-                if profile.get("ssl_no_proxy"):
-                    proxy_types.append("SSL No Proxy")
-
-                if proxy_types:
-                    typer.echo(f"  Proxy Types: {', '.join(proxy_types)}")
-
-                # Display SSL protocol settings if present
-                if profile.get("ssl_protocol_settings"):
-                    settings = profile["ssl_protocol_settings"]
-                    if "min_version" in settings or "max_version" in settings:
-                        typer.echo(f"  SSL Versions: {settings.get('min_version', 'N/A')} - {settings.get('max_version', 'N/A')}")
-
-                # Display ID if present
-                if profile.get("id"):
-                    typer.echo(f"  ID: {profile['id']}")
-
-                typer.echo("-" * 80)
-
-            return profiles
-
-    except Exception as e:
-        typer.echo(f"Error showing decryption profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return profiles
 
 
 # =============================================================================================================================================================================================
@@ -1895,6 +1833,7 @@ def show_decryption_profile(
 
 
 @backup_app.command("wildfire-antivirus-profile")
+@handle_command_errors("backing up WildFire antivirus profiles")
 def backup_wildfire_antivirus_profile(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -1924,41 +1863,37 @@ def backup_wildfire_antivirus_profile(
     if not file:
         file = get_default_backup_filename("wildfire-antivirus-profiles", location_type, location_value)
 
-    try:
-        # List all WildFire antivirus profiles with exact_match=True using kwargs pattern
-        kwargs = {location_type: location_value}
-        profiles = scm_client.list_wildfire_antivirus_profiles(**kwargs, exact_match=True)
+    # List all WildFire antivirus profiles with exact_match=True using kwargs pattern
+    kwargs = {location_type: location_value}
+    profiles = scm_client.list_wildfire_antivirus_profiles(**kwargs, exact_match=True)
 
-        if not profiles:
-            typer.echo(f"No WildFire antivirus profiles found in {location_type} '{location_value}'")
-            return
+    if not profiles:
+        typer.echo(f"No WildFire antivirus profiles found in {location_type} '{location_value}'")
+        return
 
-        # Convert SDK models to dictionaries, excluding unset values
-        backup_data = []
-        for profile in profiles:
-            # The list method already returns dicts with exclude_unset=True
-            profile_dict = profile.copy()
-            # Remove system fields that shouldn't be in backup
-            profile_dict.pop("id", None)
+    # Convert SDK models to dictionaries, excluding unset values
+    backup_data = []
+    for profile in profiles:
+        # The list method already returns dicts with exclude_unset=True
+        profile_dict = profile.copy()
+        # Remove system fields that shouldn't be in backup
+        profile_dict.pop("id", None)
 
-            backup_data.append(profile_dict)
+        backup_data.append(profile_dict)
 
-        # Create the YAML structure
-        yaml_data = {"wildfire_antivirus_profiles": backup_data}
+    # Create the YAML structure
+    yaml_data = {"wildfire_antivirus_profiles": backup_data}
 
-        # Write to YAML file
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    # Write to YAML file
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} WildFire antivirus profiles to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up WildFire antivirus profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} WildFire antivirus profiles to {file}")
+    return file
 
 
 @delete_app.command("wildfire-antivirus-profile")
+@handle_command_errors("deleting WildFire antivirus profile")
 def delete_wildfire_antivirus_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the WildFire antivirus profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the WildFire antivirus profile"),
@@ -1987,23 +1922,20 @@ def delete_wildfire_antivirus_profile(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_wildfire_antivirus_profile(**kwargs, name=name)
-        if result:
-            typer.echo(f"Deleted WildFire antivirus profile: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(
-                f"WildFire antivirus profile not found: {name} in {location_type} {location_value}",
-                err=True,
-            )
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting WildFire antivirus profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_wildfire_antivirus_profile(**kwargs, name=name)
+    if result:
+        typer.echo(f"Deleted WildFire antivirus profile: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(
+            f"WildFire antivirus profile not found: {name} in {location_type} {location_value}",
+            err=True,
+        )
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("wildfire-antivirus-profile", help="Load WildFire antivirus profiles from a YAML file.")
+@handle_command_errors("loading WildFire antivirus profiles")
 def load_wildfire_antivirus_profile(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -2027,111 +1959,107 @@ def load_wildfire_antivirus_profile(
         scm load security wildfire-antivirus-profile --file config/wildfire_antivirus_profiles.yml --dry-run
 
     """
-    try:
-        # Validate container override parameters
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+    # Validate container override parameters
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo(
+            "Error: Only one of --folder, --snippet, or --device can be specified",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # Validate file exists
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
+
+    # Load YAML data using the same pattern as other commands
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
+
+    if not raw_data or "wildfire_antivirus_profiles" not in raw_data:
+        typer.echo("No WildFire antivirus profiles found in file", err=True)
+        raise typer.Exit(code=1)
+
+    profiles = raw_data["wildfire_antivirus_profiles"]
+    if not isinstance(profiles, list):
+        profiles = [profiles]
+
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        # Show override information if applicable
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(profiles))
+        return []
+
+    # Apply each WildFire antivirus profile
+    results = []
+    created_count = 0
+    updated_count = 0
+
+    for profile_data in profiles:
+        try:
+            # Apply container override if specified
+            if folder:
+                profile_data["folder"] = folder
+                profile_data.pop("snippet", None)
+                profile_data.pop("device", None)
+            elif snippet:
+                profile_data["snippet"] = snippet
+                profile_data.pop("folder", None)
+                profile_data.pop("device", None)
+            elif device:
+                profile_data["device"] = device
+                profile_data.pop("folder", None)
+                profile_data.pop("snippet", None)
+
+            # Validate using the Pydantic model
+            profile = WildfireAntivirusProfile(**profile_data)
+
+            # Call the SDK client to create the WildFire antivirus profile
+            sdk_data = profile.to_sdk_model()
+
+            # Extract container params
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
+
+            result = scm_client.create_wildfire_antivirus_profile(**container_kwargs, **sdk_data)
+
+            results.append(result)
+
+            # Track if created or updated based on response
+            if "created" in str(result).lower():
+                created_count += 1
+            else:
+                updated_count += 1
+
+        except Exception as e:
             typer.echo(
-                "Error: Only one of --folder, --snippet, or --device can be specified",
+                f"Error processing WildFire antivirus profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                 err=True,
             )
-            raise typer.Exit(code=1)
+            # Continue processing other profiles
+            continue
 
-        # Validate file exists
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    # Display summary with counts
+    typer.echo(f"Successfully processed {len(results)} WildFire antivirus profile(s):")
+    if created_count > 0:
+        typer.echo(f"  - Created: {created_count}")
+    if updated_count > 0:
+        typer.echo(f"  - Updated: {updated_count}")
 
-        # Load YAML data using the same pattern as other commands
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
-
-        if not raw_data or "wildfire_antivirus_profiles" not in raw_data:
-            typer.echo("No WildFire antivirus profiles found in file", err=True)
-            raise typer.Exit(code=1)
-
-        profiles = raw_data["wildfire_antivirus_profiles"]
-        if not isinstance(profiles, list):
-            profiles = [profiles]
-
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            # Show override information if applicable
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(profiles))
-            return []
-
-        # Apply each WildFire antivirus profile
-        results = []
-        created_count = 0
-        updated_count = 0
-
-        for profile_data in profiles:
-            try:
-                # Apply container override if specified
-                if folder:
-                    profile_data["folder"] = folder
-                    profile_data.pop("snippet", None)
-                    profile_data.pop("device", None)
-                elif snippet:
-                    profile_data["snippet"] = snippet
-                    profile_data.pop("folder", None)
-                    profile_data.pop("device", None)
-                elif device:
-                    profile_data["device"] = device
-                    profile_data.pop("folder", None)
-                    profile_data.pop("snippet", None)
-
-                # Validate using the Pydantic model
-                profile = WildfireAntivirusProfile(**profile_data)
-
-                # Call the SDK client to create the WildFire antivirus profile
-                sdk_data = profile.to_sdk_model()
-
-                # Extract container params
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
-
-                result = scm_client.create_wildfire_antivirus_profile(**container_kwargs, **sdk_data)
-
-                results.append(result)
-
-                # Track if created or updated based on response
-                if "created" in str(result).lower():
-                    created_count += 1
-                else:
-                    updated_count += 1
-
-            except Exception as e:
-                typer.echo(
-                    f"Error processing WildFire antivirus profile '{profile_data.get('name', 'unknown')}': {str(e)}",
-                    err=True,
-                )
-                # Continue processing other profiles
-                continue
-
-        # Display summary with counts
-        typer.echo(f"Successfully processed {len(results)} WildFire antivirus profile(s):")
-        if created_count > 0:
-            typer.echo(f"  - Created: {created_count}")
-        if updated_count > 0:
-            typer.echo(f"  - Updated: {updated_count}")
-
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading WildFire antivirus profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    return results
 
 
 @set_app.command("wildfire-antivirus-profile")
+@handle_command_errors("creating WildFire antivirus profile")
 def set_wildfire_antivirus_profile(
     folder: str = typer.Option(None, "--folder", help="Folder path for the WildFire antivirus profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path for the WildFire antivirus profile"),
@@ -2168,69 +2096,65 @@ def set_wildfire_antivirus_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        # Validate and create WildFire antivirus profile
-        profile_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-        }
+    # Validate and create WildFire antivirus profile
+    profile_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+    }
 
-        if description:
-            profile_data["description"] = description
-        if packet_capture:
-            profile_data["packet_capture"] = packet_capture
+    if description:
+        profile_data["description"] = description
+    if packet_capture:
+        profile_data["packet_capture"] = packet_capture
 
-        # Parse rules from JSON if provided
-        if rules_json:
-            try:
-                profile_data["rules"] = json.loads(rules_json)
-            except json.JSONDecodeError as e:
-                typer.echo(f"Error parsing rules JSON: {str(e)}", err=True)
-                raise typer.Exit(code=1) from e
-        else:
-            # Add a default rule
-            profile_data["rules"] = [
-                {
-                    "name": "default-fwd",
-                    "direction": "both",
-                    "analysis": "public-cloud",
-                    "application": ["any"],
-                    "file_type": ["any"],
-                }
-            ]
+    # Parse rules from JSON if provided
+    if rules_json:
+        try:
+            profile_data["rules"] = json.loads(rules_json)
+        except json.JSONDecodeError as e:
+            typer.echo(f"Error parsing rules JSON: {str(e)}", err=True)
+            raise typer.Exit(code=1) from e
+    else:
+        # Add a default rule
+        profile_data["rules"] = [
+            {
+                "name": "default-fwd",
+                "direction": "both",
+                "analysis": "public-cloud",
+                "application": ["any"],
+                "file_type": ["any"],
+            }
+        ]
 
-        # Validate using the Pydantic model
-        profile = WildfireAntivirusProfile(**profile_data)
+    # Validate using the Pydantic model
+    profile = WildfireAntivirusProfile(**profile_data)
 
-        # Call SDK client to create the profile
-        sdk_data = profile.to_sdk_model()
+    # Call SDK client to create the profile
+    sdk_data = profile.to_sdk_model()
 
-        # Extract container params
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    # Extract container params
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_wildfire_antivirus_profile(**container_kwargs, **sdk_data)
+    result = scm_client.create_wildfire_antivirus_profile(**container_kwargs, **sdk_data)
 
-        # Format and display output
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created WildFire antivirus profile: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated WildFire antivirus profile: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for WildFire antivirus profile: {result['name']} in {location_type} {location_value}")
-
-    except Exception as e:
-        typer.echo(f"Error creating WildFire antivirus profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    # Format and display output
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created WildFire antivirus profile: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated WildFire antivirus profile: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for WildFire antivirus profile: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("wildfire-antivirus-profile")
+@handle_command_errors("showing WildFire antivirus profile")
 def show_wildfire_antivirus_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the WildFire antivirus profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the WildFire antivirus profile"),
@@ -2253,125 +2177,120 @@ def show_wildfire_antivirus_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            # Get a specific WildFire antivirus profile by name
-            kwargs = {location_type: location_value}
-            profile = scm_client.get_wildfire_antivirus_profile(**kwargs, name=name)
+    if name:
+        # Get a specific WildFire antivirus profile by name
+        kwargs = {location_type: location_value}
+        profile = scm_client.get_wildfire_antivirus_profile(**kwargs, name=name)
 
-            typer.echo(f"\nWildFire Antivirus Profile: {profile.get('name', 'N/A')}")
-            typer.echo("=" * 80)
+        typer.echo(f"\nWildFire Antivirus Profile: {profile.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+
+        # Display container location (folder, snippet, or device)
+        if profile.get("folder"):
+            typer.echo(f"Location: Folder '{profile['folder']}'")
+        elif profile.get("snippet"):
+            typer.echo(f"Location: Snippet '{profile['snippet']}'")
+        elif profile.get("device"):
+            typer.echo(f"Location: Device '{profile['device']}'")
+
+        # Display description if present
+        if profile.get("description"):
+            typer.echo(f"Description: {profile['description']}")
+
+        # Display packet capture setting
+        if "packet_capture" in profile:
+            typer.echo(f"Packet Capture: {'Enabled' if profile['packet_capture'] else 'Disabled'}")
+
+        # Display rules in detail
+        if profile.get("rules"):
+            typer.echo(f"\nRules ({len(profile['rules'])}):")
+            for idx, rule in enumerate(profile["rules"], 1):
+                typer.echo(f"  Rule {idx}: {rule.get('name', 'Unnamed')}")
+                typer.echo(f"    Direction: {rule.get('direction', 'N/A')}")
+                if rule.get("analysis"):
+                    typer.echo(f"    Analysis: {rule['analysis']}")
+                if rule.get("application"):
+                    typer.echo(f"    Applications: {', '.join(rule['application'])}")
+                if rule.get("file_type"):
+                    typer.echo(f"    File Types: {', '.join(rule['file_type'])}")
+
+        # Display MLAV exceptions if present
+        if profile.get("mlav_exception"):
+            typer.echo(f"\nMLAV Exceptions ({len(profile['mlav_exception'])}):")
+            for idx, exc in enumerate(profile["mlav_exception"], 1):
+                typer.echo(f"  Exception {idx}: {exc.get('name', 'Unnamed')}")
+                if exc.get("filename"):
+                    typer.echo(f"    Filename: {exc['filename']}")
+                if exc.get("description"):
+                    typer.echo(f"    Description: {exc['description']}")
+
+        # Display threat exceptions if present
+        if profile.get("threat_exception"):
+            typer.echo(f"\nThreat Exceptions ({len(profile['threat_exception'])}):")
+            for idx, exc in enumerate(profile["threat_exception"], 1):
+                typer.echo(f"  Exception {idx}: {exc.get('name', 'Unnamed')}")
+                if exc.get("notes"):
+                    typer.echo(f"    Notes: {exc['notes']}")
+
+        # Display ID if present
+        if profile.get("id"):
+            typer.echo(f"\nID: {profile['id']}")
+
+        return profile
+
+    else:
+        # Default behavior: list all
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_wildfire_antivirus_profiles(**kwargs, exact_match=False)
+
+        if not profiles:
+            typer.echo(f"No WildFire antivirus profiles found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nWildFire Antivirus Profiles in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for profile in profiles:
+            # Display profile information
+            typer.echo(f"Name: {profile.get('name', 'N/A')}")
 
             # Display container location (folder, snippet, or device)
             if profile.get("folder"):
-                typer.echo(f"Location: Folder '{profile['folder']}'")
+                typer.echo(f"  Location: Folder '{profile['folder']}'")
             elif profile.get("snippet"):
-                typer.echo(f"Location: Snippet '{profile['snippet']}'")
+                typer.echo(f"  Location: Snippet '{profile['snippet']}'")
             elif profile.get("device"):
-                typer.echo(f"Location: Device '{profile['device']}'")
+                typer.echo(f"  Location: Device '{profile['device']}'")
 
             # Display description if present
             if profile.get("description"):
-                typer.echo(f"Description: {profile['description']}")
+                typer.echo(f"  Description: {profile['description']}")
+
+            # Display rules if present
+            if profile.get("rules"):
+                typer.echo(f"  Rules: {len(profile['rules'])} configured")
+                for rule in profile["rules"]:
+                    typer.echo(f"    - {rule.get('name', 'Unnamed')}: {rule.get('direction', 'N/A')}")
 
             # Display packet capture setting
-            if "packet_capture" in profile:
-                typer.echo(f"Packet Capture: {'Enabled' if profile['packet_capture'] else 'Disabled'}")
-
-            # Display rules in detail
-            if profile.get("rules"):
-                typer.echo(f"\nRules ({len(profile['rules'])}):")
-                for idx, rule in enumerate(profile["rules"], 1):
-                    typer.echo(f"  Rule {idx}: {rule.get('name', 'Unnamed')}")
-                    typer.echo(f"    Direction: {rule.get('direction', 'N/A')}")
-                    if rule.get("analysis"):
-                        typer.echo(f"    Analysis: {rule['analysis']}")
-                    if rule.get("application"):
-                        typer.echo(f"    Applications: {', '.join(rule['application'])}")
-                    if rule.get("file_type"):
-                        typer.echo(f"    File Types: {', '.join(rule['file_type'])}")
-
-            # Display MLAV exceptions if present
-            if profile.get("mlav_exception"):
-                typer.echo(f"\nMLAV Exceptions ({len(profile['mlav_exception'])}):")
-                for idx, exc in enumerate(profile["mlav_exception"], 1):
-                    typer.echo(f"  Exception {idx}: {exc.get('name', 'Unnamed')}")
-                    if exc.get("filename"):
-                        typer.echo(f"    Filename: {exc['filename']}")
-                    if exc.get("description"):
-                        typer.echo(f"    Description: {exc['description']}")
+            if profile.get("packet_capture"):
+                typer.echo("  Packet Capture: Enabled")
 
             # Display threat exceptions if present
             if profile.get("threat_exception"):
-                typer.echo(f"\nThreat Exceptions ({len(profile['threat_exception'])}):")
-                for idx, exc in enumerate(profile["threat_exception"], 1):
-                    typer.echo(f"  Exception {idx}: {exc.get('name', 'Unnamed')}")
-                    if exc.get("notes"):
-                        typer.echo(f"    Notes: {exc['notes']}")
+                typer.echo(f"  Threat Exceptions: {len(profile['threat_exception'])}")
+
+            # Display MLAV exceptions if present
+            if profile.get("mlav_exception"):
+                typer.echo(f"  MLAV Exceptions: {len(profile['mlav_exception'])}")
 
             # Display ID if present
             if profile.get("id"):
-                typer.echo(f"\nID: {profile['id']}")
+                typer.echo(f"  ID: {profile['id']}")
 
-            return profile
+            typer.echo("-" * 80)
 
-        else:
-            # Default behavior: list all
-            kwargs = {location_type: location_value}
-            profiles = scm_client.list_wildfire_antivirus_profiles(**kwargs, exact_match=False)
-
-            if not profiles:
-                typer.echo(f"No WildFire antivirus profiles found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nWildFire Antivirus Profiles in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for profile in profiles:
-                # Display profile information
-                typer.echo(f"Name: {profile.get('name', 'N/A')}")
-
-                # Display container location (folder, snippet, or device)
-                if profile.get("folder"):
-                    typer.echo(f"  Location: Folder '{profile['folder']}'")
-                elif profile.get("snippet"):
-                    typer.echo(f"  Location: Snippet '{profile['snippet']}'")
-                elif profile.get("device"):
-                    typer.echo(f"  Location: Device '{profile['device']}'")
-
-                # Display description if present
-                if profile.get("description"):
-                    typer.echo(f"  Description: {profile['description']}")
-
-                # Display rules if present
-                if profile.get("rules"):
-                    typer.echo(f"  Rules: {len(profile['rules'])} configured")
-                    for rule in profile["rules"]:
-                        typer.echo(f"    - {rule.get('name', 'Unnamed')}: {rule.get('direction', 'N/A')}")
-
-                # Display packet capture setting
-                if profile.get("packet_capture"):
-                    typer.echo("  Packet Capture: Enabled")
-
-                # Display threat exceptions if present
-                if profile.get("threat_exception"):
-                    typer.echo(f"  Threat Exceptions: {len(profile['threat_exception'])}")
-
-                # Display MLAV exceptions if present
-                if profile.get("mlav_exception"):
-                    typer.echo(f"  MLAV Exceptions: {len(profile['mlav_exception'])}")
-
-                # Display ID if present
-                if profile.get("id"):
-                    typer.echo(f"  ID: {profile['id']}")
-
-                typer.echo("-" * 80)
-
-            return profiles
-
-    except Exception as e:
-        typer.echo(f"Error showing WildFire antivirus profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return profiles
 
 
 # =============================================================================================================================================================================================
@@ -2385,6 +2304,7 @@ DNS_SEC_DEVICE_OPTION = typer.Option(None, "--device", help="Device containing t
 
 
 @backup_app.command("dns-security-profile")
+@handle_command_errors("backing up DNS security profiles")
 def backup_dns_security_profile(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -2411,41 +2331,37 @@ def backup_dns_security_profile(
     if not file:
         file = get_default_backup_filename("dns-security-profiles", location_type, location_value)
 
-    try:
-        # List all DNS security profiles with exact_match=True using kwargs pattern
-        kwargs = {location_type: location_value}
-        profiles = scm_client.list_dns_security_profiles(**kwargs, exact_match=True)
+    # List all DNS security profiles with exact_match=True using kwargs pattern
+    kwargs = {location_type: location_value}
+    profiles = scm_client.list_dns_security_profiles(**kwargs, exact_match=True)
 
-        if not profiles:
-            typer.echo(f"No DNS security profiles found in {location_type} '{location_value}'")
-            return
+    if not profiles:
+        typer.echo(f"No DNS security profiles found in {location_type} '{location_value}'")
+        return
 
-        # Convert SDK models to dictionaries, excluding unset values
-        backup_data = []
-        for profile in profiles:
-            # The list method already returns dicts with exclude_unset=True
-            profile_dict = profile.copy()
-            # Remove system fields that shouldn't be in backup
-            profile_dict.pop("id", None)
+    # Convert SDK models to dictionaries, excluding unset values
+    backup_data = []
+    for profile in profiles:
+        # The list method already returns dicts with exclude_unset=True
+        profile_dict = profile.copy()
+        # Remove system fields that shouldn't be in backup
+        profile_dict.pop("id", None)
 
-            backup_data.append(profile_dict)
+        backup_data.append(profile_dict)
 
-        # Create the YAML structure
-        yaml_data = {"dns_security_profiles": backup_data}
+    # Create the YAML structure
+    yaml_data = {"dns_security_profiles": backup_data}
 
-        # Write to YAML file
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    # Write to YAML file
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} DNS security profiles to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up DNS security profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} DNS security profiles to {file}")
+    return file
 
 
 @delete_app.command("dns-security-profile")
+@handle_command_errors("deleting DNS security profile")
 def delete_dns_security_profile(
     folder: str = DNS_SEC_FOLDER_OPTION,
     snippet: str = DNS_SEC_SNIPPET_OPTION,
@@ -2471,23 +2387,20 @@ def delete_dns_security_profile(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_dns_security_profile(**kwargs, name=name)
-        if result:
-            typer.echo(f"Deleted DNS security profile: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(
-                f"DNS security profile not found: {name} in {location_type} {location_value}",
-                err=True,
-            )
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting DNS security profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_dns_security_profile(**kwargs, name=name)
+    if result:
+        typer.echo(f"Deleted DNS security profile: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(
+            f"DNS security profile not found: {name} in {location_type} {location_value}",
+            err=True,
+        )
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("dns-security-profile", help="Load DNS security profiles from a YAML file.")
+@handle_command_errors("loading DNS security profiles")
 def load_dns_security_profile(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -2508,112 +2421,108 @@ def load_dns_security_profile(
         scm load security dns-security-profile --file config/dns_security_profiles.yml --dry-run
 
     """
-    try:
-        # Validate container override parameters
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+    # Validate container override parameters
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo(
+            "Error: Only one of --folder, --snippet, or --device can be specified",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # Validate file exists
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
+
+    # Load YAML data using the same pattern as other commands
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
+
+    if not raw_data or "dns_security_profiles" not in raw_data:
+        typer.echo("No DNS security profiles found in file", err=True)
+        raise typer.Exit(code=1)
+
+    profiles = raw_data["dns_security_profiles"]
+    if not isinstance(profiles, list):
+        profiles = [profiles]
+
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        # Show override information if applicable
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(profiles))
+        return []
+
+    # Apply each DNS security profile
+    results = []
+    created_count = 0
+    updated_count = 0
+
+    for profile_data in profiles:
+        try:
+            # Apply container override if specified
+            if folder:
+                profile_data["folder"] = folder
+                profile_data.pop("snippet", None)
+                profile_data.pop("device", None)
+            elif snippet:
+                profile_data["snippet"] = snippet
+                profile_data.pop("folder", None)
+                profile_data.pop("device", None)
+            elif device:
+                profile_data["device"] = device
+                profile_data.pop("folder", None)
+                profile_data.pop("snippet", None)
+
+            # Validate using the Pydantic model
+            profile = DNSSecurityProfile(**profile_data)
+
+            # Call the SDK client to create the DNS security profile
+            sdk_data = profile.to_sdk_model()
+
+            # Extract container params
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
+
+            result = scm_client.create_dns_security_profile(**container_kwargs, **sdk_data)
+
+            results.append(result)
+
+            # Track if created or updated based on __action__ field
+            action = result.get("__action__", "")
+            if action == "created":
+                created_count += 1
+            elif action == "updated":
+                updated_count += 1
+
+        except Exception as e:
             typer.echo(
-                "Error: Only one of --folder, --snippet, or --device can be specified",
+                f"Error processing DNS security profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                 err=True,
             )
-            raise typer.Exit(code=1)
+            # Continue processing other profiles
+            continue
 
-        # Validate file exists
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    # Display summary with counts
+    typer.echo(f"Successfully processed {len(results)} DNS security profile(s):")
+    if created_count > 0:
+        typer.echo(f"  - Created: {created_count}")
+    if updated_count > 0:
+        typer.echo(f"  - Updated: {updated_count}")
 
-        # Load YAML data using the same pattern as other commands
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
-
-        if not raw_data or "dns_security_profiles" not in raw_data:
-            typer.echo("No DNS security profiles found in file", err=True)
-            raise typer.Exit(code=1)
-
-        profiles = raw_data["dns_security_profiles"]
-        if not isinstance(profiles, list):
-            profiles = [profiles]
-
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            # Show override information if applicable
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(profiles))
-            return []
-
-        # Apply each DNS security profile
-        results = []
-        created_count = 0
-        updated_count = 0
-
-        for profile_data in profiles:
-            try:
-                # Apply container override if specified
-                if folder:
-                    profile_data["folder"] = folder
-                    profile_data.pop("snippet", None)
-                    profile_data.pop("device", None)
-                elif snippet:
-                    profile_data["snippet"] = snippet
-                    profile_data.pop("folder", None)
-                    profile_data.pop("device", None)
-                elif device:
-                    profile_data["device"] = device
-                    profile_data.pop("folder", None)
-                    profile_data.pop("snippet", None)
-
-                # Validate using the Pydantic model
-                profile = DNSSecurityProfile(**profile_data)
-
-                # Call the SDK client to create the DNS security profile
-                sdk_data = profile.to_sdk_model()
-
-                # Extract container params
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
-
-                result = scm_client.create_dns_security_profile(**container_kwargs, **sdk_data)
-
-                results.append(result)
-
-                # Track if created or updated based on __action__ field
-                action = result.get("__action__", "")
-                if action == "created":
-                    created_count += 1
-                elif action == "updated":
-                    updated_count += 1
-
-            except Exception as e:
-                typer.echo(
-                    f"Error processing DNS security profile '{profile_data.get('name', 'unknown')}': {str(e)}",
-                    err=True,
-                )
-                # Continue processing other profiles
-                continue
-
-        # Display summary with counts
-        typer.echo(f"Successfully processed {len(results)} DNS security profile(s):")
-        if created_count > 0:
-            typer.echo(f"  - Created: {created_count}")
-        if updated_count > 0:
-            typer.echo(f"  - Updated: {updated_count}")
-
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading DNS security profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    return results
 
 
 @set_app.command("dns-security-profile")
+@handle_command_errors("creating DNS security profile")
 def set_dns_security_profile(
     folder: str = typer.Option(None, "--folder", help="Folder path for the DNS security profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path for the DNS security profile"),
@@ -2645,56 +2554,49 @@ def set_dns_security_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        # Build profile data
-        profile_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-        }
+    # Build profile data
+    profile_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+    }
 
-        # Add optional description
-        if description:
-            profile_data["description"] = description
+    # Add optional description
+    if description:
+        profile_data["description"] = description
 
-        # Parse JSON string for botnet domains
-        if botnet_domains:
-            profile_data["botnet_domains"] = json.loads(botnet_domains)
+    # Parse JSON string for botnet domains
+    if botnet_domains:
+        profile_data["botnet_domains"] = json.loads(botnet_domains)
 
-        # Validate using the Pydantic model
-        profile = DNSSecurityProfile(**profile_data)
+    # Validate using the Pydantic model
+    profile = DNSSecurityProfile(**profile_data)
 
-        # Call SDK client to create the profile
-        sdk_data = profile.to_sdk_model()
+    # Call SDK client to create the profile
+    sdk_data = profile.to_sdk_model()
 
-        # Extract container params
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    # Extract container params
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_dns_security_profile(**container_kwargs, **sdk_data)
+    result = scm_client.create_dns_security_profile(**container_kwargs, **sdk_data)
 
-        # Format and display output based on action
-        action = result.get("__action__", "created")
-        if action == "updated":
-            typer.echo(f"Updated DNS security profile: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes to DNS security profile: {result['name']} in {location_type} {location_value}")
-        else:
-            typer.echo(f"Created DNS security profile: {result['name']} in {location_type} {location_value}")
-
-    except json.JSONDecodeError as e:
-        typer.echo(f"Error parsing JSON settings: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        typer.echo(f"Error creating DNS security profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    # Format and display output based on action
+    action = result.get("__action__", "created")
+    if action == "updated":
+        typer.echo(f"Updated DNS security profile: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes to DNS security profile: {result['name']} in {location_type} {location_value}")
+    else:
+        typer.echo(f"Created DNS security profile: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("dns-security-profile")
+@handle_command_errors("showing DNS security profile")
 def show_dns_security_profile(
     folder: str = DNS_SEC_FOLDER_OPTION,
     snippet: str = DNS_SEC_SNIPPET_OPTION,
@@ -2717,131 +2619,126 @@ def show_dns_security_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            # Get a specific DNS security profile by name
-            kwargs = {location_type: location_value}
-            profile = scm_client.get_dns_security_profile(**kwargs, name=name)
+    if name:
+        # Get a specific DNS security profile by name
+        kwargs = {location_type: location_value}
+        profile = scm_client.get_dns_security_profile(**kwargs, name=name)
 
-            typer.echo(f"\nDNS Security Profile: {profile.get('name', 'N/A')}")
-            typer.echo("=" * 80)
+        typer.echo(f"\nDNS Security Profile: {profile.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+
+        # Display container location (folder, snippet, or device)
+        if profile.get("folder"):
+            typer.echo(f"Location: Folder '{profile['folder']}'")
+        elif profile.get("snippet"):
+            typer.echo(f"Location: Snippet '{profile['snippet']}'")
+        elif profile.get("device"):
+            typer.echo(f"Location: Device '{profile['device']}'")
+
+        # Display description if present
+        if profile.get("description"):
+            typer.echo(f"Description: {profile['description']}")
+
+        # Display botnet domains settings
+        botnet = profile.get("botnet_domains")
+        if botnet:
+            # Display DNS security categories
+            categories = botnet.get("dns_security_categories")
+            if categories:
+                typer.echo("\nDNS Security Categories:")
+                for cat in categories:
+                    typer.echo(f"  Name: {cat.get('name', 'N/A')}")
+                    typer.echo(f"    Action: {cat.get('action', 'N/A')}")
+                    if cat.get("log_level"):
+                        typer.echo(f"    Log Level: {cat['log_level']}")
+                    if cat.get("packet_capture"):
+                        typer.echo(f"    Packet Capture: {cat['packet_capture']}")
+
+            # Display lists
+            lists = botnet.get("lists")
+            if lists:
+                typer.echo("\nDNS Lists:")
+                for lst in lists:
+                    typer.echo(f"  Name: {lst.get('name', 'N/A')}")
+                    if lst.get("action"):
+                        typer.echo(f"    Action: {lst['action']}")
+                    if lst.get("packet_capture"):
+                        typer.echo(f"    Packet Capture: {lst['packet_capture']}")
+
+            # Display sinkhole settings
+            sinkhole = botnet.get("sinkhole")
+            if sinkhole:
+                typer.echo("\nSinkhole Settings:")
+                typer.echo(f"  IPv4 Address: {sinkhole.get('ipv4_address', 'N/A')}")
+                typer.echo(f"  IPv6 Address: {sinkhole.get('ipv6_address', 'N/A')}")
+
+            # Display whitelist
+            whitelist = botnet.get("whitelist")
+            if whitelist:
+                typer.echo("\nWhitelist:")
+                for entry in whitelist:
+                    typer.echo(f"  Domain: {entry.get('name', 'N/A')}")
+                    if entry.get("description"):
+                        typer.echo(f"    Description: {entry['description']}")
+
+        # Display ID if present
+        if profile.get("id"):
+            typer.echo(f"\nID: {profile['id']}")
+
+        return profile
+
+    else:
+        # Default behavior: list all
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_dns_security_profiles(**kwargs, exact_match=False)
+
+        if not profiles:
+            typer.echo(f"No DNS security profiles found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nDNS Security Profiles in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for profile in profiles:
+            # Display profile information
+            typer.echo(f"Name: {profile.get('name', 'N/A')}")
 
             # Display container location (folder, snippet, or device)
             if profile.get("folder"):
-                typer.echo(f"Location: Folder '{profile['folder']}'")
+                typer.echo(f"  Location: Folder '{profile['folder']}'")
             elif profile.get("snippet"):
-                typer.echo(f"Location: Snippet '{profile['snippet']}'")
+                typer.echo(f"  Location: Snippet '{profile['snippet']}'")
             elif profile.get("device"):
-                typer.echo(f"Location: Device '{profile['device']}'")
+                typer.echo(f"  Location: Device '{profile['device']}'")
 
             # Display description if present
             if profile.get("description"):
-                typer.echo(f"Description: {profile['description']}")
+                typer.echo(f"  Description: {profile['description']}")
 
-            # Display botnet domains settings
+            # Display DNS security categories count
             botnet = profile.get("botnet_domains")
             if botnet:
-                # Display DNS security categories
                 categories = botnet.get("dns_security_categories")
                 if categories:
-                    typer.echo("\nDNS Security Categories:")
-                    for cat in categories:
-                        typer.echo(f"  Name: {cat.get('name', 'N/A')}")
-                        typer.echo(f"    Action: {cat.get('action', 'N/A')}")
-                        if cat.get("log_level"):
-                            typer.echo(f"    Log Level: {cat['log_level']}")
-                        if cat.get("packet_capture"):
-                            typer.echo(f"    Packet Capture: {cat['packet_capture']}")
+                    typer.echo(f"  DNS Security Categories: {len(categories)}")
 
-                # Display lists
-                lists = botnet.get("lists")
-                if lists:
-                    typer.echo("\nDNS Lists:")
-                    for lst in lists:
-                        typer.echo(f"  Name: {lst.get('name', 'N/A')}")
-                        if lst.get("action"):
-                            typer.echo(f"    Action: {lst['action']}")
-                        if lst.get("packet_capture"):
-                            typer.echo(f"    Packet Capture: {lst['packet_capture']}")
+                # Show sinkhole config
+                if botnet.get("sinkhole"):
+                    sinkhole = botnet["sinkhole"]
+                    typer.echo(f"  Sinkhole: IPv4={sinkhole.get('ipv4_address', 'N/A')}, IPv6={sinkhole.get('ipv6_address', 'N/A')}")
 
-                # Display sinkhole settings
-                sinkhole = botnet.get("sinkhole")
-                if sinkhole:
-                    typer.echo("\nSinkhole Settings:")
-                    typer.echo(f"  IPv4 Address: {sinkhole.get('ipv4_address', 'N/A')}")
-                    typer.echo(f"  IPv6 Address: {sinkhole.get('ipv6_address', 'N/A')}")
-
-                # Display whitelist
+                # Show whitelist count
                 whitelist = botnet.get("whitelist")
                 if whitelist:
-                    typer.echo("\nWhitelist:")
-                    for entry in whitelist:
-                        typer.echo(f"  Domain: {entry.get('name', 'N/A')}")
-                        if entry.get("description"):
-                            typer.echo(f"    Description: {entry['description']}")
+                    typer.echo(f"  Whitelist Entries: {len(whitelist)}")
 
             # Display ID if present
             if profile.get("id"):
-                typer.echo(f"\nID: {profile['id']}")
+                typer.echo(f"  ID: {profile['id']}")
 
-            return profile
+            typer.echo("-" * 80)
 
-        else:
-            # Default behavior: list all
-            kwargs = {location_type: location_value}
-            profiles = scm_client.list_dns_security_profiles(**kwargs, exact_match=False)
-
-            if not profiles:
-                typer.echo(f"No DNS security profiles found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nDNS Security Profiles in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for profile in profiles:
-                # Display profile information
-                typer.echo(f"Name: {profile.get('name', 'N/A')}")
-
-                # Display container location (folder, snippet, or device)
-                if profile.get("folder"):
-                    typer.echo(f"  Location: Folder '{profile['folder']}'")
-                elif profile.get("snippet"):
-                    typer.echo(f"  Location: Snippet '{profile['snippet']}'")
-                elif profile.get("device"):
-                    typer.echo(f"  Location: Device '{profile['device']}'")
-
-                # Display description if present
-                if profile.get("description"):
-                    typer.echo(f"  Description: {profile['description']}")
-
-                # Display DNS security categories count
-                botnet = profile.get("botnet_domains")
-                if botnet:
-                    categories = botnet.get("dns_security_categories")
-                    if categories:
-                        typer.echo(f"  DNS Security Categories: {len(categories)}")
-
-                    # Show sinkhole config
-                    if botnet.get("sinkhole"):
-                        sinkhole = botnet["sinkhole"]
-                        typer.echo(f"  Sinkhole: IPv4={sinkhole.get('ipv4_address', 'N/A')}, IPv6={sinkhole.get('ipv6_address', 'N/A')}")
-
-                    # Show whitelist count
-                    whitelist = botnet.get("whitelist")
-                    if whitelist:
-                        typer.echo(f"  Whitelist Entries: {len(whitelist)}")
-
-                # Display ID if present
-                if profile.get("id"):
-                    typer.echo(f"  ID: {profile['id']}")
-
-                typer.echo("-" * 80)
-
-            return profiles
-
-    except Exception as e:
-        typer.echo(f"Error showing DNS security profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return profiles
 
 
 # =============================================================================================================================================================================================
@@ -2850,6 +2747,7 @@ def show_dns_security_profile(
 
 
 @backup_app.command("vulnerability-protection-profile")
+@handle_command_errors("backing up vulnerability protection profiles")
 def backup_vulnerability_protection_profile(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -2879,41 +2777,37 @@ def backup_vulnerability_protection_profile(
     if not file:
         file = get_default_backup_filename("vulnerability-protection-profiles", location_type, location_value)
 
-    try:
-        # List all vulnerability protection profiles with exact_match=True using kwargs pattern
-        kwargs = {location_type: location_value}
-        profiles = scm_client.list_vulnerability_protection_profiles(**kwargs, exact_match=True)
+    # List all vulnerability protection profiles with exact_match=True using kwargs pattern
+    kwargs = {location_type: location_value}
+    profiles = scm_client.list_vulnerability_protection_profiles(**kwargs, exact_match=True)
 
-        if not profiles:
-            typer.echo(f"No vulnerability protection profiles found in {location_type} '{location_value}'")
-            return
+    if not profiles:
+        typer.echo(f"No vulnerability protection profiles found in {location_type} '{location_value}'")
+        return
 
-        # Convert SDK models to dictionaries, excluding unset values
-        backup_data = []
-        for profile in profiles:
-            # The list method already returns dicts with exclude_unset=True
-            profile_dict = profile.copy()
-            # Remove system fields that shouldn't be in backup
-            profile_dict.pop("id", None)
+    # Convert SDK models to dictionaries, excluding unset values
+    backup_data = []
+    for profile in profiles:
+        # The list method already returns dicts with exclude_unset=True
+        profile_dict = profile.copy()
+        # Remove system fields that shouldn't be in backup
+        profile_dict.pop("id", None)
 
-            backup_data.append(profile_dict)
+        backup_data.append(profile_dict)
 
-        # Create the YAML structure
-        yaml_data = {"vulnerability_protection_profiles": backup_data}
+    # Create the YAML structure
+    yaml_data = {"vulnerability_protection_profiles": backup_data}
 
-        # Write to YAML file
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    # Write to YAML file
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} vulnerability protection profiles to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up vulnerability protection profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} vulnerability protection profiles to {file}")
+    return file
 
 
 @delete_app.command("vulnerability-protection-profile")
+@handle_command_errors("deleting vulnerability protection profile")
 def delete_vulnerability_protection_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the vulnerability protection profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the vulnerability protection profile"),
@@ -2942,23 +2836,20 @@ def delete_vulnerability_protection_profile(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_vulnerability_protection_profile(**kwargs, name=name)
-        if result:
-            typer.echo(f"Deleted vulnerability protection profile: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(
-                f"Vulnerability protection profile not found: {name} in {location_type} {location_value}",
-                err=True,
-            )
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting vulnerability protection profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_vulnerability_protection_profile(**kwargs, name=name)
+    if result:
+        typer.echo(f"Deleted vulnerability protection profile: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(
+            f"Vulnerability protection profile not found: {name} in {location_type} {location_value}",
+            err=True,
+        )
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("vulnerability-protection-profile", help="Load vulnerability protection profiles from a YAML file.")
+@handle_command_errors("loading vulnerability protection profiles")
 def load_vulnerability_protection_profile(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -2982,111 +2873,107 @@ def load_vulnerability_protection_profile(
         scm load security vulnerability-protection-profile --file config/vuln_profiles.yml --dry-run
 
     """
-    try:
-        # Validate container override parameters
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+    # Validate container override parameters
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo(
+            "Error: Only one of --folder, --snippet, or --device can be specified",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # Validate file exists
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
+
+    # Load YAML data using the same pattern as other commands
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
+
+    if not raw_data or "vulnerability_protection_profiles" not in raw_data:
+        typer.echo("No vulnerability protection profiles found in file", err=True)
+        raise typer.Exit(code=1)
+
+    profiles = raw_data["vulnerability_protection_profiles"]
+    if not isinstance(profiles, list):
+        profiles = [profiles]
+
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        # Show override information if applicable
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(profiles))
+        return []
+
+    # Apply each vulnerability protection profile
+    results = []
+    created_count = 0
+    updated_count = 0
+
+    for profile_data in profiles:
+        try:
+            # Apply container override if specified
+            if folder:
+                profile_data["folder"] = folder
+                profile_data.pop("snippet", None)
+                profile_data.pop("device", None)
+            elif snippet:
+                profile_data["snippet"] = snippet
+                profile_data.pop("folder", None)
+                profile_data.pop("device", None)
+            elif device:
+                profile_data["device"] = device
+                profile_data.pop("folder", None)
+                profile_data.pop("snippet", None)
+
+            # Validate using the Pydantic model
+            profile = VulnerabilityProtectionProfile(**profile_data)
+
+            # Call the SDK client to create the vulnerability protection profile
+            sdk_data = profile.to_sdk_model()
+
+            # Extract container params
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
+
+            result = scm_client.create_vulnerability_protection_profile(**container_kwargs, **sdk_data)
+
+            results.append(result)
+
+            # Track if created or updated based on response
+            if "created" in str(result).lower():
+                created_count += 1
+            else:
+                updated_count += 1
+
+        except Exception as e:
             typer.echo(
-                "Error: Only one of --folder, --snippet, or --device can be specified",
+                f"Error processing vulnerability protection profile '{profile_data.get('name', 'unknown')}': {str(e)}",
                 err=True,
             )
-            raise typer.Exit(code=1)
+            # Continue processing other profiles
+            continue
 
-        # Validate file exists
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    # Display summary with counts
+    typer.echo(f"Successfully processed {len(results)} vulnerability protection profile(s):")
+    if created_count > 0:
+        typer.echo(f"  - Created: {created_count}")
+    if updated_count > 0:
+        typer.echo(f"  - Updated: {updated_count}")
 
-        # Load YAML data using the same pattern as other commands
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
-
-        if not raw_data or "vulnerability_protection_profiles" not in raw_data:
-            typer.echo("No vulnerability protection profiles found in file", err=True)
-            raise typer.Exit(code=1)
-
-        profiles = raw_data["vulnerability_protection_profiles"]
-        if not isinstance(profiles, list):
-            profiles = [profiles]
-
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            # Show override information if applicable
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(profiles))
-            return []
-
-        # Apply each vulnerability protection profile
-        results = []
-        created_count = 0
-        updated_count = 0
-
-        for profile_data in profiles:
-            try:
-                # Apply container override if specified
-                if folder:
-                    profile_data["folder"] = folder
-                    profile_data.pop("snippet", None)
-                    profile_data.pop("device", None)
-                elif snippet:
-                    profile_data["snippet"] = snippet
-                    profile_data.pop("folder", None)
-                    profile_data.pop("device", None)
-                elif device:
-                    profile_data["device"] = device
-                    profile_data.pop("folder", None)
-                    profile_data.pop("snippet", None)
-
-                # Validate using the Pydantic model
-                profile = VulnerabilityProtectionProfile(**profile_data)
-
-                # Call the SDK client to create the vulnerability protection profile
-                sdk_data = profile.to_sdk_model()
-
-                # Extract container params
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
-
-                result = scm_client.create_vulnerability_protection_profile(**container_kwargs, **sdk_data)
-
-                results.append(result)
-
-                # Track if created or updated based on response
-                if "created" in str(result).lower():
-                    created_count += 1
-                else:
-                    updated_count += 1
-
-            except Exception as e:
-                typer.echo(
-                    f"Error processing vulnerability protection profile '{profile_data.get('name', 'unknown')}': {str(e)}",
-                    err=True,
-                )
-                # Continue processing other profiles
-                continue
-
-        # Display summary with counts
-        typer.echo(f"Successfully processed {len(results)} vulnerability protection profile(s):")
-        if created_count > 0:
-            typer.echo(f"  - Created: {created_count}")
-        if updated_count > 0:
-            typer.echo(f"  - Updated: {updated_count}")
-
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading vulnerability protection profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    return results
 
 
 @set_app.command("vulnerability-protection-profile")
+@handle_command_errors("creating vulnerability protection profile")
 def set_vulnerability_protection_profile(
     folder: str = typer.Option(None, "--folder", help="Folder path for the vulnerability protection profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path for the vulnerability protection profile"),
@@ -3118,77 +3005,73 @@ def set_vulnerability_protection_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        # Validate and create vulnerability protection profile
-        profile_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-        }
+    # Validate and create vulnerability protection profile
+    profile_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+    }
 
-        if description:
-            profile_data["description"] = description
+    if description:
+        profile_data["description"] = description
 
-        # Add a default rule if requested or if no rules specified
-        if block_critical_high:
-            profile_data["rules"] = [
-                {
-                    "name": "Block Critical and High",
-                    "severity": ["critical", "high"],
-                    "category": "any",
-                    "host": "any",
-                    "cve": ["any"],
-                    "vendor_id": ["any"],
-                    "action": "alert",
-                    "packet_capture": "single-packet",
-                }
-            ]
-        else:
-            # Add a minimal default rule to satisfy SDK requirements
-            profile_data["rules"] = [
-                {
-                    "name": "simple-critical",
-                    "severity": ["critical"],
-                    "category": "any",
-                    "host": "any",
-                    "cve": ["any"],
-                    "vendor_id": ["any"],
-                    "action": "default",
-                }
-            ]
+    # Add a default rule if requested or if no rules specified
+    if block_critical_high:
+        profile_data["rules"] = [
+            {
+                "name": "Block Critical and High",
+                "severity": ["critical", "high"],
+                "category": "any",
+                "host": "any",
+                "cve": ["any"],
+                "vendor_id": ["any"],
+                "action": "alert",
+                "packet_capture": "single-packet",
+            }
+        ]
+    else:
+        # Add a minimal default rule to satisfy SDK requirements
+        profile_data["rules"] = [
+            {
+                "name": "simple-critical",
+                "severity": ["critical"],
+                "category": "any",
+                "host": "any",
+                "cve": ["any"],
+                "vendor_id": ["any"],
+                "action": "default",
+            }
+        ]
 
-        # VulnerabilityProtectionProfile expects specific field types
-        typed_profile_data = profile_data.copy()
-        profile = VulnerabilityProtectionProfile(**typed_profile_data)
+    # VulnerabilityProtectionProfile expects specific field types
+    typed_profile_data = profile_data.copy()
+    profile = VulnerabilityProtectionProfile(**typed_profile_data)
 
-        # Call SDK client to create the profile
-        sdk_data = profile.to_sdk_model()
+    # Call SDK client to create the profile
+    sdk_data = profile.to_sdk_model()
 
-        # Extract container params
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    # Extract container params
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_vulnerability_protection_profile(**container_kwargs, **sdk_data)
+    result = scm_client.create_vulnerability_protection_profile(**container_kwargs, **sdk_data)
 
-        # Format and display output
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created vulnerability protection profile: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated vulnerability protection profile: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for vulnerability protection profile: {result['name']} in {location_type} {location_value}")
-
-    except Exception as e:
-        typer.echo(f"Error creating vulnerability protection profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    # Format and display output
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created vulnerability protection profile: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated vulnerability protection profile: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for vulnerability protection profile: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("vulnerability-protection-profile")
+@handle_command_errors("showing vulnerability protection profile")
 def show_vulnerability_protection_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the vulnerability protection profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the vulnerability protection profile"),
@@ -3211,125 +3094,120 @@ def show_vulnerability_protection_profile(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            # Get a specific vulnerability protection profile by name
-            kwargs = {location_type: location_value}
-            profile = scm_client.get_vulnerability_protection_profile(**kwargs, name=name)
+    if name:
+        # Get a specific vulnerability protection profile by name
+        kwargs = {location_type: location_value}
+        profile = scm_client.get_vulnerability_protection_profile(**kwargs, name=name)
 
-            typer.echo(f"\nVulnerability Protection Profile: {profile.get('name', 'N/A')}")
-            typer.echo("=" * 80)
+        typer.echo(f"\nVulnerability Protection Profile: {profile.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+
+        # Display container location (folder, snippet, or device)
+        if profile.get("folder"):
+            typer.echo(f"Location: Folder '{profile['folder']}'")
+        elif profile.get("snippet"):
+            typer.echo(f"Location: Snippet '{profile['snippet']}'")
+        elif profile.get("device"):
+            typer.echo(f"Location: Device '{profile['device']}'")
+
+        # Display description if present
+        if profile.get("description"):
+            typer.echo(f"Description: {profile['description']}")
+
+        # Display rules in detail
+        if profile.get("rules"):
+            typer.echo(f"\nRules ({len(profile['rules'])}):")
+            for idx, rule in enumerate(profile["rules"], 1):
+                typer.echo(f"  Rule {idx}: {rule.get('name', 'Unnamed')}")
+                if rule.get("severity"):
+                    severity = rule["severity"] if isinstance(rule["severity"], list) else [rule["severity"]]
+                    typer.echo(f"    Severity: {', '.join(severity)}")
+                typer.echo(f"    Action: {rule.get('action', 'N/A')}")
+                if rule.get("category"):
+                    typer.echo(f"    Category: {rule['category']}")
+                if rule.get("host"):
+                    typer.echo(f"    Host: {rule['host']}")
+                if rule.get("threat_name"):
+                    typer.echo(f"    Threat Name: {rule['threat_name']}")
+                if rule.get("packet_capture"):
+                    typer.echo(f"    Packet Capture: {rule['packet_capture']}")
+                if rule.get("cve"):
+                    typer.echo(f"    CVE: {', '.join(rule['cve'])}")
+                if rule.get("vendor_id") or rule.get("vendor-id"):
+                    vendor_ids = rule.get("vendor_id") or rule.get("vendor-id")
+                    typer.echo(f"    Vendor ID: {', '.join(vendor_ids)}")
+
+        # Display threat exceptions in detail
+        if profile.get("threat_exception"):
+            typer.echo(f"\nThreat Exceptions ({len(profile['threat_exception'])}):")
+            for idx, exception in enumerate(profile["threat_exception"], 1):
+                typer.echo(f"  Exception {idx}:")
+                if exception.get("name"):
+                    typer.echo(f"    Name: {exception['name']}")
+                if exception.get("packet_capture"):
+                    typer.echo(f"    Packet Capture: {exception['packet_capture']}")
+                if exception.get("action"):
+                    typer.echo(f"    Action: {exception['action']}")
+                if exception.get("exempt_ip"):
+                    ips = [ip.get("name", str(ip)) if isinstance(ip, dict) else str(ip) for ip in exception["exempt_ip"]]
+                    typer.echo(f"    Exempt IPs: {', '.join(ips)}")
+                if exception.get("notes"):
+                    typer.echo(f"    Notes: {exception['notes']}")
+                if exception.get("time_attribute"):
+                    ta = exception["time_attribute"]
+                    typer.echo(f"    Time Attribute: interval={ta.get('interval')}, threshold={ta.get('threshold')}, track_by={ta.get('track_by')}")
+
+        # Display ID if present
+        if profile.get("id"):
+            typer.echo(f"\nID: {profile['id']}")
+
+        return profile
+
+    else:
+        # Default behavior: list all
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_vulnerability_protection_profiles(**kwargs, exact_match=False)
+
+        if not profiles:
+            typer.echo(f"No vulnerability protection profiles found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nVulnerability Protection Profiles in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for profile in profiles:
+            # Display profile information
+            typer.echo(f"Name: {profile.get('name', 'N/A')}")
 
             # Display container location (folder, snippet, or device)
             if profile.get("folder"):
-                typer.echo(f"Location: Folder '{profile['folder']}'")
+                typer.echo(f"  Location: Folder '{profile['folder']}'")
             elif profile.get("snippet"):
-                typer.echo(f"Location: Snippet '{profile['snippet']}'")
+                typer.echo(f"  Location: Snippet '{profile['snippet']}'")
             elif profile.get("device"):
-                typer.echo(f"Location: Device '{profile['device']}'")
+                typer.echo(f"  Location: Device '{profile['device']}'")
 
             # Display description if present
             if profile.get("description"):
-                typer.echo(f"Description: {profile['description']}")
+                typer.echo(f"  Description: {profile['description']}")
 
-            # Display rules in detail
+            # Display rules if present
             if profile.get("rules"):
-                typer.echo(f"\nRules ({len(profile['rules'])}):")
-                for idx, rule in enumerate(profile["rules"], 1):
-                    typer.echo(f"  Rule {idx}: {rule.get('name', 'Unnamed')}")
-                    if rule.get("severity"):
-                        severity = rule["severity"] if isinstance(rule["severity"], list) else [rule["severity"]]
-                        typer.echo(f"    Severity: {', '.join(severity)}")
-                    typer.echo(f"    Action: {rule.get('action', 'N/A')}")
-                    if rule.get("category"):
-                        typer.echo(f"    Category: {rule['category']}")
-                    if rule.get("host"):
-                        typer.echo(f"    Host: {rule['host']}")
-                    if rule.get("threat_name"):
-                        typer.echo(f"    Threat Name: {rule['threat_name']}")
-                    if rule.get("packet_capture"):
-                        typer.echo(f"    Packet Capture: {rule['packet_capture']}")
-                    if rule.get("cve"):
-                        typer.echo(f"    CVE: {', '.join(rule['cve'])}")
-                    if rule.get("vendor_id") or rule.get("vendor-id"):
-                        vendor_ids = rule.get("vendor_id") or rule.get("vendor-id")
-                        typer.echo(f"    Vendor ID: {', '.join(vendor_ids)}")
+                typer.echo(f"  Rules: {len(profile['rules'])} configured")
+                for rule in profile["rules"]:
+                    typer.echo(f"    - {rule.get('name', 'Unnamed')}: {rule.get('action', 'N/A')}")
 
-            # Display threat exceptions in detail
+            # Display threat exceptions if present
             if profile.get("threat_exception"):
-                typer.echo(f"\nThreat Exceptions ({len(profile['threat_exception'])}):")
-                for idx, exception in enumerate(profile["threat_exception"], 1):
-                    typer.echo(f"  Exception {idx}:")
-                    if exception.get("name"):
-                        typer.echo(f"    Name: {exception['name']}")
-                    if exception.get("packet_capture"):
-                        typer.echo(f"    Packet Capture: {exception['packet_capture']}")
-                    if exception.get("action"):
-                        typer.echo(f"    Action: {exception['action']}")
-                    if exception.get("exempt_ip"):
-                        ips = [ip.get("name", str(ip)) if isinstance(ip, dict) else str(ip) for ip in exception["exempt_ip"]]
-                        typer.echo(f"    Exempt IPs: {', '.join(ips)}")
-                    if exception.get("notes"):
-                        typer.echo(f"    Notes: {exception['notes']}")
-                    if exception.get("time_attribute"):
-                        ta = exception["time_attribute"]
-                        typer.echo(f"    Time Attribute: interval={ta.get('interval')}, threshold={ta.get('threshold')}, track_by={ta.get('track_by')}")
+                typer.echo(f"  Threat Exceptions: {len(profile['threat_exception'])}")
 
             # Display ID if present
             if profile.get("id"):
-                typer.echo(f"\nID: {profile['id']}")
+                typer.echo(f"  ID: {profile['id']}")
 
-            return profile
+            typer.echo("-" * 80)
 
-        else:
-            # Default behavior: list all
-            kwargs = {location_type: location_value}
-            profiles = scm_client.list_vulnerability_protection_profiles(**kwargs, exact_match=False)
-
-            if not profiles:
-                typer.echo(f"No vulnerability protection profiles found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nVulnerability Protection Profiles in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for profile in profiles:
-                # Display profile information
-                typer.echo(f"Name: {profile.get('name', 'N/A')}")
-
-                # Display container location (folder, snippet, or device)
-                if profile.get("folder"):
-                    typer.echo(f"  Location: Folder '{profile['folder']}'")
-                elif profile.get("snippet"):
-                    typer.echo(f"  Location: Snippet '{profile['snippet']}'")
-                elif profile.get("device"):
-                    typer.echo(f"  Location: Device '{profile['device']}'")
-
-                # Display description if present
-                if profile.get("description"):
-                    typer.echo(f"  Description: {profile['description']}")
-
-                # Display rules if present
-                if profile.get("rules"):
-                    typer.echo(f"  Rules: {len(profile['rules'])} configured")
-                    for rule in profile["rules"]:
-                        typer.echo(f"    - {rule.get('name', 'Unnamed')}: {rule.get('action', 'N/A')}")
-
-                # Display threat exceptions if present
-                if profile.get("threat_exception"):
-                    typer.echo(f"  Threat Exceptions: {len(profile['threat_exception'])}")
-
-                # Display ID if present
-                if profile.get("id"):
-                    typer.echo(f"  ID: {profile['id']}")
-
-                typer.echo("-" * 80)
-
-            return profiles
-
-    except Exception as e:
-        typer.echo(f"Error showing vulnerability protection profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return profiles
 
 
 # =============================================================================================================================================================================================
@@ -3338,6 +3216,7 @@ def show_vulnerability_protection_profile(
 
 
 @backup_app.command("url-category")
+@handle_command_errors("backing up URL categories")
 def backup_url_category(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -3367,40 +3246,36 @@ def backup_url_category(
     if not file:
         file = get_default_backup_filename("url-categories", location_type, location_value)
 
-    try:
-        # List all URL categories with exact_match=True using kwargs pattern
-        kwargs = {location_type: location_value}
-        categories = scm_client.list_url_categories(**kwargs, exact_match=True)
+    # List all URL categories with exact_match=True using kwargs pattern
+    kwargs = {location_type: location_value}
+    categories = scm_client.list_url_categories(**kwargs, exact_match=True)
 
-        if not categories:
-            typer.echo(f"No URL categories found in {location_type} '{location_value}'")
-            return
+    if not categories:
+        typer.echo(f"No URL categories found in {location_type} '{location_value}'")
+        return
 
-        # Convert SDK models to dictionaries, excluding unset values
-        backup_data = []
-        for category in categories:
-            category_dict = category.copy()
-            # Remove system fields that shouldn't be in backup
-            category_dict.pop("id", None)
+    # Convert SDK models to dictionaries, excluding unset values
+    backup_data = []
+    for category in categories:
+        category_dict = category.copy()
+        # Remove system fields that shouldn't be in backup
+        category_dict.pop("id", None)
 
-            backup_data.append(category_dict)
+        backup_data.append(category_dict)
 
-        # Create the YAML structure
-        yaml_data = {"url_categories": backup_data}
+    # Create the YAML structure
+    yaml_data = {"url_categories": backup_data}
 
-        # Write to YAML file
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    # Write to YAML file
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} URL categories to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up URL categories: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} URL categories to {file}")
+    return file
 
 
 @delete_app.command("url-category")
+@handle_command_errors("deleting URL category")
 def delete_url_category(
     folder: str = typer.Option(None, "--folder", help="Folder containing the URL category"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the URL category"),
@@ -3429,23 +3304,20 @@ def delete_url_category(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_url_category(**kwargs, name=name)
-        if result:
-            typer.echo(f"Deleted URL category: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(
-                f"URL category not found: {name} in {location_type} {location_value}",
-                err=True,
-            )
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting URL category: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_url_category(**kwargs, name=name)
+    if result:
+        typer.echo(f"Deleted URL category: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(
+            f"URL category not found: {name} in {location_type} {location_value}",
+            err=True,
+        )
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("url-category", help="Load URL categories from a YAML file.")
+@handle_command_errors("loading URL categories")
 def load_url_category(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -3469,111 +3341,107 @@ def load_url_category(
         scm load security url-category --file config/url_categories.yml --dry-run
 
     """
-    try:
-        # Validate container override parameters
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+    # Validate container override parameters
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo(
+            "Error: Only one of --folder, --snippet, or --device can be specified",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    # Validate file exists
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
+
+    # Load YAML data using the same pattern as other commands
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
+
+    if not raw_data or "url_categories" not in raw_data:
+        typer.echo("No URL categories found in file", err=True)
+        raise typer.Exit(code=1)
+
+    categories = raw_data["url_categories"]
+    if not isinstance(categories, list):
+        categories = [categories]
+
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        # Show override information if applicable
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(categories))
+        return []
+
+    # Apply each URL category
+    results = []
+    created_count = 0
+    updated_count = 0
+
+    for category_data in categories:
+        try:
+            # Apply container override if specified
+            if folder:
+                category_data["folder"] = folder
+                category_data.pop("snippet", None)
+                category_data.pop("device", None)
+            elif snippet:
+                category_data["snippet"] = snippet
+                category_data.pop("folder", None)
+                category_data.pop("device", None)
+            elif device:
+                category_data["device"] = device
+                category_data.pop("folder", None)
+                category_data.pop("snippet", None)
+
+            # Validate using the Pydantic model
+            category = URLCategory(**category_data)
+
+            # Call the SDK client to create the URL category
+            sdk_data = category.to_sdk_model()
+
+            # Extract container params
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
+
+            result = scm_client.create_url_category(**container_kwargs, **sdk_data)
+
+            results.append(result)
+
+            # Track if created or updated based on response
+            if result.get("__action__") == "created":
+                created_count += 1
+            else:
+                updated_count += 1
+
+        except Exception as e:
             typer.echo(
-                "Error: Only one of --folder, --snippet, or --device can be specified",
+                f"Error processing URL category '{category_data.get('name', 'unknown')}': {str(e)}",
                 err=True,
             )
-            raise typer.Exit(code=1)
+            # Continue processing other categories
+            continue
 
-        # Validate file exists
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    # Display summary with counts
+    typer.echo(f"Successfully processed {len(results)} URL category(ies):")
+    if created_count > 0:
+        typer.echo(f"  - Created: {created_count}")
+    if updated_count > 0:
+        typer.echo(f"  - Updated: {updated_count}")
 
-        # Load YAML data using the same pattern as other commands
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
-
-        if not raw_data or "url_categories" not in raw_data:
-            typer.echo("No URL categories found in file", err=True)
-            raise typer.Exit(code=1)
-
-        categories = raw_data["url_categories"]
-        if not isinstance(categories, list):
-            categories = [categories]
-
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            # Show override information if applicable
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(categories))
-            return []
-
-        # Apply each URL category
-        results = []
-        created_count = 0
-        updated_count = 0
-
-        for category_data in categories:
-            try:
-                # Apply container override if specified
-                if folder:
-                    category_data["folder"] = folder
-                    category_data.pop("snippet", None)
-                    category_data.pop("device", None)
-                elif snippet:
-                    category_data["snippet"] = snippet
-                    category_data.pop("folder", None)
-                    category_data.pop("device", None)
-                elif device:
-                    category_data["device"] = device
-                    category_data.pop("folder", None)
-                    category_data.pop("snippet", None)
-
-                # Validate using the Pydantic model
-                category = URLCategory(**category_data)
-
-                # Call the SDK client to create the URL category
-                sdk_data = category.to_sdk_model()
-
-                # Extract container params
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
-
-                result = scm_client.create_url_category(**container_kwargs, **sdk_data)
-
-                results.append(result)
-
-                # Track if created or updated based on response
-                if result.get("__action__") == "created":
-                    created_count += 1
-                else:
-                    updated_count += 1
-
-            except Exception as e:
-                typer.echo(
-                    f"Error processing URL category '{category_data.get('name', 'unknown')}': {str(e)}",
-                    err=True,
-                )
-                # Continue processing other categories
-                continue
-
-        # Display summary with counts
-        typer.echo(f"Successfully processed {len(results)} URL category(ies):")
-        if created_count > 0:
-            typer.echo(f"  - Created: {created_count}")
-        if updated_count > 0:
-            typer.echo(f"  - Updated: {updated_count}")
-
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading URL categories: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    return results
 
 
 @set_app.command("url-category")
+@handle_command_errors("creating URL category")
 def set_url_category(
     folder: str = typer.Option(None, "--folder", help="Folder path for the URL category"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path for the URL category"),
@@ -3602,51 +3470,47 @@ def set_url_category(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        # Build category data
-        category_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-            "type": type,
-        }
+    # Build category data
+    category_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+        "type": type,
+    }
 
-        if description:
-            category_data["description"] = description
-        if urls:
-            category_data["list"] = urls
+    if description:
+        category_data["description"] = description
+    if urls:
+        category_data["list"] = urls
 
-        # Validate using Pydantic model
-        category = URLCategory(**category_data)
+    # Validate using Pydantic model
+    category = URLCategory(**category_data)
 
-        # Call SDK client
-        sdk_data = category.to_sdk_model()
+    # Call SDK client
+    sdk_data = category.to_sdk_model()
 
-        # Extract container params
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    # Extract container params
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_url_category(**container_kwargs, **sdk_data)
+    result = scm_client.create_url_category(**container_kwargs, **sdk_data)
 
-        # Format and display output
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created URL category: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated URL category: {result['name']} in {location_type} {location_value}")
-        else:
-            typer.echo(f"No changes to URL category: {result['name']} in {location_type} {location_value}")
-
-    except Exception as e:
-        typer.echo(f"Error creating URL category: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    # Format and display output
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created URL category: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated URL category: {result['name']} in {location_type} {location_value}")
+    else:
+        typer.echo(f"No changes to URL category: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("url-category")
+@handle_command_errors("showing URL category")
 def show_url_category(
     folder: str = typer.Option(None, "--folder", help="Folder containing the URL category"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the URL category"),
@@ -3669,89 +3533,84 @@ def show_url_category(
     # Validate location parameters
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            # Get a specific URL category by name
-            kwargs = {location_type: location_value}
-            category = scm_client.get_url_category(**kwargs, name=name)
+    if name:
+        # Get a specific URL category by name
+        kwargs = {location_type: location_value}
+        category = scm_client.get_url_category(**kwargs, name=name)
 
-            typer.echo(f"\nURL Category: {category.get('name', 'N/A')}")
-            typer.echo("=" * 80)
+        typer.echo(f"\nURL Category: {category.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+
+        # Display container location
+        if category.get("folder"):
+            typer.echo(f"Location: Folder '{category['folder']}'")
+        elif category.get("snippet"):
+            typer.echo(f"Location: Snippet '{category['snippet']}'")
+        elif category.get("device"):
+            typer.echo(f"Location: Device '{category['device']}'")
+
+        # Display description if present
+        if category.get("description"):
+            typer.echo(f"Description: {category['description']}")
+
+        # Display type
+        if category.get("type"):
+            typer.echo(f"Type: {category['type']}")
+
+        # Display URL list
+        if category.get("list"):
+            typer.echo(f"\nURLs ({len(category['list'])}):")
+            for url in category["list"]:
+                typer.echo(f"  - {url}")
+
+        # Display ID if present
+        if category.get("id"):
+            typer.echo(f"\nID: {category['id']}")
+
+        return category
+
+    else:
+        # Default behavior: list all
+        kwargs = {location_type: location_value}
+        categories = scm_client.list_url_categories(**kwargs, exact_match=False)
+
+        if not categories:
+            typer.echo(f"No URL categories found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nURL Categories in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for category in categories:
+            typer.echo(f"Name: {category.get('name', 'N/A')}")
 
             # Display container location
             if category.get("folder"):
-                typer.echo(f"Location: Folder '{category['folder']}'")
+                typer.echo(f"  Location: Folder '{category['folder']}'")
             elif category.get("snippet"):
-                typer.echo(f"Location: Snippet '{category['snippet']}'")
+                typer.echo(f"  Location: Snippet '{category['snippet']}'")
             elif category.get("device"):
-                typer.echo(f"Location: Device '{category['device']}'")
+                typer.echo(f"  Location: Device '{category['device']}'")
 
             # Display description if present
             if category.get("description"):
-                typer.echo(f"Description: {category['description']}")
+                typer.echo(f"  Description: {category['description']}")
 
             # Display type
             if category.get("type"):
-                typer.echo(f"Type: {category['type']}")
+                typer.echo(f"  Type: {category['type']}")
 
-            # Display URL list
+            # Display URL count
             if category.get("list"):
-                typer.echo(f"\nURLs ({len(category['list'])}):")
-                for url in category["list"]:
-                    typer.echo(f"  - {url}")
+                typer.echo(f"  URLs: {len(category['list'])} entries")
 
             # Display ID if present
             if category.get("id"):
-                typer.echo(f"\nID: {category['id']}")
+                typer.echo(f"  ID: {category['id']}")
 
-            return category
+            typer.echo("-" * 80)
 
-        else:
-            # Default behavior: list all
-            kwargs = {location_type: location_value}
-            categories = scm_client.list_url_categories(**kwargs, exact_match=False)
-
-            if not categories:
-                typer.echo(f"No URL categories found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nURL Categories in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for category in categories:
-                typer.echo(f"Name: {category.get('name', 'N/A')}")
-
-                # Display container location
-                if category.get("folder"):
-                    typer.echo(f"  Location: Folder '{category['folder']}'")
-                elif category.get("snippet"):
-                    typer.echo(f"  Location: Snippet '{category['snippet']}'")
-                elif category.get("device"):
-                    typer.echo(f"  Location: Device '{category['device']}'")
-
-                # Display description if present
-                if category.get("description"):
-                    typer.echo(f"  Description: {category['description']}")
-
-                # Display type
-                if category.get("type"):
-                    typer.echo(f"  Type: {category['type']}")
-
-                # Display URL count
-                if category.get("list"):
-                    typer.echo(f"  URLs: {len(category['list'])} entries")
-
-                # Display ID if present
-                if category.get("id"):
-                    typer.echo(f"  ID: {category['id']}")
-
-                typer.echo("-" * 80)
-
-            return categories
-
-    except Exception as e:
-        typer.echo(f"Error showing URL category: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return categories
 
 
 # =============================================================================================================================================================================================
@@ -3760,6 +3619,7 @@ def show_url_category(
 
 
 @backup_app.command("app-override-rule")
+@handle_command_errors("backing up app override rules")
 def backup_app_override_rule(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -3782,35 +3642,31 @@ def backup_app_override_rule(
     if not file:
         file = get_default_backup_filename("app-override-rules", location_type, location_value, rulebase)
 
-    try:
-        kwargs = {location_type: location_value}
-        rules = scm_client.list_app_override_rules(**kwargs, rulebase=rulebase, exact_match=True)
+    kwargs = {location_type: location_value}
+    rules = scm_client.list_app_override_rules(**kwargs, rulebase=rulebase, exact_match=True)
 
-        if not rules:
-            typer.echo(f"No app override rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
-            return
+    if not rules:
+        typer.echo(f"No app override rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
+        return
 
-        backup_data = []
-        for rule in rules:
-            rule_dict = rule.copy()
-            rule_dict.pop("id", None)
-            rule_dict["rulebase"] = rulebase
-            backup_data.append(rule_dict)
+    backup_data = []
+    for rule in rules:
+        rule_dict = rule.copy()
+        rule_dict.pop("id", None)
+        rule_dict["rulebase"] = rulebase
+        backup_data.append(rule_dict)
 
-        yaml_data = {"app_override_rules": backup_data}
+    yaml_data = {"app_override_rules": backup_data}
 
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} app override rules to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up app override rules: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} app override rules to {file}")
+    return file
 
 
 @delete_app.command("app-override-rule")
+@handle_command_errors("deleting app override rule")
 def delete_app_override_rule(
     folder: str = typer.Option(None, "--folder", help="Folder containing the rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the rule"),
@@ -3832,20 +3688,17 @@ def delete_app_override_rule(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_app_override_rule(**kwargs, name=name, rulebase=rulebase)
-        if result:
-            typer.echo(f"Deleted app override rule: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(f"App override rule not found: {name} in {location_type} {location_value}", err=True)
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting app override rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_app_override_rule(**kwargs, name=name, rulebase=rulebase)
+    if result:
+        typer.echo(f"Deleted app override rule: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(f"App override rule not found: {name} in {location_type} {location_value}", err=True)
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("app-override-rule", help="Load app override rules from a YAML file.")
+@handle_command_errors("loading app override rules")
 def load_app_override_rule(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -3861,78 +3714,74 @@ def load_app_override_rule(
         scm load security app-override-rule --file config/app_override_rules.yml --dry-run
 
     """
-    try:
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
-            typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
-            raise typer.Exit(code=1)
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
+        raise typer.Exit(code=1)
 
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
 
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
 
-        if not raw_data or "app_override_rules" not in raw_data:
-            typer.echo("No app override rules found in file", err=True)
-            raise typer.Exit(code=1)
+    if not raw_data or "app_override_rules" not in raw_data:
+        typer.echo("No app override rules found in file", err=True)
+        raise typer.Exit(code=1)
 
-        rules = raw_data["app_override_rules"]
-        if not isinstance(rules, list):
-            rules = [rules]
+    rules = raw_data["app_override_rules"]
+    if not isinstance(rules, list):
+        rules = [rules]
 
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(rules))
-            return []
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(rules))
+        return []
 
-        results = []
-        for rule_data in rules:
-            try:
-                if folder:
-                    rule_data["folder"] = folder
-                    rule_data.pop("snippet", None)
-                    rule_data.pop("device", None)
-                elif snippet:
-                    rule_data["snippet"] = snippet
-                    rule_data.pop("folder", None)
-                    rule_data.pop("device", None)
-                elif device:
-                    rule_data["device"] = device
-                    rule_data.pop("folder", None)
-                    rule_data.pop("snippet", None)
+    results = []
+    for rule_data in rules:
+        try:
+            if folder:
+                rule_data["folder"] = folder
+                rule_data.pop("snippet", None)
+                rule_data.pop("device", None)
+            elif snippet:
+                rule_data["snippet"] = snippet
+                rule_data.pop("folder", None)
+                rule_data.pop("device", None)
+            elif device:
+                rule_data["device"] = device
+                rule_data.pop("folder", None)
+                rule_data.pop("snippet", None)
 
-                rule = AppOverrideRule(**rule_data)
-                sdk_data = rule.to_sdk_model()
+            rule = AppOverrideRule(**rule_data)
+            sdk_data = rule.to_sdk_model()
 
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
 
-                result = scm_client.create_app_override_rule(**container_kwargs, **sdk_data)
-                results.append(result)
+            result = scm_client.create_app_override_rule(**container_kwargs, **sdk_data)
+            results.append(result)
 
-            except Exception as e:
-                typer.echo(f"Error processing app override rule '{rule_data.get('name', 'unknown')}': {str(e)}", err=True)
-                continue
+        except Exception as e:
+            typer.echo(f"Error processing app override rule '{rule_data.get('name', 'unknown')}': {str(e)}", err=True)
+            continue
 
-        typer.echo(f"Successfully processed {len(results)} app override rule(s)")
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading app override rules: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully processed {len(results)} app override rule(s)")
+    return results
 
 
 @set_app.command("app-override-rule")
+@handle_command_errors("creating app override rule")
 def set_app_override_rule(
     folder: str = typer.Option(None, "--folder", help="Folder path"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path"),
@@ -3957,53 +3806,49 @@ def set_app_override_rule(
     """
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        rule_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-            "application": application,
-            "port": port,
-            "protocol": protocol,
-            "rulebase": rulebase,
-        }
+    rule_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+        "application": application,
+        "port": port,
+        "protocol": protocol,
+        "rulebase": rulebase,
+    }
 
-        if description:
-            rule_data["description"] = description
-        if source_zones:
-            rule_data["from_zones"] = source_zones
-        if destination_zones:
-            rule_data["to_zones"] = destination_zones
-        if disabled:
-            rule_data["disabled"] = disabled
-        if tags:
-            rule_data["tag"] = tags
+    if description:
+        rule_data["description"] = description
+    if source_zones:
+        rule_data["from_zones"] = source_zones
+    if destination_zones:
+        rule_data["to_zones"] = destination_zones
+    if disabled:
+        rule_data["disabled"] = disabled
+    if tags:
+        rule_data["tag"] = tags
 
-        rule = AppOverrideRule(**rule_data)
-        sdk_data = rule.to_sdk_model()
+    rule = AppOverrideRule(**rule_data)
+    sdk_data = rule.to_sdk_model()
 
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_app_override_rule(**container_kwargs, **sdk_data)
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created app override rule: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated app override rule: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for app override rule: {result['name']} in {location_type} {location_value}")
-
-    except Exception as e:
-        typer.echo(f"Error creating app override rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.create_app_override_rule(**container_kwargs, **sdk_data)
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created app override rule: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated app override rule: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for app override rule: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("app-override-rule")
+@handle_command_errors("showing app override rule")
 def show_app_override_rule(
     folder: str = typer.Option(None, "--folder", help="Folder containing the rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the rule"),
@@ -4020,58 +3865,53 @@ def show_app_override_rule(
     """
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            kwargs = {location_type: location_value}
-            rule = scm_client.get_app_override_rule(**kwargs, name=name, rulebase=rulebase)
+    if name:
+        kwargs = {location_type: location_value}
+        rule = scm_client.get_app_override_rule(**kwargs, name=name, rulebase=rulebase)
 
-            typer.echo(f"\nApp Override Rule: {rule.get('name', 'N/A')}")
-            typer.echo("=" * 80)
-            if rule.get("folder"):
-                typer.echo(f"Location: Folder '{rule['folder']}'")
-            elif rule.get("snippet"):
-                typer.echo(f"Location: Snippet '{rule['snippet']}'")
-            elif rule.get("device"):
-                typer.echo(f"Location: Device '{rule['device']}'")
-            if rule.get("description"):
-                typer.echo(f"Description: {rule['description']}")
-            typer.echo(f"Application: {rule.get('application', 'N/A')}")
-            typer.echo(f"Port: {rule.get('port', 'N/A')}")
-            typer.echo(f"Protocol: {rule.get('protocol', 'N/A')}")
-            typer.echo(f"From: {rule.get('from', ['any'])}")
-            typer.echo(f"To: {rule.get('to', ['any'])}")
-            typer.echo(f"Source: {rule.get('source', ['any'])}")
-            typer.echo(f"Destination: {rule.get('destination', ['any'])}")
-            if rule.get("disabled"):
-                typer.echo("Status: Disabled")
+        typer.echo(f"\nApp Override Rule: {rule.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+        if rule.get("folder"):
+            typer.echo(f"Location: Folder '{rule['folder']}'")
+        elif rule.get("snippet"):
+            typer.echo(f"Location: Snippet '{rule['snippet']}'")
+        elif rule.get("device"):
+            typer.echo(f"Location: Device '{rule['device']}'")
+        if rule.get("description"):
+            typer.echo(f"Description: {rule['description']}")
+        typer.echo(f"Application: {rule.get('application', 'N/A')}")
+        typer.echo(f"Port: {rule.get('port', 'N/A')}")
+        typer.echo(f"Protocol: {rule.get('protocol', 'N/A')}")
+        typer.echo(f"From: {rule.get('from', ['any'])}")
+        typer.echo(f"To: {rule.get('to', ['any'])}")
+        typer.echo(f"Source: {rule.get('source', ['any'])}")
+        typer.echo(f"Destination: {rule.get('destination', ['any'])}")
+        if rule.get("disabled"):
+            typer.echo("Status: Disabled")
+        if rule.get("id"):
+            typer.echo(f"ID: {rule['id']}")
+
+    else:
+        kwargs = {location_type: location_value}
+        rules = scm_client.list_app_override_rules(**kwargs, rulebase=rulebase, exact_match=False)
+
+        if not rules:
+            typer.echo(f"No app override rules found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nApp Override Rules in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for rule in rules:
+            typer.echo(f"Name: {rule.get('name', 'N/A')}")
+            typer.echo(f"  Application: {rule.get('application', 'N/A')}")
+            typer.echo(f"  Port: {rule.get('port', 'N/A')}")
+            typer.echo(f"  Protocol: {rule.get('protocol', 'N/A')}")
             if rule.get("id"):
-                typer.echo(f"ID: {rule['id']}")
+                typer.echo(f"  ID: {rule['id']}")
+            typer.echo("-" * 80)
 
-        else:
-            kwargs = {location_type: location_value}
-            rules = scm_client.list_app_override_rules(**kwargs, rulebase=rulebase, exact_match=False)
-
-            if not rules:
-                typer.echo(f"No app override rules found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nApp Override Rules in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for rule in rules:
-                typer.echo(f"Name: {rule.get('name', 'N/A')}")
-                typer.echo(f"  Application: {rule.get('application', 'N/A')}")
-                typer.echo(f"  Port: {rule.get('port', 'N/A')}")
-                typer.echo(f"  Protocol: {rule.get('protocol', 'N/A')}")
-                if rule.get("id"):
-                    typer.echo(f"  ID: {rule['id']}")
-                typer.echo("-" * 80)
-
-            return rules
-
-    except Exception as e:
-        typer.echo(f"Error showing app override rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return rules
 
 
 # =============================================================================================================================================================================================
@@ -4080,6 +3920,7 @@ def show_app_override_rule(
 
 
 @backup_app.command("authentication-rule")
+@handle_command_errors("backing up authentication rules")
 def backup_authentication_rule(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -4098,35 +3939,31 @@ def backup_authentication_rule(
     if not file:
         file = get_default_backup_filename("authentication-rules", location_type, location_value, rulebase)
 
-    try:
-        kwargs = {location_type: location_value}
-        rules = scm_client.list_authentication_rules(**kwargs, rulebase=rulebase, exact_match=True)
+    kwargs = {location_type: location_value}
+    rules = scm_client.list_authentication_rules(**kwargs, rulebase=rulebase, exact_match=True)
 
-        if not rules:
-            typer.echo(f"No authentication rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
-            return
+    if not rules:
+        typer.echo(f"No authentication rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
+        return
 
-        backup_data = []
-        for rule in rules:
-            rule_dict = rule.copy()
-            rule_dict.pop("id", None)
-            rule_dict["rulebase"] = rulebase
-            backup_data.append(rule_dict)
+    backup_data = []
+    for rule in rules:
+        rule_dict = rule.copy()
+        rule_dict.pop("id", None)
+        rule_dict["rulebase"] = rulebase
+        backup_data.append(rule_dict)
 
-        yaml_data = {"authentication_rules": backup_data}
+    yaml_data = {"authentication_rules": backup_data}
 
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} authentication rules to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up authentication rules: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} authentication rules to {file}")
+    return file
 
 
 @delete_app.command("authentication-rule")
+@handle_command_errors("deleting authentication rule")
 def delete_authentication_rule(
     folder: str = typer.Option(None, "--folder", help="Folder containing the rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the rule"),
@@ -4148,20 +3985,17 @@ def delete_authentication_rule(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_authentication_rule(**kwargs, name=name, rulebase=rulebase)
-        if result:
-            typer.echo(f"Deleted authentication rule: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(f"Authentication rule not found: {name} in {location_type} {location_value}", err=True)
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting authentication rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_authentication_rule(**kwargs, name=name, rulebase=rulebase)
+    if result:
+        typer.echo(f"Deleted authentication rule: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(f"Authentication rule not found: {name} in {location_type} {location_value}", err=True)
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("authentication-rule", help="Load authentication rules from a YAML file.")
+@handle_command_errors("loading authentication rules")
 def load_authentication_rule(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -4176,78 +4010,74 @@ def load_authentication_rule(
         scm load security authentication-rule --file config/authentication_rules.yml --folder Production
 
     """
-    try:
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
-            typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
-            raise typer.Exit(code=1)
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
+        raise typer.Exit(code=1)
 
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
 
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
 
-        if not raw_data or "authentication_rules" not in raw_data:
-            typer.echo("No authentication rules found in file", err=True)
-            raise typer.Exit(code=1)
+    if not raw_data or "authentication_rules" not in raw_data:
+        typer.echo("No authentication rules found in file", err=True)
+        raise typer.Exit(code=1)
 
-        rules = raw_data["authentication_rules"]
-        if not isinstance(rules, list):
-            rules = [rules]
+    rules = raw_data["authentication_rules"]
+    if not isinstance(rules, list):
+        rules = [rules]
 
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(rules))
-            return []
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(rules))
+        return []
 
-        results = []
-        for rule_data in rules:
-            try:
-                if folder:
-                    rule_data["folder"] = folder
-                    rule_data.pop("snippet", None)
-                    rule_data.pop("device", None)
-                elif snippet:
-                    rule_data["snippet"] = snippet
-                    rule_data.pop("folder", None)
-                    rule_data.pop("device", None)
-                elif device:
-                    rule_data["device"] = device
-                    rule_data.pop("folder", None)
-                    rule_data.pop("snippet", None)
+    results = []
+    for rule_data in rules:
+        try:
+            if folder:
+                rule_data["folder"] = folder
+                rule_data.pop("snippet", None)
+                rule_data.pop("device", None)
+            elif snippet:
+                rule_data["snippet"] = snippet
+                rule_data.pop("folder", None)
+                rule_data.pop("device", None)
+            elif device:
+                rule_data["device"] = device
+                rule_data.pop("folder", None)
+                rule_data.pop("snippet", None)
 
-                rule = AuthenticationRule(**rule_data)
-                sdk_data = rule.to_sdk_model()
+            rule = AuthenticationRule(**rule_data)
+            sdk_data = rule.to_sdk_model()
 
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
 
-                result = scm_client.create_authentication_rule(**container_kwargs, **sdk_data)
-                results.append(result)
+            result = scm_client.create_authentication_rule(**container_kwargs, **sdk_data)
+            results.append(result)
 
-            except Exception as e:
-                typer.echo(f"Error processing authentication rule '{rule_data.get('name', 'unknown')}': {str(e)}", err=True)
-                continue
+        except Exception as e:
+            typer.echo(f"Error processing authentication rule '{rule_data.get('name', 'unknown')}': {str(e)}", err=True)
+            continue
 
-        typer.echo(f"Successfully processed {len(results)} authentication rule(s)")
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading authentication rules: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully processed {len(results)} authentication rule(s)")
+    return results
 
 
 @set_app.command("authentication-rule")
+@handle_command_errors("creating authentication rule")
 def set_authentication_rule(
     folder: str = typer.Option(None, "--folder", help="Folder path"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path"),
@@ -4272,56 +4102,52 @@ def set_authentication_rule(
     """
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        rule_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-            "rulebase": rulebase,
-        }
+    rule_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+        "rulebase": rulebase,
+    }
 
-        if description:
-            rule_data["description"] = description
-        if source_zones:
-            rule_data["from_zones"] = source_zones
-        if destination_zones:
-            rule_data["to_zones"] = destination_zones
-        if service:
-            rule_data["service"] = service
-        if category:
-            rule_data["category"] = category
-        if authentication_enforcement:
-            rule_data["authentication_enforcement"] = authentication_enforcement
-        if disabled:
-            rule_data["disabled"] = disabled
-        if tags:
-            rule_data["tag"] = tags
+    if description:
+        rule_data["description"] = description
+    if source_zones:
+        rule_data["from_zones"] = source_zones
+    if destination_zones:
+        rule_data["to_zones"] = destination_zones
+    if service:
+        rule_data["service"] = service
+    if category:
+        rule_data["category"] = category
+    if authentication_enforcement:
+        rule_data["authentication_enforcement"] = authentication_enforcement
+    if disabled:
+        rule_data["disabled"] = disabled
+    if tags:
+        rule_data["tag"] = tags
 
-        rule = AuthenticationRule(**rule_data)
-        sdk_data = rule.to_sdk_model()
+    rule = AuthenticationRule(**rule_data)
+    sdk_data = rule.to_sdk_model()
 
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_authentication_rule(**container_kwargs, **sdk_data)
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created authentication rule: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated authentication rule: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for authentication rule: {result['name']} in {location_type} {location_value}")
-
-    except Exception as e:
-        typer.echo(f"Error creating authentication rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.create_authentication_rule(**container_kwargs, **sdk_data)
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created authentication rule: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated authentication rule: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for authentication rule: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("authentication-rule")
+@handle_command_errors("showing authentication rule")
 def show_authentication_rule(
     folder: str = typer.Option(None, "--folder", help="Folder containing the rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the rule"),
@@ -4338,58 +4164,53 @@ def show_authentication_rule(
     """
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            kwargs = {location_type: location_value}
-            rule = scm_client.get_authentication_rule(**kwargs, name=name, rulebase=rulebase)
+    if name:
+        kwargs = {location_type: location_value}
+        rule = scm_client.get_authentication_rule(**kwargs, name=name, rulebase=rulebase)
 
-            typer.echo(f"\nAuthentication Rule: {rule.get('name', 'N/A')}")
-            typer.echo("=" * 80)
-            if rule.get("folder"):
-                typer.echo(f"Location: Folder '{rule['folder']}'")
-            elif rule.get("snippet"):
-                typer.echo(f"Location: Snippet '{rule['snippet']}'")
-            elif rule.get("device"):
-                typer.echo(f"Location: Device '{rule['device']}'")
-            if rule.get("description"):
-                typer.echo(f"Description: {rule['description']}")
-            typer.echo(f"From: {rule.get('from', ['any'])}")
-            typer.echo(f"To: {rule.get('to', ['any'])}")
-            typer.echo(f"Source: {rule.get('source', ['any'])}")
-            typer.echo(f"Destination: {rule.get('destination', ['any'])}")
-            typer.echo(f"Service: {rule.get('service', ['any'])}")
-            typer.echo(f"Category: {rule.get('category', ['any'])}")
+        typer.echo(f"\nAuthentication Rule: {rule.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+        if rule.get("folder"):
+            typer.echo(f"Location: Folder '{rule['folder']}'")
+        elif rule.get("snippet"):
+            typer.echo(f"Location: Snippet '{rule['snippet']}'")
+        elif rule.get("device"):
+            typer.echo(f"Location: Device '{rule['device']}'")
+        if rule.get("description"):
+            typer.echo(f"Description: {rule['description']}")
+        typer.echo(f"From: {rule.get('from', ['any'])}")
+        typer.echo(f"To: {rule.get('to', ['any'])}")
+        typer.echo(f"Source: {rule.get('source', ['any'])}")
+        typer.echo(f"Destination: {rule.get('destination', ['any'])}")
+        typer.echo(f"Service: {rule.get('service', ['any'])}")
+        typer.echo(f"Category: {rule.get('category', ['any'])}")
+        if rule.get("authentication_enforcement"):
+            typer.echo(f"Authentication Enforcement: {rule['authentication_enforcement']}")
+        if rule.get("disabled"):
+            typer.echo("Status: Disabled")
+        if rule.get("id"):
+            typer.echo(f"ID: {rule['id']}")
+
+    else:
+        kwargs = {location_type: location_value}
+        rules = scm_client.list_authentication_rules(**kwargs, rulebase=rulebase, exact_match=False)
+
+        if not rules:
+            typer.echo(f"No authentication rules found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nAuthentication Rules in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for rule in rules:
+            typer.echo(f"Name: {rule.get('name', 'N/A')}")
             if rule.get("authentication_enforcement"):
-                typer.echo(f"Authentication Enforcement: {rule['authentication_enforcement']}")
-            if rule.get("disabled"):
-                typer.echo("Status: Disabled")
+                typer.echo(f"  Auth Enforcement: {rule['authentication_enforcement']}")
             if rule.get("id"):
-                typer.echo(f"ID: {rule['id']}")
+                typer.echo(f"  ID: {rule['id']}")
+            typer.echo("-" * 80)
 
-        else:
-            kwargs = {location_type: location_value}
-            rules = scm_client.list_authentication_rules(**kwargs, rulebase=rulebase, exact_match=False)
-
-            if not rules:
-                typer.echo(f"No authentication rules found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nAuthentication Rules in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for rule in rules:
-                typer.echo(f"Name: {rule.get('name', 'N/A')}")
-                if rule.get("authentication_enforcement"):
-                    typer.echo(f"  Auth Enforcement: {rule['authentication_enforcement']}")
-                if rule.get("id"):
-                    typer.echo(f"  ID: {rule['id']}")
-                typer.echo("-" * 80)
-
-            return rules
-
-    except Exception as e:
-        typer.echo(f"Error showing authentication rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return rules
 
 
 # =============================================================================================================================================================================================
@@ -4398,6 +4219,7 @@ def show_authentication_rule(
 
 
 @backup_app.command("decryption-rule")
+@handle_command_errors("backing up decryption rules")
 def backup_decryption_rule(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -4416,35 +4238,31 @@ def backup_decryption_rule(
     if not file:
         file = get_default_backup_filename("decryption-rules", location_type, location_value, rulebase)
 
-    try:
-        kwargs = {location_type: location_value}
-        rules = scm_client.list_decryption_rules(**kwargs, rulebase=rulebase, exact_match=True)
+    kwargs = {location_type: location_value}
+    rules = scm_client.list_decryption_rules(**kwargs, rulebase=rulebase, exact_match=True)
 
-        if not rules:
-            typer.echo(f"No decryption rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
-            return
+    if not rules:
+        typer.echo(f"No decryption rules found in {location_type} '{location_value}' rulebase '{rulebase}'")
+        return
 
-        backup_data = []
-        for rule in rules:
-            rule_dict = rule.copy()
-            rule_dict.pop("id", None)
-            rule_dict["rulebase"] = rulebase
-            backup_data.append(rule_dict)
+    backup_data = []
+    for rule in rules:
+        rule_dict = rule.copy()
+        rule_dict.pop("id", None)
+        rule_dict["rulebase"] = rulebase
+        backup_data.append(rule_dict)
 
-        yaml_data = {"decryption_rules": backup_data}
+    yaml_data = {"decryption_rules": backup_data}
 
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} decryption rules to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up decryption rules: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} decryption rules to {file}")
+    return file
 
 
 @delete_app.command("decryption-rule")
+@handle_command_errors("deleting decryption rule")
 def delete_decryption_rule(
     folder: str = typer.Option(None, "--folder", help="Folder containing the rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the rule"),
@@ -4466,20 +4284,17 @@ def delete_decryption_rule(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_decryption_rule(**kwargs, name=name, rulebase=rulebase)
-        if result:
-            typer.echo(f"Deleted decryption rule: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(f"Decryption rule not found: {name} in {location_type} {location_value}", err=True)
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting decryption rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_decryption_rule(**kwargs, name=name, rulebase=rulebase)
+    if result:
+        typer.echo(f"Deleted decryption rule: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(f"Decryption rule not found: {name} in {location_type} {location_value}", err=True)
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("decryption-rule", help="Load decryption rules from a YAML file.")
+@handle_command_errors("loading decryption rules")
 def load_decryption_rule(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -4494,78 +4309,74 @@ def load_decryption_rule(
         scm load security decryption-rule --file config/decryption_rules.yml --folder Production
 
     """
-    try:
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
-            typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
-            raise typer.Exit(code=1)
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
+        raise typer.Exit(code=1)
 
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
 
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
 
-        if not raw_data or "decryption_rules" not in raw_data:
-            typer.echo("No decryption rules found in file", err=True)
-            raise typer.Exit(code=1)
+    if not raw_data or "decryption_rules" not in raw_data:
+        typer.echo("No decryption rules found in file", err=True)
+        raise typer.Exit(code=1)
 
-        rules = raw_data["decryption_rules"]
-        if not isinstance(rules, list):
-            rules = [rules]
+    rules = raw_data["decryption_rules"]
+    if not isinstance(rules, list):
+        rules = [rules]
 
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(rules))
-            return []
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(rules))
+        return []
 
-        results = []
-        for rule_data in rules:
-            try:
-                if folder:
-                    rule_data["folder"] = folder
-                    rule_data.pop("snippet", None)
-                    rule_data.pop("device", None)
-                elif snippet:
-                    rule_data["snippet"] = snippet
-                    rule_data.pop("folder", None)
-                    rule_data.pop("device", None)
-                elif device:
-                    rule_data["device"] = device
-                    rule_data.pop("folder", None)
-                    rule_data.pop("snippet", None)
+    results = []
+    for rule_data in rules:
+        try:
+            if folder:
+                rule_data["folder"] = folder
+                rule_data.pop("snippet", None)
+                rule_data.pop("device", None)
+            elif snippet:
+                rule_data["snippet"] = snippet
+                rule_data.pop("folder", None)
+                rule_data.pop("device", None)
+            elif device:
+                rule_data["device"] = device
+                rule_data.pop("folder", None)
+                rule_data.pop("snippet", None)
 
-                rule = DecryptionRule(**rule_data)
-                sdk_data = rule.to_sdk_model()
+            rule = DecryptionRule(**rule_data)
+            sdk_data = rule.to_sdk_model()
 
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
 
-                result = scm_client.create_decryption_rule(**container_kwargs, **sdk_data)
-                results.append(result)
+            result = scm_client.create_decryption_rule(**container_kwargs, **sdk_data)
+            results.append(result)
 
-            except Exception as e:
-                typer.echo(f"Error processing decryption rule '{rule_data.get('name', 'unknown')}': {str(e)}", err=True)
-                continue
+        except Exception as e:
+            typer.echo(f"Error processing decryption rule '{rule_data.get('name', 'unknown')}': {str(e)}", err=True)
+            continue
 
-        typer.echo(f"Successfully processed {len(results)} decryption rule(s)")
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading decryption rules: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully processed {len(results)} decryption rule(s)")
+    return results
 
 
 @set_app.command("decryption-rule")
+@handle_command_errors("creating decryption rule")
 def set_decryption_rule(
     folder: str = typer.Option(None, "--folder", help="Folder path"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path"),
@@ -4593,58 +4404,51 @@ def set_decryption_rule(
     """
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        rule_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-            "action": action,
-            "rulebase": rulebase,
-        }
+    rule_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+        "action": action,
+        "rulebase": rulebase,
+    }
 
-        if description:
-            rule_data["description"] = description
-        if source_zones:
-            rule_data["from_zones"] = source_zones
-        if destination_zones:
-            rule_data["to_zones"] = destination_zones
-        if profile:
-            rule_data["profile"] = profile
-        if type_json:
-            rule_data["type"] = json.loads(type_json)
-        if disabled:
-            rule_data["disabled"] = disabled
-        if tags:
-            rule_data["tag"] = tags
+    if description:
+        rule_data["description"] = description
+    if source_zones:
+        rule_data["from_zones"] = source_zones
+    if destination_zones:
+        rule_data["to_zones"] = destination_zones
+    if profile:
+        rule_data["profile"] = profile
+    if type_json:
+        rule_data["type"] = json.loads(type_json)
+    if disabled:
+        rule_data["disabled"] = disabled
+    if tags:
+        rule_data["tag"] = tags
 
-        rule = DecryptionRule(**rule_data)
-        sdk_data = rule.to_sdk_model()
+    rule = DecryptionRule(**rule_data)
+    sdk_data = rule.to_sdk_model()
 
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_decryption_rule(**container_kwargs, **sdk_data)
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created decryption rule: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated decryption rule: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for decryption rule: {result['name']} in {location_type} {location_value}")
-
-    except json.JSONDecodeError as e:
-        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        typer.echo(f"Error creating decryption rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.create_decryption_rule(**container_kwargs, **sdk_data)
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created decryption rule: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated decryption rule: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for decryption rule: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("decryption-rule")
+@handle_command_errors("showing decryption rule")
 def show_decryption_rule(
     folder: str = typer.Option(None, "--folder", help="Folder containing the rule"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the rule"),
@@ -4661,58 +4465,53 @@ def show_decryption_rule(
     """
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            kwargs = {location_type: location_value}
-            rule = scm_client.get_decryption_rule(**kwargs, name=name, rulebase=rulebase)
+    if name:
+        kwargs = {location_type: location_value}
+        rule = scm_client.get_decryption_rule(**kwargs, name=name, rulebase=rulebase)
 
-            typer.echo(f"\nDecryption Rule: {rule.get('name', 'N/A')}")
-            typer.echo("=" * 80)
-            if rule.get("folder"):
-                typer.echo(f"Location: Folder '{rule['folder']}'")
-            elif rule.get("snippet"):
-                typer.echo(f"Location: Snippet '{rule['snippet']}'")
-            elif rule.get("device"):
-                typer.echo(f"Location: Device '{rule['device']}'")
-            if rule.get("description"):
-                typer.echo(f"Description: {rule['description']}")
-            typer.echo(f"Action: {rule.get('action', 'N/A')}")
-            typer.echo(f"From: {rule.get('from', ['any'])}")
-            typer.echo(f"To: {rule.get('to', ['any'])}")
-            typer.echo(f"Source: {rule.get('source', ['any'])}")
-            typer.echo(f"Destination: {rule.get('destination', ['any'])}")
-            if rule.get("profile"):
-                typer.echo(f"Profile: {rule['profile']}")
-            if rule.get("type"):
-                typer.echo(f"Type: {rule['type']}")
-            if rule.get("disabled"):
-                typer.echo("Status: Disabled")
+        typer.echo(f"\nDecryption Rule: {rule.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+        if rule.get("folder"):
+            typer.echo(f"Location: Folder '{rule['folder']}'")
+        elif rule.get("snippet"):
+            typer.echo(f"Location: Snippet '{rule['snippet']}'")
+        elif rule.get("device"):
+            typer.echo(f"Location: Device '{rule['device']}'")
+        if rule.get("description"):
+            typer.echo(f"Description: {rule['description']}")
+        typer.echo(f"Action: {rule.get('action', 'N/A')}")
+        typer.echo(f"From: {rule.get('from', ['any'])}")
+        typer.echo(f"To: {rule.get('to', ['any'])}")
+        typer.echo(f"Source: {rule.get('source', ['any'])}")
+        typer.echo(f"Destination: {rule.get('destination', ['any'])}")
+        if rule.get("profile"):
+            typer.echo(f"Profile: {rule['profile']}")
+        if rule.get("type"):
+            typer.echo(f"Type: {rule['type']}")
+        if rule.get("disabled"):
+            typer.echo("Status: Disabled")
+        if rule.get("id"):
+            typer.echo(f"ID: {rule['id']}")
+
+    else:
+        kwargs = {location_type: location_value}
+        rules = scm_client.list_decryption_rules(**kwargs, rulebase=rulebase, exact_match=False)
+
+        if not rules:
+            typer.echo(f"No decryption rules found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nDecryption Rules in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for rule in rules:
+            typer.echo(f"Name: {rule.get('name', 'N/A')}")
+            typer.echo(f"  Action: {rule.get('action', 'N/A')}")
             if rule.get("id"):
-                typer.echo(f"ID: {rule['id']}")
+                typer.echo(f"  ID: {rule['id']}")
+            typer.echo("-" * 80)
 
-        else:
-            kwargs = {location_type: location_value}
-            rules = scm_client.list_decryption_rules(**kwargs, rulebase=rulebase, exact_match=False)
-
-            if not rules:
-                typer.echo(f"No decryption rules found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nDecryption Rules in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for rule in rules:
-                typer.echo(f"Name: {rule.get('name', 'N/A')}")
-                typer.echo(f"  Action: {rule.get('action', 'N/A')}")
-                if rule.get("id"):
-                    typer.echo(f"  ID: {rule['id']}")
-                typer.echo("-" * 80)
-
-            return rules
-
-    except Exception as e:
-        typer.echo(f"Error showing decryption rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return rules
 
 
 # =============================================================================================================================================================================================
@@ -4721,6 +4520,7 @@ def show_decryption_rule(
 
 
 @backup_app.command("url-access-profile")
+@handle_command_errors("backing up URL access profiles")
 def backup_url_access_profile(
     folder: str = BACKUP_FOLDER_OPTION,
     snippet: str = BACKUP_SNIPPET_OPTION,
@@ -4738,34 +4538,30 @@ def backup_url_access_profile(
     if not file:
         file = get_default_backup_filename("url-access-profiles", location_type, location_value)
 
-    try:
-        kwargs = {location_type: location_value}
-        profiles = scm_client.list_url_access_profiles(**kwargs, exact_match=True)
+    kwargs = {location_type: location_value}
+    profiles = scm_client.list_url_access_profiles(**kwargs, exact_match=True)
 
-        if not profiles:
-            typer.echo(f"No URL access profiles found in {location_type} '{location_value}'")
-            return
+    if not profiles:
+        typer.echo(f"No URL access profiles found in {location_type} '{location_value}'")
+        return
 
-        backup_data = []
-        for profile in profiles:
-            profile_dict = profile.copy()
-            profile_dict.pop("id", None)
-            backup_data.append(profile_dict)
+    backup_data = []
+    for profile in profiles:
+        profile_dict = profile.copy()
+        profile_dict.pop("id", None)
+        backup_data.append(profile_dict)
 
-        yaml_data = {"url_access_profiles": backup_data}
+    yaml_data = {"url_access_profiles": backup_data}
 
-        with open(file, "w") as f:
-            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+    with open(file, "w") as f:
+        yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
 
-        typer.echo(f"Successfully backed up {len(backup_data)} URL access profiles to {file}")
-        return file
-
-    except Exception as e:
-        typer.echo(f"Error backing up URL access profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully backed up {len(backup_data)} URL access profiles to {file}")
+    return file
 
 
 @delete_app.command("url-access-profile")
+@handle_command_errors("deleting URL access profile")
 def delete_url_access_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the profile"),
@@ -4786,20 +4582,17 @@ def delete_url_access_profile(
         if not confirm:
             raise typer.Abort()
 
-    try:
-        kwargs = {location_type: location_value}
-        result = scm_client.delete_url_access_profile(**kwargs, name=name)
-        if result:
-            typer.echo(f"Deleted URL access profile: {name} from {location_type} {location_value}")
-        else:
-            typer.echo(f"URL access profile not found: {name} in {location_type} {location_value}", err=True)
-            raise typer.Exit(code=1) from Exception
-    except Exception as e:
-        typer.echo(f"Error deleting URL access profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    result = scm_client.delete_url_access_profile(**kwargs, name=name)
+    if result:
+        typer.echo(f"Deleted URL access profile: {name} from {location_type} {location_value}")
+    else:
+        typer.echo(f"URL access profile not found: {name} in {location_type} {location_value}", err=True)
+        raise typer.Exit(code=1) from Exception
 
 
 @load_app.command("url-access-profile", help="Load URL access profiles from a YAML file.")
+@handle_command_errors("loading URL access profiles")
 def load_url_access_profile(
     file: Path = FILE_OPTION,
     dry_run: bool = DRY_RUN_OPTION,
@@ -4814,78 +4607,74 @@ def load_url_access_profile(
         scm load security url-access-profile --file config/url_access_profiles.yml --folder Production
 
     """
-    try:
-        if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
-            typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
-            raise typer.Exit(code=1)
+    if sum(1 for x in [folder, snippet, device] if x is not None) > 1:
+        typer.echo("Error: Only one of --folder, --snippet, or --device can be specified", err=True)
+        raise typer.Exit(code=1)
 
-        if not file.exists():
-            typer.echo(f"File not found: {file}", err=True)
-            raise typer.Exit(code=1)
+    if not file.exists():
+        typer.echo(f"File not found: {file}", err=True)
+        raise typer.Exit(code=1)
 
-        with open(file) as f:
-            raw_data = yaml.safe_load(f)
+    with open(file) as f:
+        raw_data = yaml.safe_load(f)
 
-        if not raw_data or "url_access_profiles" not in raw_data:
-            typer.echo("No URL access profiles found in file", err=True)
-            raise typer.Exit(code=1)
+    if not raw_data or "url_access_profiles" not in raw_data:
+        typer.echo("No URL access profiles found in file", err=True)
+        raise typer.Exit(code=1)
 
-        profiles = raw_data["url_access_profiles"]
-        if not isinstance(profiles, list):
-            profiles = [profiles]
+    profiles = raw_data["url_access_profiles"]
+    if not isinstance(profiles, list):
+        profiles = [profiles]
 
-        if dry_run:
-            typer.echo("Dry run mode: would apply the following configurations:")
-            if folder or snippet or device:
-                override_type = "folder" if folder else ("snippet" if snippet else "device")
-                override_value = folder or snippet or device
-                typer.echo(f"Container override: {override_type} = '{override_value}'")
-            typer.echo(yaml.dump(profiles))
-            return []
+    if dry_run:
+        typer.echo("Dry run mode: would apply the following configurations:")
+        if folder or snippet or device:
+            override_type = "folder" if folder else ("snippet" if snippet else "device")
+            override_value = folder or snippet or device
+            typer.echo(f"Container override: {override_type} = '{override_value}'")
+        typer.echo(yaml.dump(profiles))
+        return []
 
-        results = []
-        for profile_data in profiles:
-            try:
-                if folder:
-                    profile_data["folder"] = folder
-                    profile_data.pop("snippet", None)
-                    profile_data.pop("device", None)
-                elif snippet:
-                    profile_data["snippet"] = snippet
-                    profile_data.pop("folder", None)
-                    profile_data.pop("device", None)
-                elif device:
-                    profile_data["device"] = device
-                    profile_data.pop("folder", None)
-                    profile_data.pop("snippet", None)
+    results = []
+    for profile_data in profiles:
+        try:
+            if folder:
+                profile_data["folder"] = folder
+                profile_data.pop("snippet", None)
+                profile_data.pop("device", None)
+            elif snippet:
+                profile_data["snippet"] = snippet
+                profile_data.pop("folder", None)
+                profile_data.pop("device", None)
+            elif device:
+                profile_data["device"] = device
+                profile_data.pop("folder", None)
+                profile_data.pop("snippet", None)
 
-                profile = URLAccessProfile(**profile_data)
-                sdk_data = profile.to_sdk_model()
+            profile = URLAccessProfile(**profile_data)
+            sdk_data = profile.to_sdk_model()
 
-                container_kwargs = {}
-                if sdk_data.get("folder"):
-                    container_kwargs["folder"] = sdk_data.pop("folder")
-                elif sdk_data.get("snippet"):
-                    container_kwargs["snippet"] = sdk_data.pop("snippet")
-                elif sdk_data.get("device"):
-                    container_kwargs["device"] = sdk_data.pop("device")
+            container_kwargs = {}
+            if sdk_data.get("folder"):
+                container_kwargs["folder"] = sdk_data.pop("folder")
+            elif sdk_data.get("snippet"):
+                container_kwargs["snippet"] = sdk_data.pop("snippet")
+            elif sdk_data.get("device"):
+                container_kwargs["device"] = sdk_data.pop("device")
 
-                result = scm_client.create_url_access_profile(**container_kwargs, **sdk_data)
-                results.append(result)
+            result = scm_client.create_url_access_profile(**container_kwargs, **sdk_data)
+            results.append(result)
 
-            except Exception as e:
-                typer.echo(f"Error processing URL access profile '{profile_data.get('name', 'unknown')}': {str(e)}", err=True)
-                continue
+        except Exception as e:
+            typer.echo(f"Error processing URL access profile '{profile_data.get('name', 'unknown')}': {str(e)}", err=True)
+            continue
 
-        typer.echo(f"Successfully processed {len(results)} URL access profile(s)")
-        return results
-
-    except Exception as e:
-        typer.echo(f"Error loading URL access profiles: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    typer.echo(f"Successfully processed {len(results)} URL access profile(s)")
+    return results
 
 
 @set_app.command("url-access-profile")
+@handle_command_errors("creating URL access profile")
 def set_url_access_profile(
     folder: str = typer.Option(None, "--folder", help="Folder path"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet path"),
@@ -4908,56 +4697,49 @@ def set_url_access_profile(
     """
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        profile_data: dict[str, Any] = {
-            location_type: location_value,
-            "name": name,
-        }
+    profile_data: dict[str, Any] = {
+        location_type: location_value,
+        "name": name,
+    }
 
-        if description:
-            profile_data["description"] = description
-        if block:
-            profile_data["block"] = block
-        if alert:
-            profile_data["alert"] = alert
-        if allow:
-            profile_data["allow"] = allow
-        if credential_enforcement_json:
-            profile_data["credential_enforcement"] = json.loads(credential_enforcement_json)
-        if cloud_inline_cat:
-            profile_data["cloud_inline_cat"] = cloud_inline_cat
-        if safe_search_enforcement:
-            profile_data["safe_search_enforcement"] = safe_search_enforcement
+    if description:
+        profile_data["description"] = description
+    if block:
+        profile_data["block"] = block
+    if alert:
+        profile_data["alert"] = alert
+    if allow:
+        profile_data["allow"] = allow
+    if credential_enforcement_json:
+        profile_data["credential_enforcement"] = json.loads(credential_enforcement_json)
+    if cloud_inline_cat:
+        profile_data["cloud_inline_cat"] = cloud_inline_cat
+    if safe_search_enforcement:
+        profile_data["safe_search_enforcement"] = safe_search_enforcement
 
-        profile = URLAccessProfile(**profile_data)
-        sdk_data = profile.to_sdk_model()
+    profile = URLAccessProfile(**profile_data)
+    sdk_data = profile.to_sdk_model()
 
-        container_kwargs = {}
-        if sdk_data.get("folder"):
-            container_kwargs["folder"] = sdk_data.pop("folder")
-        elif sdk_data.get("snippet"):
-            container_kwargs["snippet"] = sdk_data.pop("snippet")
-        elif sdk_data.get("device"):
-            container_kwargs["device"] = sdk_data.pop("device")
+    container_kwargs = {}
+    if sdk_data.get("folder"):
+        container_kwargs["folder"] = sdk_data.pop("folder")
+    elif sdk_data.get("snippet"):
+        container_kwargs["snippet"] = sdk_data.pop("snippet")
+    elif sdk_data.get("device"):
+        container_kwargs["device"] = sdk_data.pop("device")
 
-        result = scm_client.create_url_access_profile(**container_kwargs, **sdk_data)
-        action = result.get("__action__", "created")
-        if action == "created":
-            typer.echo(f"Created URL access profile: {result['name']} in {location_type} {location_value}")
-        elif action == "updated":
-            typer.echo(f"Updated URL access profile: {result['name']} in {location_type} {location_value}")
-        elif action == "no_change":
-            typer.echo(f"No changes needed for URL access profile: {result['name']} in {location_type} {location_value}")
-
-    except json.JSONDecodeError as e:
-        typer.echo(f"Error parsing JSON: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
-    except Exception as e:
-        typer.echo(f"Error creating URL access profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    result = scm_client.create_url_access_profile(**container_kwargs, **sdk_data)
+    action = result.get("__action__", "created")
+    if action == "created":
+        typer.echo(f"Created URL access profile: {result['name']} in {location_type} {location_value}")
+    elif action == "updated":
+        typer.echo(f"Updated URL access profile: {result['name']} in {location_type} {location_value}")
+    elif action == "no_change":
+        typer.echo(f"No changes needed for URL access profile: {result['name']} in {location_type} {location_value}")
 
 
 @show_app.command("url-access-profile")
+@handle_command_errors("showing URL access profile")
 def show_url_access_profile(
     folder: str = typer.Option(None, "--folder", help="Folder containing the profile"),
     snippet: str = typer.Option(None, "--snippet", help="Snippet containing the profile"),
@@ -4973,68 +4755,63 @@ def show_url_access_profile(
     """
     location_type, location_value = validate_location_params(folder, snippet, device)
 
-    try:
-        if name:
-            kwargs = {location_type: location_value}
-            profile = scm_client.get_url_access_profile(**kwargs, name=name)
+    if name:
+        kwargs = {location_type: location_value}
+        profile = scm_client.get_url_access_profile(**kwargs, name=name)
 
-            typer.echo(f"\nURL Access Profile: {profile.get('name', 'N/A')}")
-            typer.echo("=" * 80)
-            if profile.get("folder"):
-                typer.echo(f"Location: Folder '{profile['folder']}'")
-            elif profile.get("snippet"):
-                typer.echo(f"Location: Snippet '{profile['snippet']}'")
-            elif profile.get("device"):
-                typer.echo(f"Location: Device '{profile['device']}'")
+        typer.echo(f"\nURL Access Profile: {profile.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+        if profile.get("folder"):
+            typer.echo(f"Location: Folder '{profile['folder']}'")
+        elif profile.get("snippet"):
+            typer.echo(f"Location: Snippet '{profile['snippet']}'")
+        elif profile.get("device"):
+            typer.echo(f"Location: Device '{profile['device']}'")
+        if profile.get("description"):
+            typer.echo(f"Description: {profile['description']}")
+        if profile.get("block"):
+            typer.echo(f"Block: {profile['block']}")
+        if profile.get("alert"):
+            typer.echo(f"Alert: {profile['alert']}")
+        if profile.get("allow"):
+            typer.echo(f"Allow: {profile['allow']}")
+        if profile.get("continue"):
+            typer.echo(f"Continue: {profile['continue']}")
+        if profile.get("redirect"):
+            typer.echo(f"Redirect: {profile['redirect']}")
+        if profile.get("credential_enforcement"):
+            typer.echo(f"Credential Enforcement: {profile['credential_enforcement']}")
+        if profile.get("cloud_inline_cat") is not None:
+            typer.echo(f"Cloud Inline Cat: {'Enabled' if profile['cloud_inline_cat'] else 'Disabled'}")
+        if profile.get("safe_search_enforcement") is not None:
+            typer.echo(f"Safe Search: {'Enabled' if profile['safe_search_enforcement'] else 'Disabled'}")
+        if profile.get("id"):
+            typer.echo(f"ID: {profile['id']}")
+
+    else:
+        kwargs = {location_type: location_value}
+        profiles = scm_client.list_url_access_profiles(**kwargs, exact_match=False)
+
+        if not profiles:
+            typer.echo(f"No URL access profiles found in {location_type} '{location_value}'")
+            return
+
+        typer.echo(f"\nURL Access Profiles in {location_type} '{location_value}':")
+        typer.echo("=" * 80)
+
+        for profile in profiles:
+            typer.echo(f"Name: {profile.get('name', 'N/A')}")
             if profile.get("description"):
-                typer.echo(f"Description: {profile['description']}")
+                typer.echo(f"  Description: {profile['description']}")
             if profile.get("block"):
-                typer.echo(f"Block: {profile['block']}")
+                typer.echo(f"  Block: {len(profile['block'])} categories")
             if profile.get("alert"):
-                typer.echo(f"Alert: {profile['alert']}")
-            if profile.get("allow"):
-                typer.echo(f"Allow: {profile['allow']}")
-            if profile.get("continue"):
-                typer.echo(f"Continue: {profile['continue']}")
-            if profile.get("redirect"):
-                typer.echo(f"Redirect: {profile['redirect']}")
-            if profile.get("credential_enforcement"):
-                typer.echo(f"Credential Enforcement: {profile['credential_enforcement']}")
-            if profile.get("cloud_inline_cat") is not None:
-                typer.echo(f"Cloud Inline Cat: {'Enabled' if profile['cloud_inline_cat'] else 'Disabled'}")
-            if profile.get("safe_search_enforcement") is not None:
-                typer.echo(f"Safe Search: {'Enabled' if profile['safe_search_enforcement'] else 'Disabled'}")
+                typer.echo(f"  Alert: {len(profile['alert'])} categories")
             if profile.get("id"):
-                typer.echo(f"ID: {profile['id']}")
+                typer.echo(f"  ID: {profile['id']}")
+            typer.echo("-" * 80)
 
-        else:
-            kwargs = {location_type: location_value}
-            profiles = scm_client.list_url_access_profiles(**kwargs, exact_match=False)
-
-            if not profiles:
-                typer.echo(f"No URL access profiles found in {location_type} '{location_value}'")
-                return
-
-            typer.echo(f"\nURL Access Profiles in {location_type} '{location_value}':")
-            typer.echo("=" * 80)
-
-            for profile in profiles:
-                typer.echo(f"Name: {profile.get('name', 'N/A')}")
-                if profile.get("description"):
-                    typer.echo(f"  Description: {profile['description']}")
-                if profile.get("block"):
-                    typer.echo(f"  Block: {len(profile['block'])} categories")
-                if profile.get("alert"):
-                    typer.echo(f"  Alert: {len(profile['alert'])} categories")
-                if profile.get("id"):
-                    typer.echo(f"  ID: {profile['id']}")
-                typer.echo("-" * 80)
-
-            return profiles
-
-    except Exception as e:
-        typer.echo(f"Error showing URL access profile: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+        return profiles
 
 
 # =============================================================================================================================================================================================
@@ -5051,6 +4828,7 @@ MOVE_DESTINATION_RULE_OPTION = typer.Option(None, "--destination-rule", help="UU
 
 
 @move_app.command("rule")
+@handle_command_errors("moving security rule")
 def move_security_rule_cmd(
     folder: str = MOVE_FOLDER_OPTION,
     snippet: str = MOVE_SNIPPET_OPTION,
@@ -5073,23 +4851,19 @@ def move_security_rule_cmd(
         typer.echo("Error: --destination-rule is required when using before/after", err=True)
         raise typer.Exit(code=1)
 
-    try:
-        kwargs = {location_type: location_value}
-        scm_client.move_security_rule(
-            **kwargs,
-            name=name,
-            rulebase=rulebase,
-            destination=destination,
-            destination_rule=destination_rule,
-        )
-        typer.echo(f"Moved security rule '{name}' to {destination} in {location_type} '{location_value}' rulebase '{rulebase}'")
-
-    except Exception as e:
-        typer.echo(f"Error moving security rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    scm_client.move_security_rule(
+        **kwargs,
+        name=name,
+        rulebase=rulebase,
+        destination=destination,
+        destination_rule=destination_rule,
+    )
+    typer.echo(f"Moved security rule '{name}' to {destination} in {location_type} '{location_value}' rulebase '{rulebase}'")
 
 
 @move_app.command("app-override-rule")
+@handle_command_errors("moving app override rule")
 def move_app_override_rule_cmd(
     folder: str = MOVE_FOLDER_OPTION,
     snippet: str = MOVE_SNIPPET_OPTION,
@@ -5112,23 +4886,19 @@ def move_app_override_rule_cmd(
         typer.echo("Error: --destination-rule is required when using before/after", err=True)
         raise typer.Exit(code=1)
 
-    try:
-        kwargs = {location_type: location_value}
-        scm_client.move_app_override_rule(
-            **kwargs,
-            name=name,
-            rulebase=rulebase,
-            destination=destination,
-            destination_rule=destination_rule,
-        )
-        typer.echo(f"Moved app override rule '{name}' to {destination} in {location_type} '{location_value}' rulebase '{rulebase}'")
-
-    except Exception as e:
-        typer.echo(f"Error moving app override rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    scm_client.move_app_override_rule(
+        **kwargs,
+        name=name,
+        rulebase=rulebase,
+        destination=destination,
+        destination_rule=destination_rule,
+    )
+    typer.echo(f"Moved app override rule '{name}' to {destination} in {location_type} '{location_value}' rulebase '{rulebase}'")
 
 
 @move_app.command("authentication-rule")
+@handle_command_errors("moving authentication rule")
 def move_authentication_rule_cmd(
     folder: str = MOVE_FOLDER_OPTION,
     snippet: str = MOVE_SNIPPET_OPTION,
@@ -5150,23 +4920,19 @@ def move_authentication_rule_cmd(
         typer.echo("Error: --destination-rule is required when using before/after", err=True)
         raise typer.Exit(code=1)
 
-    try:
-        kwargs = {location_type: location_value}
-        scm_client.move_authentication_rule(
-            **kwargs,
-            name=name,
-            rulebase=rulebase,
-            destination=destination,
-            destination_rule=destination_rule,
-        )
-        typer.echo(f"Moved authentication rule '{name}' to {destination} in {location_type} '{location_value}' rulebase '{rulebase}'")
-
-    except Exception as e:
-        typer.echo(f"Error moving authentication rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    scm_client.move_authentication_rule(
+        **kwargs,
+        name=name,
+        rulebase=rulebase,
+        destination=destination,
+        destination_rule=destination_rule,
+    )
+    typer.echo(f"Moved authentication rule '{name}' to {destination} in {location_type} '{location_value}' rulebase '{rulebase}'")
 
 
 @move_app.command("decryption-rule")
+@handle_command_errors("moving decryption rule")
 def move_decryption_rule_cmd(
     folder: str = MOVE_FOLDER_OPTION,
     snippet: str = MOVE_SNIPPET_OPTION,
@@ -5188,17 +4954,12 @@ def move_decryption_rule_cmd(
         typer.echo("Error: --destination-rule is required when using before/after", err=True)
         raise typer.Exit(code=1)
 
-    try:
-        kwargs = {location_type: location_value}
-        scm_client.move_decryption_rule(
-            **kwargs,
-            name=name,
-            rulebase=rulebase,
-            destination=destination,
-            destination_rule=destination_rule,
-        )
-        typer.echo(f"Moved decryption rule '{name}' to {destination} in {location_type} '{location_value}' rulebase '{rulebase}'")
-
-    except Exception as e:
-        typer.echo(f"Error moving decryption rule: {str(e)}", err=True)
-        raise typer.Exit(code=1) from e
+    kwargs = {location_type: location_value}
+    scm_client.move_decryption_rule(
+        **kwargs,
+        name=name,
+        rulebase=rulebase,
+        destination=destination,
+        destination_rule=destination_rule,
+    )
+    typer.echo(f"Moved decryption rule '{name}' to {destination} in {location_type} '{location_value}' rulebase '{rulebase}'")


### PR DESCRIPTION
## Summary
- Convert 59 functions in `security.py` to use `@handle_command_errors` decorator from #205
- Eliminates duplicated try/except error handling boilerplate across all set/delete/show/list/load/backup commands
- Inner try/except blocks (in load command loops) preserved
- Added `handle_command_errors` import

## Verification
- `grep -c "except Exception as e:"` reduced from 70 to 11 (all inner/loop blocks)
- All lint/format checks pass
- Test baseline unchanged: 37 failures, 845 passed

## Test plan
- [x] Syntax check passes
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `pytest` baseline unchanged (37 fail, 845 pass)
- [x] No outer `except Exception as e:` blocks remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)