### PR TITLE
Show display_name in folder output. Handle nested folders.

### DIFF
--- a/src/scm_cli/commands/setup.py
+++ b/src/scm_cli/commands/setup.py
@@ -275,8 +275,7 @@ def delete_folder(
         if child_folders:
             child_list = ", ".join(child_folders)
             typer.echo(
-                f"Cannot delete folder '{name}' because it contains child folder(s): {child_list}. "
-                "Delete or move the child folder(s) first.",
+                f"Cannot delete folder '{name}' because it contains child folder(s): {child_list}. Delete or move the child folder(s) first.",
                 err=True,
             )
             raise typer.Exit(code=1)

--- a/src/scm_cli/commands/setup.py
+++ b/src/scm_cli/commands/setup.py
@@ -153,6 +153,12 @@ def validate_container_params(folder: str | None = None, snippet: str | None = N
         return "device", device
 
 
+def get_child_folder_names(parent_name: str) -> list[str]:
+    """Return direct child folder names for a parent folder."""
+    folders = scm_client.list_folders()
+    return sorted(f.get("name", "N/A") for f in folders if f.get("parent") == parent_name)
+
+
 # =============================================================================================================================================================================================
 # FOLDER COMMANDS
 # =============================================================================================================================================================================================
@@ -240,6 +246,8 @@ def show_folder(
             typer.echo("-" * 80)
             for f in folders:
                 typer.echo(f"Name: {f.get('name', 'N/A')}")
+                if f.get("display_name"):
+                    typer.echo(f"  Display Name: {f['display_name']}")
                 typer.echo(f"  Parent: {f.get('parent', 'N/A')}")
                 if f.get("description"):
                     typer.echo(f"  Description: {f['description']}")
@@ -262,6 +270,17 @@ def delete_folder(
     try:
         if not force:
             typer.confirm(f"Delete folder '{name}'?", abort=True)
+
+        child_folders = get_child_folder_names(name)
+        if child_folders:
+            child_list = ", ".join(child_folders)
+            typer.echo(
+                f"Cannot delete folder '{name}' because it contains child folder(s): {child_list}. "
+                "Delete or move the child folder(s) first.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
         result = scm_client.delete_folder(name=name)
 
         if result:
@@ -269,6 +288,8 @@ def delete_folder(
         else:
             typer.echo(f"Folder not found: {name}", err=True)
             raise typer.Exit(code=1)
+    except typer.Exit:
+        raise
     except Exception as e:
         typer.echo(f"Error deleting folder: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/tests/test_setup_commands.py
+++ b/tests/test_setup_commands.py
@@ -115,6 +115,7 @@ class TestFolderCommands:
     def test_delete_folder_command(self, runner, monkeypatch):
         from scm_cli.utils.sdk_client import scm_client
 
+        monkeypatch.setattr(scm_client, "list_folders", lambda *a, **kw: [])
         monkeypatch.setattr(scm_client, "delete_folder", lambda *a, **kw: True)
 
         test_app = typer.Typer()
@@ -124,6 +125,30 @@ class TestFolderCommands:
 
         assert result.exit_code == 0
         assert "Deleted folder" in result.stdout
+
+    def test_delete_folder_with_child_folders_fails(self, runner, monkeypatch):
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {"id": "f1", "name": "Texas", "parent": "All"},
+                {"id": "f2", "name": "Austin", "parent": "Texas"},
+            ]
+
+        def mock_delete(*args, **kwargs):
+            pytest.fail("delete_folder should not be called when child folders exist")
+
+        monkeypatch.setattr(scm_client, "list_folders", mock_list)
+        monkeypatch.setattr(scm_client, "delete_folder", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_folder)
+
+        result = runner.invoke(test_app, ["--name", "Texas", "--force"])
+
+        assert result.exit_code == 1
+        assert "Cannot delete folder 'Texas'" in result.output
+        assert "Austin" in result.output
 
 
 class TestLabelCommands:


### PR DESCRIPTION
- Show display_name in folder list output when available.
    - SCM stores the serial number as the unique ID of a NGFW, which is currently displayed. Added the user assigned name as well for easier consumption. Doesn't show if not populated. 
- Prevent deletion of folders that contain direct child folders.
- Return a clear error listing child folders that must be moved or deleted first. 
- Add regression tests for successful deletion and nested-folder rejection.