### PR TITLE
fix: resolve all 37 pre-existing test failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ packages = [{ include = "scm_cli", from = "src" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
+click = ">=8.0.0,<8.2"
 typer = "^0.15.4"
 pyyaml = "^6.0.2"
 pydantic = "^2.11.5"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,9 @@ from scm_cli.utils.context import get_context_aware_settings as _get_settings  #
 _config_module.settings = _get_settings()
 
 # Patch Scm SDK client before any test modules import it, preventing real HTTP auth calls.
-# This must happen at module level (not in a fixture) because test module collection
-# triggers imports of command modules which import sdk_client.
-_scm_patcher = patch("scm.client.Scm", return_value=MagicMock())
+# Must patch where Scm is used (sdk_client module), not where it's defined (scm.client),
+# because sdk_client.py does `from scm.client import Scm` creating a local reference.
+_scm_patcher = patch("scm_cli.utils.sdk_client.Scm", return_value=MagicMock())
 _scm_patcher.start()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,17 @@ from typer.testing import CliRunner
 # Add the src directory to the path so we can import the package
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../")))
 
+# Patch context before any module imports config.py, preventing real credentials
+# from ~/.scm-cli/contexts/ from leaking into tests.
+_ctx_patcher = patch("scm_cli.utils.context.get_current_context", return_value=None)
+_ctx_patcher.start()
+
+# Recreate settings without context file (must happen after context patch, before Scm patch)
+import scm_cli.utils.config as _config_module  # noqa: E402
+from scm_cli.utils.context import get_context_aware_settings as _get_settings  # noqa: E402
+
+_config_module.settings = _get_settings()
+
 # Patch Scm SDK client before any test modules import it, preventing real HTTP auth calls.
 # This must happen at module level (not in a fixture) because test module collection
 # triggers imports of command modules which import sdk_client.

--- a/tests/test_deployment_commands.py
+++ b/tests/test_deployment_commands.py
@@ -112,8 +112,8 @@ class TestBandwidthAllocationCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating bandwidth allocation" in result.stdout
-        assert "Test error" in result.stdout
+        assert "Error creating bandwidth allocation" in result.output
+        assert "Test error" in result.output
 
     def test_delete_bandwidth_allocation_command(self, runner, monkeypatch):
         """Test the delete bandwidth allocation command."""
@@ -172,8 +172,8 @@ class TestBandwidthAllocationCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error deleting bandwidth allocation" in result.stdout
-        assert "Test error" in result.stdout
+        assert "Error deleting bandwidth allocation" in result.output
+        assert "Test error" in result.output
 
     def test_load_bandwidth_allocation_command(self, runner, monkeypatch, mock_yaml_file):
         """Test the load bandwidth allocation command."""
@@ -262,8 +262,8 @@ class TestBandwidthAllocationCommands:
         monkeypatch.setattr(deployment_module, "load_from_yaml", original_load_from_yaml)
 
         assert result.exit_code == 1
-        assert "Error loading bandwidth allocations" in result.stdout
-        assert "YAML parsing error" in result.stdout
+        assert "Error loading bandwidth allocations" in result.output
+        assert "YAML parsing error" in result.output
 
     def test_set_bandwidth_allocation_updated(self, runner, monkeypatch):
         from scm_cli.utils.sdk_client import scm_client
@@ -380,7 +380,7 @@ class TestBGPRoutingCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating BGP routing" in result.stdout
+        assert "Error creating BGP routing" in result.output
 
     def test_show_bgp_routing_command(self, runner, monkeypatch):
         """Test the show bgp-routing command."""
@@ -490,7 +490,7 @@ class TestInternalDNSServerCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating internal DNS server" in result.stdout
+        assert "Error creating internal DNS server" in result.output
 
     def test_show_internal_dns_server_specific(self, runner, monkeypatch):
         """Test showing a specific internal DNS server."""

--- a/tests/test_dynaconf_config.py
+++ b/tests/test_dynaconf_config.py
@@ -1,6 +1,7 @@
 """Tests for dynaconf configuration module."""
 
 import pytest
+
 from scm_cli.utils.config import get_credentials, settings
 
 

--- a/tests/test_network_commands.py
+++ b/tests/test_network_commands.py
@@ -201,8 +201,8 @@ class TestZoneCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating security zone" in result.stdout
-        assert "Test error" in result.stdout
+        assert "Error creating security zone" in result.output
+        assert "Test error" in result.output
 
     def test_delete_zone_command(self, runner, monkeypatch):
         """Test the delete zone command."""
@@ -260,8 +260,8 @@ class TestZoneCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error deleting security zone" in result.stdout
-        assert "Test error" in result.stdout
+        assert "Error deleting security zone" in result.output
+        assert "Test error" in result.output
 
     def test_load_zone_command(self, runner, monkeypatch, mock_zones_yaml_file):
         """Test the load zone command."""
@@ -405,7 +405,7 @@ class TestIKECryptoProfileCommands:
         test_app.command()(set_ike_crypto_profile)
         result = runner.invoke(test_app, ["test-profile", "--hash", "sha256", "--dh-group", "group14", "--encryption", "aes-256-cbc", "--folder", "test-folder"])
         assert result.exit_code == 1
-        assert "Error" in result.stdout
+        assert "Error" in result.output
 
     def test_show_ike_crypto_profile_list(self, runner, monkeypatch):
         """Test show ike-crypto-profile command lists profiles."""
@@ -561,7 +561,7 @@ class TestIKEGatewayCommands:
             ],
         )
         assert result.exit_code == 1
-        assert "Error" in result.stdout
+        assert "Error" in result.output
 
     def test_set_ike_gateway_missing_auth(self, runner, monkeypatch):
         """Test set ike-gateway command requires authentication."""
@@ -802,7 +802,7 @@ class TestIPsecCryptoProfileCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating IPsec crypto profile" in result.stdout
+        assert "Error creating IPsec crypto profile" in result.output
 
     def test_set_ipsec_crypto_profile_updated(self, runner, monkeypatch):
         from scm_cli.utils.sdk_client import scm_client
@@ -1148,7 +1148,7 @@ class TestNATRuleCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating NAT rule" in result.stdout
+        assert "Error creating NAT rule" in result.output
 
     def test_delete_nat_rule_command(self, runner, monkeypatch):
         """Test the delete nat-rule command."""
@@ -1199,7 +1199,7 @@ class TestNATRuleCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error deleting NAT rule" in result.stdout
+        assert "Error deleting NAT rule" in result.output
 
     def test_show_nat_rule_single(self, runner, monkeypatch):
         """Test showing a single NAT rule."""
@@ -1383,7 +1383,7 @@ class TestAggregateInterfaceCommands:
             ],
         )
         assert result.exit_code == 1
-        assert "Error" in result.stdout
+        assert "Error" in result.output
 
     def test_show_aggregate_interface_list(self, runner, monkeypatch):
         """Test show aggregate-interface command lists interfaces."""

--- a/tests/test_objects_commands.py
+++ b/tests/test_objects_commands.py
@@ -136,7 +136,7 @@ class TestAddressGroupCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error" in result.stdout
+        assert "Error" in result.output
 
     def test_delete_address_group_command(self, runner, monkeypatch):
         """Test the delete address group command."""
@@ -170,7 +170,7 @@ class TestAddressGroupCommands:
         result = runner.invoke(test_app, ["--folder", "test-folder", "--name", "test-group", "--force"])
 
         assert result.exit_code == 1
-        assert "Error" in result.stdout
+        assert "Error" in result.output
 
     def test_load_address_group_command(self, runner, monkeypatch, mock_address_groups_yaml_file):
         """Test the load address group command."""
@@ -392,7 +392,7 @@ class TestScheduleCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating/updating schedule" in result.stdout
+        assert "Error creating/updating schedule" in result.output
 
     def test_show_schedule_list(self, runner, monkeypatch):
         """Test the show schedule command listing all."""
@@ -522,7 +522,7 @@ class TestRegionCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating/updating region" in result.stdout
+        assert "Error creating/updating region" in result.output
 
     def test_delete_region_command(self, runner, monkeypatch):
         """Test the delete region command."""
@@ -789,7 +789,7 @@ quarantined_devices:
         result = runner.invoke(test_app, ["--file", "/nonexistent/file.yml"])
 
         assert result.exit_code == 1
-        assert "File not found" in result.stdout
+        assert "File not found" in result.output
 
 
 class TestAutoTagActionCommands:

--- a/tests/test_security_commands.py
+++ b/tests/test_security_commands.py
@@ -160,8 +160,8 @@ class TestSecurityRuleCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating security rule" in result.stdout
-        assert "Test error" in result.stdout
+        assert "Error creating security rule" in result.output
+        assert "Test error" in result.output
 
     def test_delete_security_rule_command(self, runner, monkeypatch):
         """Test the delete security rule command."""
@@ -221,8 +221,8 @@ class TestSecurityRuleCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error deleting security rule" in result.stdout
-        assert "Test error" in result.stdout
+        assert "Error deleting security rule" in result.output
+        assert "Test error" in result.output
 
     def test_load_security_rule_command(self, runner, monkeypatch, mock_security_rules_yaml_file):
         """Test the load security rule command."""
@@ -430,7 +430,7 @@ class TestWildfireAntivirusProfileCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating WildFire antivirus profile" in result.stdout
+        assert "Error creating WildFire antivirus profile" in result.output
 
     def test_delete_wildfire_antivirus_profile_command(self, runner, monkeypatch):
         """Test the delete wildfire-antivirus-profile command."""
@@ -688,7 +688,7 @@ class TestDNSSecurityProfileCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating DNS security profile" in result.stdout
+        assert "Error creating DNS security profile" in result.output
 
     def test_delete_dns_security_profile_command(self, runner, monkeypatch):
         """Test the delete DNS security profile command."""
@@ -843,7 +843,7 @@ class TestVulnerabilityProtectionProfileCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating vulnerability protection profile" in result.stdout
+        assert "Error creating vulnerability protection profile" in result.output
 
     def test_delete_vulnerability_protection_profile_command(self, runner, monkeypatch):
         """Test the delete vulnerability protection profile command."""
@@ -896,7 +896,7 @@ class TestVulnerabilityProtectionProfileCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error deleting vulnerability protection profile" in result.stdout
+        assert "Error deleting vulnerability protection profile" in result.output
 
     def test_show_vulnerability_protection_profile_single(self, runner, monkeypatch):
         """Test the show command for a single profile."""
@@ -1275,7 +1275,7 @@ class TestURLCategoryCommands:
         )
 
         assert result.exit_code == 1
-        assert "Error creating URL category" in result.stdout
+        assert "Error creating URL category" in result.output
 
     def test_delete_url_category_command(self, runner, monkeypatch):
         """Test the delete URL category command."""


### PR DESCRIPTION
## Summary
- Fix 25 error test assertions: `result.stdout` → `result.output` (typer 0.15.4 separates stderr in CliRunner)
- Fix 6 credential leak tests: patch `get_current_context` to `None` in conftest.py, recreate settings singleton
- Fix 4 main help tests: pin `click>=8.0.0,<8.2` (typer 0.15.4 incompatible with click 8.3's `make_metavar(ctx)` API)
- Fix 4 SDK client tests: resolved by credential leak fix (now falls back to mock mode correctly)

## Test plan
- [x] `poetry run pytest` → 882 passed, 0 failed, 29 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)