### PR TITLE
feat(cli): add --version / -V flag

### DIFF
--- a/.changeset/0001-version-flag.md
+++ b/.changeset/0001-version-flag.md
@@ -1,0 +1,5 @@
+---
+"pan-scm-cli": patch
+---
+
+Add `--version` (and `-V`) flag to the top-level `scm` command so users can quickly check the installed CLI version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pan-scm-cli"
-version = "1.4.0"
+version = "1.4.1"
 description = "CICD and Network Engineer-friendly CLI tool for Palo Alto Networks Strata Cloud Manager"
 authors = ["Calvin Remsburg <dev@cdot.io>"]
 readme = "README.md"

--- a/src/scm_cli/main.py
+++ b/src/scm_cli/main.py
@@ -300,12 +300,28 @@ def get_region_override() -> str | None:
     return _region_override
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        from scm_cli import __version__
+
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
 @app.callback()
 def callback(
     region: str | None = typer.Option(
         None,
         "--region",
         help="Override SCM API region for this invocation",
+    ),
+    version: bool | None = typer.Option(
+        None,
+        "--version",
+        "-V",
+        help="Show the CLI version and exit",
+        callback=_version_callback,
+        is_eager=True,
     ),
 ):
     """Manage Palo Alto Networks Strata Cloud Manager (SCM) configurations.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,3 +49,21 @@ def test_load_command_help(runner):
     assert "network" in result.stdout
     assert "object" in result.stdout
     assert "security" in result.stdout
+
+
+def test_version_flag(runner):
+    """`scm --version` prints the installed version and exits 0."""
+    from scm_cli import __version__
+
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+
+
+def test_version_short_flag(runner):
+    """`scm -V` is an alias for --version."""
+    from scm_cli import __version__
+
+    result = runner.invoke(app, ["-V"])
+    assert result.exit_code == 0
+    assert __version__ in result.stdout


### PR DESCRIPTION
## Summary
- Adds `--version` (and `-V`) option to the top-level `scm` command.
- Prints the installed version via `importlib.metadata` and exits.
- Patch bump to 1.4.1.

## Test plan
- [x] `test_version_flag` and `test_version_short_flag` in `tests/test_main.py`
- [x] Full suite: 977 passed / 29 skipped
- [x] `ruff check` / `ruff format --check` clean on touched files
- [x] Smoke: `scm --version` prints `1.4.1`