### PR TITLE
feat: bump pan-scm-sdk to ^0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ click = ">=8.0.0,<8.2"
 typer = "^0.15.4"
 pyyaml = "^6.0.2"
 pydantic = "^2.11.5"
-pan-scm-sdk = "^0.14.0"
+pan-scm-sdk = "^0.15.0"
 dynaconf = "^3.2.11"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## What

Bump `pan-scm-sdk` pin `^0.14.0` → `^0.15.0` (Phase 0 foundation for GlobalProtect mobile-agent service rollout).

## Why

SDK 0.15.0 adds nine new mobile-agent services (infrastructure/global settings, agent/tunnel profiles, forwarding profiles + sub-resources) that follow-up PRs will expose as CLI commands. This PR lands the pin first so service PRs branch from an updated main.

## Validation

- `poetry lock` + `poetry install` clean (lockfile is gitignored in this repo, updated locally)
- Full suite: 975 passed, 29 skipped — zero fallout from bump
- `make quality` green (lint, format, mypy, tests)
- auth_settings alignment verified against SDK 0.15.0 source: `fetch(name, folder)` unchanged; `list()` gains optional `name` server-side filter (additive); wrapper's existing calls compatible. All 21 mobile-agent tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)