### PR TITLE
docs: update for v1.0.16 decorator rollout and test fixes

### DIFF
--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -113,11 +113,35 @@ poetry run mkdocs serve
 When adding new CLI commands:
 
 1. **Follow existing patterns** in the appropriate command module under `src/scm_cli/commands/`
-2. **Add Pydantic validators** in `utils/validators.py` if needed
-3. **Register the command** in `main.py`
-4. **Include helpful error messages** and proper input validation
+2. **Use the error handling decorator** — apply `@handle_command_errors("operation description")` after `@app.command()` instead of writing manual try/except blocks (see below)
+3. **Add Pydantic validators** in `utils/validators.py` if needed
+4. **Register the command** in `main.py`
 5. **Add tests** in `tests/`
 6. **Document the command** with examples in `docs/cli/`
+
+### Error Handling
+
+All command functions use the `@handle_command_errors` decorator from `utils/decorators.py` for consistent error handling. The decorator catches exceptions, prints a formatted error message to stderr, and exits with code 1.
+
+```python
+from ..utils.decorators import handle_command_errors
+
+@set_app.command("my-resource")
+@handle_command_errors("creating my resource")
+def set_my_resource(
+    folder: str = FOLDER_OPTION,
+    name: str = NAME_OPTION,
+):
+    """Create or update a resource."""
+    # No try/except needed — the decorator handles it
+    result = scm_client.create_my_resource(folder=folder, name=name)
+    typer.echo(f"Created resource: {result['name']}")
+```
+
+The operation string should be a lowercase present participle describing the action (e.g., `"deleting address"`, `"loading zones"`, `"backing up security rules"`). Error output follows the format: `Error <operation>: <details>`.
+
+!!! note
+    Inner try/except blocks (e.g., per-item error handling inside bulk load loops) should still be written manually — the decorator only replaces the outermost error handler.
 
 ## Bug Reports and Feature Requests
 

--- a/docs/about/release-notes.md
+++ b/docs/about/release-notes.md
@@ -2,6 +2,23 @@
 
 This page contains the release history of the Strata Cloud Manager CLI, with the most recent releases at the top.
 
+## Version 1.0.16
+
+**Released:** March 20, 2026
+
+### Changed
+
+- **Centralized Error Handling**: Replaced duplicated try/except boilerplate across 278 command functions with the `@handle_command_errors` decorator. All error handling now flows through a single decorator in `utils/decorators.py`, producing consistent `Error <operation>: <details>` messages on stderr with exit code 1.
+- **Error Handling Coverage**: Applied decorator to all functions in `objects.py` (89), `security.py` (59), and `network.py` (130). Inner try/except blocks in bulk load loops preserved for per-item error reporting.
+
+### Fixed
+
+- **Test Suite**: Resolved all 37 pre-existing test failures:
+    - Fixed 25 error assertion tests to use `result.output` instead of `result.stdout` for compatibility with typer 0.15.4's stderr separation in CliRunner.
+    - Fixed credential isolation in tests — real `~/.scm-cli/contexts/` credentials no longer leak into test environment.
+    - Pinned `click>=8.0.0,<8.2` to fix typer 0.15.4 compatibility with click 8.3's breaking `make_metavar()` API change.
+    - Fixed Scm SDK mock to patch at usage site (`scm_cli.utils.sdk_client.Scm`) instead of definition site (`scm.client.Scm`), preventing real API calls in CI.
+
 ## Version 1.0.15
 
 **Released:** March 11, 2026

--- a/docs/about/troubleshooting.md
+++ b/docs/about/troubleshooting.md
@@ -134,15 +134,39 @@ scm show object address --folder Texas
 
 This produces verbose output showing each API call, request payloads, and response details.
 
+## Error Message Format
+
+All CLI errors follow a consistent format and are written to **stderr**:
+
+```
+Error <operation>: <details>
+```
+
+For example:
+
+```
+Error creating address: Folder Texas doesn't exist
+Error deleting zone: Resource not found: my-zone in folder Shared
+Error loading services: Empty or invalid YAML file: services.yaml
+```
+
+This format is produced by the `@handle_command_errors` decorator used across all command functions. The CLI exits with code 1 on any error.
+
+!!! tip
+    Since errors go to stderr, you can separate them from normal output in scripts:
+    ```bash
+    scm set object address --folder Texas --name test --ip-netmask 10.0.0.1/32 2>errors.log
+    ```
+
 ## Common Error Messages
 
 | Error Message | Likely Cause | Solution |
 | --- | --- | --- |
-| `Authentication failed` | Invalid credentials | Check your client ID, secret, and TSG ID |
-| `Resource not found` | Accessing a non-existent resource | Verify the resource name or create it first |
-| `Validation error` | Input data does not meet requirements | Check error details for specific field issues |
-| `Permission denied` | Insufficient permissions | Request necessary permissions for your API credentials |
-| `Connection error` | Network or API endpoint issues | Check your network connection and SCM service status |
+| `Error ... Authentication failed` | Invalid credentials | Check your client ID, secret, and TSG ID |
+| `Error ... Resource not found` | Accessing a non-existent resource | Verify the resource name or create it first |
+| `Error ... Validation error` | Input data does not meet requirements | Check error details for specific field issues |
+| `Error ... Permission denied` | Insufficient permissions | Request necessary permissions for your API credentials |
+| `Error ... Connection error` | Network or API endpoint issues | Check your network connection and SCM service status |
 
 ## Getting Help
 

--- a/docs/guide/advanced-topics.md
+++ b/docs/guide/advanced-topics.md
@@ -180,7 +180,12 @@ The CLI uses standard exit codes for scripting:
 | Exit Code | Meaning |
 | --- | --- |
 | `0` | Success |
-| Non-zero | Failure |
+| `1` | Error (details printed to stderr) |
+
+!!! info
+    Success output (e.g., "Created address: test-server") goes to **stdout**.
+    Error output (e.g., "Error creating address: ...") goes to **stderr**.
+    This separation allows clean output parsing in scripts.
 
 #### Error Checking in Scripts
 
@@ -190,12 +195,13 @@ The CLI uses standard exit codes for scripting:
 scm set object address \
     --folder Shared \
     --name test-server \
-    --ip-netmask 10.1.1.10/32
+    --ip-netmask 10.1.1.10/32 2>error.log
 
 if [ $? -eq 0 ]; then
     echo "Address created successfully"
 else
-    echo "Failed to create address"
+    echo "Failed to create address:"
+    cat error.log
     exit 1
 fi
 ```


### PR DESCRIPTION
## Summary
- Add v1.0.16 release notes covering decorator rollout (#205-208) and test fixes (#209)
- Add `@handle_command_errors` decorator usage guide to contributing.md
- Update troubleshooting page with consistent error format (`Error <operation>: <details>`) and stderr note
- Update advanced topics scripting section: errors go to stderr, stdout/stderr separation for scripts

## Test plan
- [x] `mkdocs build --strict` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)