### PR TITLE
fix: correct SDK 0.13.0 API method calls and defensive region handling

### DIFF
--- a/src/scm_cli/client.py
+++ b/src/scm_cli/client.py
@@ -3,6 +3,7 @@
 Provides client initialization for SCM API interaction.
 """
 
+import inspect
 import logging
 from typing import Any
 
@@ -88,8 +89,10 @@ def get_scm_client(mock: bool = False) -> Any:
         logger.info("No context set, using environment variables or default settings")
 
     auth_params = get_auth_config()
+    # Only pass region if SDK supports it (0.13.0+)
+    if "region" not in inspect.signature(Scm.__init__).parameters:
+        auth_params.pop("region", None)
     try:
-        # Use the Scm client from the pan-scm-sdk
         client = Scm(**auth_params)  # type: ignore[arg-type]
         logger.info(f"Successfully initialized SDK client for TSG ID: {auth_params['tsg_id']}")
         return client

--- a/src/scm_cli/commands/local.py
+++ b/src/scm_cli/commands/local.py
@@ -78,7 +78,7 @@ def list_versions(
 @app.command("download")
 def download_config(
     device: str = DEVICE_OPTION,
-    version: int = typer.Option(..., "--version", "-v", help="Config version number"),
+    version: str = typer.Option(..., "--version", "-v", help="Config version number"),
     output: str | None = typer.Option(None, "--output", "-o", help="Output file path (default: stdout)"),
 ):
     """Download a device configuration version as XML.

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -7,6 +7,7 @@ dynaconf settings.
 
 import contextlib
 import gzip
+import inspect
 import json
 import logging
 import xml.etree.ElementTree as ET
@@ -107,11 +108,13 @@ class SCMClient:
                     region_override = None
                 resolved_region = region_override or settings.get("region", "americas")
 
-                self.client = Scm(
-                    access_token=access_token,
-                    log_level=settings.get("log_level", "INFO"),
-                    region=resolved_region,
-                )
+                scm_kwargs: dict[str, Any] = {
+                    "access_token": access_token,
+                    "log_level": settings.get("log_level", "INFO"),
+                }
+                if "region" in inspect.signature(Scm.__init__).parameters:
+                    scm_kwargs["region"] = resolved_region
+                self.client = Scm(**scm_kwargs)
                 self.logger.info("Successfully initialized SDK client with bearer token")
             else:
                 # OAuth2 authentication mode
@@ -129,13 +132,15 @@ class SCMClient:
                     region_override = None
                 resolved_region = region_override or credentials.get("region", "americas")
 
-                self.client = Scm(
-                    client_id=self.client_id,
-                    client_secret=self.client_secret,
-                    tsg_id=self.tsg_id,
-                    log_level=settings.get("log_level", "INFO"),
-                    region=resolved_region,
-                )
+                scm_kwargs: dict[str, Any] = {
+                    "client_id": self.client_id,
+                    "client_secret": self.client_secret,
+                    "tsg_id": self.tsg_id,
+                    "log_level": settings.get("log_level", "INFO"),
+                }
+                if "region" in inspect.signature(Scm.__init__).parameters:
+                    scm_kwargs["region"] = resolved_region
+                self.client = Scm(**scm_kwargs)
                 self.logger.info(f"Successfully initialized SDK client for TSG ID: {self.tsg_id}")
         except (ValueError, AuthenticationError) as e:
             self.logger.warning(f"Failed to initialize SDK client: {str(e)}")
@@ -16048,12 +16053,12 @@ class SCMClient:
             ]
 
         try:
-            results = self.client.local_config.list(device=device)
+            results = self.client.local_config.list_versions(device=device)
             return [json.loads(r.model_dump_json(exclude_unset=True)) for r in results]
         except Exception as e:
             self._handle_api_exception("listing", "N/A", f"local config versions for {device}", e)
 
-    def download_local_config(self, device: str, version: int) -> bytes:
+    def download_local_config(self, device: str, version: str) -> bytes:
         """Download a configuration version as raw XML.
 
         Args:
@@ -16142,17 +16147,28 @@ class SCMClient:
             }
 
         try:
-            job = self.client.device_operations.dispatch(
-                device=device,
-                operation=operation,
-            )
+            op_method_map = {
+                "route-table": "route_table",
+                "fib-table": "fib_table",
+                "dns-proxy": "dns_proxy",
+                "interfaces": "device_interfaces",
+                "device-rules": "device_rules",
+                "bgp-export": "bgp_policy_export",
+                "logging-status": "logging_service_status",
+            }
+            method_name = op_method_map.get(operation, operation.replace("-", "_"))
+            method = getattr(self.client.device_operations, method_name)
+            result = method(devices=[device], sync=sync, timeout=timeout)
+            result_dict = json.loads(result.model_dump_json(exclude_unset=True))
             if sync:
-                result = self.client.device_operations.wait(
-                    job_id=job.job_id,
-                    timeout=timeout,
-                )
-                return json.loads(result.model_dump_json(exclude_unset=True))
-            return {"job_id": job.job_id, "device": device, "operation": operation, "status": "pending"}
+                result_dict["status"] = "completed"
+                result_dict["device"] = device
+                result_dict["operation"] = operation
+            else:
+                result_dict["device"] = device
+                result_dict["operation"] = operation
+                result_dict["status"] = "pending"
+            return result_dict
         except Exception as e:
             self._handle_api_exception("dispatching", "N/A", f"{operation} for {device}", e)
 
@@ -16179,7 +16195,7 @@ class SCMClient:
             }
 
         try:
-            result = self.client.device_operations.status(job_id=job_id)
+            result = self.client.device_operations.get_job_status(job_id=job_id)
             return json.loads(result.model_dump_json(exclude_unset=True))
         except Exception as e:
             self._handle_api_exception("checking status", "N/A", f"job {job_id}", e)
@@ -16266,13 +16282,13 @@ class SCMClient:
         try:
             kwargs: dict[str, Any] = {}
             if status:
-                kwargs["status"] = status
+                kwargs["status"] = [status]
             if severity:
-                kwargs["severity"] = severity
+                kwargs["severity"] = [severity]
             if product:
-                kwargs["product"] = product
-            results = self.client.incidents.search(**kwargs)
-            return [json.loads(r.model_dump_json(exclude_unset=True)) for r in results]
+                kwargs["product"] = [product]
+            response = self.client.incidents.search(**kwargs)
+            return json.loads(response.model_dump_json(exclude_unset=True)).get("incidents", [])
         except Exception as e:
             self._handle_api_exception("searching", "N/A", "incidents", e)
 
@@ -16287,7 +16303,7 @@ class SCMClient:
             return self._MOCK_INCIDENTS[0]
 
         try:
-            result = self.client.incidents.get(incident_id=incident_id)
+            result = self.client.incidents.get_details(incident_id=incident_id)
             return json.loads(result.model_dump_json(exclude_unset=True))
         except Exception as e:
             self._handle_api_exception("fetching", "N/A", f"incident {incident_id}", e)


### PR DESCRIPTION
## Summary
Fixes runtime errors when using the new v1.3.0 commands against the actual SDK 0.13.0 API.

- **Region**: `Scm()` constructor now only receives `region` if the installed SDK supports it (inspect-based check). Fixes `unexpected keyword argument 'region'` when SDK <0.13.0 is installed.
- **Local Config**: `local_config.list()` → `list_versions()`, version param `int` → `str`
- **Device Operations**: Replace generic `dispatch()` with per-method calls (`route_table()`, `fib_table()`, etc.) taking `devices=[device]` list param. `status()` → `get_job_status()`
- **Incidents**: `search()` filter params are lists not strings. `get()` → `get_details()`. Response model extraction via `.incidents` key.

## Test plan
- [ ] All 957 tests pass
- [ ] `ruff check` clean
- [ ] `mypy` clean
- [ ] `scm local list --device <name>` no longer crashes on region
- [ ] Mock mode still works for all new commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)