### PR TITLE
feat: mobile-agent forwarding-profile + forwarding-profile-destination commands (SDK 0.15.0)

### DIFF
--- a/docs/cli/mobile-agent/forwarding-profile-destination.md
+++ b/docs/cli/mobile-agent/forwarding-profile-destination.md
@@ -1,0 +1,181 @@
+# Forwarding Profile Destination
+
+Forwarding profile destinations define FQDN and IP address targets that GlobalProtect forwarding rules match against in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, show, backup, and load destinations.
+
+## Overview
+
+The `forwarding-profile-destination` commands allow you to:
+
+- Create destinations with FQDN entries (wildcards supported) and IP address entries (wildcards and CIDR supported)
+- Update existing destination configurations
+- Delete destinations by name or UUID
+- Show a destination by name or UUID, or list all destinations
+- Bulk import destinations from YAML files
+- Export destinations for backup or migration
+
+!!! note
+    Destinations only support the `Mobile Users` folder. The API addresses individual destinations by UUID; the CLI resolves `--name` to the UUID for you, or you can pass `--id` directly.
+
+## Entry Formats
+
+| Entry | Format | Examples |
+| --- | --- | --- |
+| FQDN | `host` or `host:port`; wildcards allowed | `app.internal`, `*.example.com:8080` |
+| IP address | `ip`, `ip/prefix`, or `ip:port`; wildcards allowed | `10.0.0.0/8`, `192.168.1.1:443`, `10.*.*.*` |
+
+Ports must be between 1 and 65535.
+
+## Set Forwarding Profile Destination
+
+Create or update a destination.
+
+### Syntax
+
+```bash
+scm set mobile-agent forwarding-profile-destination [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location (must be `Mobile Users`) | Yes |
+| `--name TEXT` | Name of the destination | Yes |
+| `--description TEXT` | Description | No |
+| `--fqdn TEXT` | FQDN entry as `host[:port]` (repeatable) | No |
+| `--ip-address TEXT` | IP entry as `ip[/prefix][:port]` (repeatable) | No |
+
+### Examples
+
+```bash
+$ scm set mobile-agent forwarding-profile-destination \
+    --folder "Mobile Users" \
+    --name "internal-apps" \
+    --fqdn "*.example.com:8080" \
+    --fqdn "app.internal" \
+    --ip-address "10.0.0.0/8"
+Created forwarding profile destination: internal-apps
+```
+
+## Show Forwarding Profile Destination
+
+Display destinations.
+
+### Syntax
+
+```bash
+scm show mobile-agent forwarding-profile-destination [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No (defaults to `Mobile Users`) |
+| `--name TEXT` | Name of the destination to show | No |
+| `--id TEXT` | UUID of the destination to show | No |
+
+### Examples
+
+```bash
+# List all destinations
+$ scm show mobile-agent forwarding-profile-destination --folder "Mobile Users"
+
+# Show by name
+$ scm show mobile-agent forwarding-profile-destination --folder "Mobile Users" --name "internal-apps"
+
+# Show by UUID
+$ scm show mobile-agent forwarding-profile-destination --id "123e4567-e89b-12d3-a456-426655440000"
+```
+
+## Delete Forwarding Profile Destination
+
+Delete a destination by name or UUID.
+
+### Syntax
+
+```bash
+scm delete mobile-agent forwarding-profile-destination [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No (defaults to `Mobile Users`) |
+| `--name TEXT` | Name of the destination to delete | Yes (or `--id`) |
+| `--id TEXT` | UUID of the destination to delete | No |
+| `--force` | Skip confirmation prompt | No |
+
+### Examples
+
+```bash
+$ scm delete mobile-agent forwarding-profile-destination --folder "Mobile Users" --name "internal-apps" --force
+Deleted forwarding profile destination: internal-apps
+```
+
+## Load Forwarding Profile Destination
+
+Bulk import destinations from a YAML file.
+
+### Syntax
+
+```bash
+scm load mobile-agent forwarding-profile-destination --file FILE [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file PATH` | YAML file to load from | Yes |
+| `--dry-run` | Preview without applying | No |
+| `--folder TEXT` | Override folder for all objects | No |
+
+### YAML Format
+
+```yaml
+forwarding_profile_destinations:
+  - name: internal-apps
+    folder: "Mobile Users"
+    description: Internal applications
+    fqdn:
+      - name: app.internal
+        port: 443
+      - name: "*.example.com"
+  - name: corp-ranges
+    folder: "Mobile Users"
+    ip_addresses:
+      - name: 10.0.0.0/8
+      - name: 192.168.1.1
+        port: 443
+```
+
+## Backup Forwarding Profile Destination
+
+Export all destinations in a folder to a YAML file (re-loadable via `scm load`).
+
+### Syntax
+
+```bash
+scm backup mobile-agent forwarding-profile-destination [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup from | No (defaults to `Mobile Users`) |
+| `--file PATH` | Output file (defaults to `forwarding-profile-destination-{folder}.yaml`) | No |
+
+### Examples
+
+```bash
+$ scm backup mobile-agent forwarding-profile-destination --folder "Mobile Users"
+Successfully backed up 2 forwarding profile destinations to forwarding-profile-destination-mobile-users.yaml
+```
+
+## Related
+
+- [Forwarding Profile](forwarding-profile.md) — profiles whose forwarding rules reference these destinations
+- [Auth Setting](auth-setting.md)

--- a/docs/cli/mobile-agent/forwarding-profile.md
+++ b/docs/cli/mobile-agent/forwarding-profile.md
@@ -1,0 +1,214 @@
+# Forwarding Profile
+
+Forwarding profiles control how GlobalProtect mobile agent traffic is forwarded (PAC file, GlobalProtect proxy, or ZTNA agent) in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, show, backup, and load forwarding profiles.
+
+## Overview
+
+The `forwarding-profile` commands allow you to:
+
+- Create forwarding profiles of type PAC file, GlobalProtect proxy, or ZTNA agent
+- Update existing forwarding profile configurations
+- Delete forwarding profiles by name or UUID
+- Show a profile by name or UUID, or list all profiles
+- Bulk import forwarding profiles (including forwarding rules and block rules) from YAML files
+- Export forwarding profiles for backup or migration
+
+!!! note
+    Forwarding profiles only support the `Mobile Users` folder. The API addresses individual profiles by UUID; the CLI resolves `--name` to the UUID for you, or you can pass `--id` directly.
+
+## Profile Types
+
+| Type | `--profile-type` value | YAML `type` key | Description |
+| --- | --- | --- | --- |
+| PAC file | `pac-file` | `pac_file` | Forwarding driven by a PAC file |
+| GlobalProtect proxy | `global-protect-proxy` | `global_protect_proxy` | Forwarding via GlobalProtect proxy |
+| ZTNA agent | `ztna-agent` | `ztna_agent` | ZTNA agent forwarding with traffic-type rules |
+
+## Set Forwarding Profile
+
+Create or update a forwarding profile.
+
+### Syntax
+
+```bash
+scm set mobile-agent forwarding-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location (must be `Mobile Users`) | Yes |
+| `--name TEXT` | Name of the forwarding profile | Yes |
+| `--description TEXT` | Description | No |
+| `--definition-method TEXT` | How the profile is defined: `rules` or `pac-file` | No |
+| `--profile-type TEXT` | Profile type: `pac-file`, `global-protect-proxy`, or `ztna-agent` | No |
+| `--pac-upload / --no-pac-upload` | Whether the user uploads a PAC file | No |
+
+Complex forwarding rules and block rules are not expressible as flags — use [Load Forwarding Profile](#load-forwarding-profile) with a YAML file for those.
+
+### Examples
+
+#### Create ZTNA Agent Profile
+
+```bash
+$ scm set mobile-agent forwarding-profile \
+    --folder "Mobile Users" \
+    --name "ztna-profile" \
+    --profile-type ztna-agent
+Created forwarding profile: ztna-profile
+```
+
+#### Create GlobalProtect Proxy Profile with PAC Upload
+
+```bash
+$ scm set mobile-agent forwarding-profile \
+    --folder "Mobile Users" \
+    --name "proxy-profile" \
+    --profile-type global-protect-proxy \
+    --pac-upload
+Created forwarding profile: proxy-profile
+```
+
+## Show Forwarding Profile
+
+Display forwarding profiles.
+
+### Syntax
+
+```bash
+scm show mobile-agent forwarding-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No (defaults to `Mobile Users`) |
+| `--name TEXT` | Name of the profile to show | No |
+| `--id TEXT` | UUID of the profile to show | No |
+
+### Examples
+
+```bash
+# List all forwarding profiles
+$ scm show mobile-agent forwarding-profile --folder "Mobile Users"
+
+# Show by name
+$ scm show mobile-agent forwarding-profile --folder "Mobile Users" --name "ztna-profile"
+
+# Show by UUID
+$ scm show mobile-agent forwarding-profile --id "123e4567-e89b-12d3-a456-426655440000"
+```
+
+## Delete Forwarding Profile
+
+Delete a forwarding profile by name or UUID.
+
+### Syntax
+
+```bash
+scm delete mobile-agent forwarding-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location | No (defaults to `Mobile Users`) |
+| `--name TEXT` | Name of the profile to delete | Yes (or `--id`) |
+| `--id TEXT` | UUID of the profile to delete | No |
+| `--force` | Skip confirmation prompt | No |
+
+### Examples
+
+```bash
+$ scm delete mobile-agent forwarding-profile --folder "Mobile Users" --name "ztna-profile" --force
+Deleted forwarding profile: ztna-profile
+```
+
+## Load Forwarding Profile
+
+Bulk import forwarding profiles from a YAML file. This is the path for full configurations including forwarding rules and block rules.
+
+### Syntax
+
+```bash
+scm load mobile-agent forwarding-profile --file FILE [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file PATH` | YAML file to load from | Yes |
+| `--dry-run` | Preview without applying | No |
+| `--folder TEXT` | Override folder for all objects | No |
+
+### YAML Format
+
+```yaml
+forwarding_profiles:
+  - name: ztna-profile
+    folder: "Mobile Users"
+    definition_method: rules
+    type:
+      ztna_agent:
+        pac_upload: false
+        forwarding_rules:
+          - name: rule1
+            traffic_type: dns            # dns | dns-and-network-traffic | network-traffic
+            enabled: true
+            user_locations: Any
+            source_applications: Any
+            destinations: Any
+            connectivity: direct
+        block_rule:
+          block_all_other_unmatched_outbound_connections: true
+          allow_icmp_for_troubleshooting: true
+  - name: pac-profile
+    folder: "Mobile Users"
+    definition_method: pac-file
+    type:
+      pac_file:
+        pac_upload: true
+        forwarding_rules:
+          - name: rule1
+            enabled: true
+            connectivity: direct
+        block_rule:
+          enable: true
+          allow_tcp:
+            enable_locations: true
+            locations:
+              - "US"
+```
+
+## Backup Forwarding Profile
+
+Export all forwarding profiles in a folder to a YAML file (re-loadable via `scm load`).
+
+### Syntax
+
+```bash
+scm backup mobile-agent forwarding-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup from | No (defaults to `Mobile Users`) |
+| `--file PATH` | Output file (defaults to `forwarding-profile-{folder}.yaml`) | No |
+
+### Examples
+
+```bash
+$ scm backup mobile-agent forwarding-profile --folder "Mobile Users"
+Successfully backed up 2 forwarding profiles to forwarding-profile-mobile-users.yaml
+```
+
+## Related
+
+- [Forwarding Profile Destination](forwarding-profile-destination.md) — destination objects referenced by forwarding rules
+- [Auth Setting](auth-setting.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -160,6 +160,8 @@ nav:
       - Mobile Agent:
           - Agent Version: cli/mobile-agent/agent-version.md
           - Auth Setting: cli/mobile-agent/auth-setting.md
+          - Forwarding Profile: cli/mobile-agent/forwarding-profile.md
+          - Forwarding Profile Destination: cli/mobile-agent/forwarding-profile-destination.md
           - SDK Reference: cli/mobile-agent/sdk-mobile-agent.md
       - Local Config:
           - Overview: cli/local/index.md

--- a/src/scm_cli/commands/mobile_agent.py
+++ b/src/scm_cli/commands/mobile_agent.py
@@ -15,7 +15,7 @@ from ..utils import validate_location_params
 from ..utils.config import load_from_yaml, settings
 from ..utils.context import get_current_context
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AuthSetting
+from ..utils.validators import AuthSetting, ForwardingProfile, ForwardingProfileDestination
 
 # =============================================================================================================================================================================================
 # HELPER FUNCTIONS
@@ -539,4 +539,607 @@ def show_auth_setting(
 
     except Exception as e:
         typer.echo(f"Error showing auth setting: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# =============================================================================================================================================================================================
+# FORWARDING PROFILE COMMANDS (GlobalProtect, SDK 0.15.0)
+# =============================================================================================================================================================================================
+
+# Forwarding profile specific options
+PROFILE_TYPE_OPTION = typer.Option(
+    None,
+    "--profile-type",
+    help="Profile type: pac-file, global-protect-proxy, or ztna-agent",
+)
+DEFINITION_METHOD_OPTION = typer.Option(
+    None,
+    "--definition-method",
+    help="How the profile is defined: rules or pac-file",
+)
+PAC_UPLOAD_OPTION = typer.Option(
+    None,
+    "--pac-upload/--no-pac-upload",
+    help="Whether the user uploads a PAC file",
+)
+PROFILE_ID_OPTION = typer.Option(
+    None,
+    "--id",
+    help="UUID of the resource (alternative to --name)",
+)
+
+_PROFILE_TYPE_KEY_MAP = {
+    "pac-file": "pac_file",
+    "global-protect-proxy": "global_protect_proxy",
+    "ztna-agent": "ztna_agent",
+}
+
+
+@backup_app.command("forwarding-profile")
+def backup_forwarding_profile(
+    folder: str = BACKUP_FOLDER_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+):
+    """Backup all forwarding profiles from a folder to a YAML file.
+
+    Examples
+    --------
+        scm backup mobile-agent forwarding-profile --folder "Mobile Users"
+
+    """
+    try:
+        if not folder:
+            folder = "Mobile Users"
+
+        profiles = scm_client.list_forwarding_profiles(folder=folder)
+
+        if not profiles:
+            typer.echo(f"No forwarding profiles found in folder '{folder}'")
+            return None
+
+        backup_data = []
+        for profile in profiles:
+            profile_dict = {k: v for k, v in profile.items() if v is not None}
+            profile_dict.pop("id", None)
+            backup_data.append(profile_dict)
+
+        yaml_data = {"forwarding_profiles": backup_data}
+
+        if file is None:
+            file = Path(get_default_backup_filename("forwarding-profile", "folder", folder))
+
+        with file.open("w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} forwarding profiles to {file}")
+        return str(file)
+
+    except Exception as e:
+        typer.echo(f"Error backing up forwarding profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("forwarding-profile")
+def delete_forwarding_profile(
+    folder: str = FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    profile_id: str | None = PROFILE_ID_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+):
+    """Delete a forwarding profile by name or UUID.
+
+    Examples
+    --------
+        scm delete mobile-agent forwarding-profile --folder "Mobile Users" --name "ztna-profile"
+
+        scm delete mobile-agent forwarding-profile --id "123e4567-e89b-12d3-a456-426655440000"
+
+    """
+    try:
+        identifier = profile_id or name
+        if not force:
+            typer.confirm(f"Delete forwarding profile '{identifier}'?", abort=True)
+        result = scm_client.delete_forwarding_profile(folder=folder, name=name, profile_id=profile_id)
+        if result:
+            typer.echo(f"Deleted forwarding profile: {identifier}")
+        return result
+    except Exception as e:
+        typer.echo(f"Error deleting forwarding profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("forwarding-profile")
+def load_forwarding_profile(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+):
+    """Load forwarding profiles from a YAML file.
+
+    Complex profile configurations (forwarding rules, block rules) are expressed in
+    YAML under the `type` key: {pac_file | global_protect_proxy | ztna_agent: {...}}.
+
+    Examples
+    --------
+        scm load mobile-agent forwarding-profile --file config/forwarding_profiles.yml
+
+    """
+    try:
+        config = load_from_yaml(str(file), "forwarding_profiles")
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            typer.echo(yaml.dump(config["forwarding_profiles"]))
+            return None
+
+        results = []
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+
+        for profile_data in config["forwarding_profiles"]:
+            try:
+                if folder:
+                    profile_data["folder"] = folder
+
+                profile = ForwardingProfile(**profile_data)
+                sdk_data = profile.to_sdk_model()
+
+                result = scm_client.create_forwarding_profile(**sdk_data)
+
+                action = result.pop("__action__", "created")
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created forwarding profile: {result.get('name', 'N/A')}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated forwarding profile: {result.get('name', 'N/A')}")
+                elif action == "no_change":
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for forwarding profile: {result.get('name', 'N/A')}")
+
+                results.append(result)
+
+            except Exception as e:
+                typer.echo(f"Error loading forwarding profile '{profile_data.get('name', 'unknown')}': {str(e)}", err=True)
+
+        typer.echo(f"\nSummary: {created_count} created, {updated_count} updated, {no_change_count} unchanged")
+
+        return results
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error loading forwarding profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("forwarding-profile")
+def set_forwarding_profile(
+    folder: str = FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    description: str | None = DESCRIPTION_OPTION,
+    definition_method: str | None = DEFINITION_METHOD_OPTION,
+    profile_type: str | None = PROFILE_TYPE_OPTION,
+    pac_upload: bool | None = PAC_UPLOAD_OPTION,
+):
+    r"""Create or update a forwarding profile.
+
+    The folder must be "Mobile Users" (the only folder supported by the API).
+    Use --profile-type to select the profile flavor; full forwarding/block rules
+    are supported via `scm load mobile-agent forwarding-profile --file ...`.
+
+    Examples
+    --------
+        scm set mobile-agent forwarding-profile \
+        --folder "Mobile Users" \
+        --name "ztna-profile" \
+        --profile-type ztna-agent
+
+    """
+    try:
+        profile_data: dict[str, Any] = {
+            "name": name,
+        }
+
+        if folder:
+            profile_data["folder"] = folder
+        if description is not None:
+            profile_data["description"] = description
+        if definition_method is not None:
+            profile_data["definition_method"] = definition_method
+        if profile_type is not None:
+            type_key = _PROFILE_TYPE_KEY_MAP.get(profile_type)
+            if type_key is None:
+                typer.echo(
+                    f"Error: --profile-type must be one of: {', '.join(sorted(_PROFILE_TYPE_KEY_MAP))}",
+                    err=True,
+                )
+                raise typer.Exit(code=1)
+            type_config: dict[str, Any] = {}
+            if pac_upload is not None:
+                type_config["pac_upload"] = pac_upload
+            profile_data["type"] = {type_key: type_config}
+
+        profile = ForwardingProfile(**profile_data)
+        sdk_data = profile.to_sdk_model()
+
+        result = scm_client.create_forwarding_profile(**sdk_data)
+
+        action = result.pop("__action__", "created")
+
+        if action == "created":
+            typer.echo(f"Created forwarding profile: {result.get('name', name)}")
+        elif action == "updated":
+            typer.echo(f"Updated forwarding profile: {result.get('name', name)}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for forwarding profile: {result.get('name', name)}")
+
+        return result
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except typer.Exit:
+        raise
+    except Exception as e:
+        typer.echo(f"Error creating/updating forwarding profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("forwarding-profile")
+def show_forwarding_profile(
+    folder: str = FOLDER_OPTION,
+    name: str | None = typer.Option(None, "--name", help="Name of the forwarding profile to show"),
+    profile_id: str | None = PROFILE_ID_OPTION,
+):
+    """Display forwarding profiles.
+
+    Examples
+    --------
+        # List all forwarding profiles (default behavior)
+        scm show mobile-agent forwarding-profile --folder "Mobile Users"
+
+        # Show a specific forwarding profile by name
+        scm show mobile-agent forwarding-profile --folder "Mobile Users" --name "ztna-profile"
+
+        # Show a specific forwarding profile by UUID
+        scm show mobile-agent forwarding-profile --id "123e4567-e89b-12d3-a456-426655440000"
+
+    """
+    try:
+        show_context_info()
+
+        if profile_id or name:
+            profile = scm_client.get_forwarding_profile(folder=folder, name=name, profile_id=profile_id)
+
+            typer.echo(f"\nForwarding Profile: {profile.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+
+            if profile.get("description"):
+                typer.echo(f"Description: {profile['description']}")
+            if profile.get("definition_method"):
+                typer.echo(f"Definition Method: {profile['definition_method']}")
+            if profile.get("type"):
+                typer.echo("Type:")
+                typer.echo(yaml.dump(profile["type"], default_flow_style=False, sort_keys=False).rstrip())
+            if profile.get("id"):
+                typer.echo(f"ID: {profile['id']}")
+
+            return profile
+
+        else:
+            profiles = scm_client.list_forwarding_profiles(folder=folder)
+
+            if not profiles:
+                typer.echo(f"No forwarding profiles found in folder '{folder or 'Mobile Users'}'")
+                return None
+
+            typer.echo(f"\nForwarding Profiles in folder '{folder or 'Mobile Users'}':")
+            typer.echo("-" * 60)
+
+            for profile in profiles:
+                typer.echo(f"Name: {profile.get('name', 'N/A')}")
+                if profile.get("definition_method"):
+                    typer.echo(f"  Definition Method: {profile['definition_method']}")
+                if profile.get("type"):
+                    typer.echo(f"  Profile Type: {', '.join(profile['type'].keys())}")
+                if profile.get("description"):
+                    typer.echo(f"  Description: {profile['description']}")
+                if profile.get("id"):
+                    typer.echo(f"  ID: {profile['id']}")
+                typer.echo("-" * 60)
+
+            return profiles
+
+    except Exception as e:
+        typer.echo(f"Error showing forwarding profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# =============================================================================================================================================================================================
+# FORWARDING PROFILE DESTINATION COMMANDS (GlobalProtect, SDK 0.15.0)
+# =============================================================================================================================================================================================
+
+# Forwarding profile destination specific options
+FQDN_OPTION = typer.Option(
+    None,
+    "--fqdn",
+    help="FQDN entry as 'host' or 'host:port' (repeatable)",
+)
+IP_ADDRESS_OPTION = typer.Option(
+    None,
+    "--ip-address",
+    help="IP entry as 'ip', 'ip/prefix', or 'ip:port' (repeatable)",
+)
+
+
+@backup_app.command("forwarding-profile-destination")
+def backup_forwarding_profile_destination(
+    folder: str = BACKUP_FOLDER_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+):
+    """Backup all forwarding profile destinations from a folder to a YAML file.
+
+    Examples
+    --------
+        scm backup mobile-agent forwarding-profile-destination --folder "Mobile Users"
+
+    """
+    try:
+        if not folder:
+            folder = "Mobile Users"
+
+        destinations = scm_client.list_forwarding_profile_destinations(folder=folder)
+
+        if not destinations:
+            typer.echo(f"No forwarding profile destinations found in folder '{folder}'")
+            return None
+
+        backup_data = []
+        for destination in destinations:
+            destination_dict = {k: v for k, v in destination.items() if v is not None}
+            destination_dict.pop("id", None)
+            backup_data.append(destination_dict)
+
+        yaml_data = {"forwarding_profile_destinations": backup_data}
+
+        if file is None:
+            file = Path(get_default_backup_filename("forwarding-profile-destination", "folder", folder))
+
+        with file.open("w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} forwarding profile destinations to {file}")
+        return str(file)
+
+    except Exception as e:
+        typer.echo(f"Error backing up forwarding profile destinations: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("forwarding-profile-destination")
+def delete_forwarding_profile_destination(
+    folder: str = FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    destination_id: str | None = PROFILE_ID_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+):
+    """Delete a forwarding profile destination by name or UUID.
+
+    Examples
+    --------
+        scm delete mobile-agent forwarding-profile-destination --folder "Mobile Users" --name "internal-apps"
+
+    """
+    try:
+        identifier = destination_id or name
+        if not force:
+            typer.confirm(f"Delete forwarding profile destination '{identifier}'?", abort=True)
+        result = scm_client.delete_forwarding_profile_destination(folder=folder, name=name, destination_id=destination_id)
+        if result:
+            typer.echo(f"Deleted forwarding profile destination: {identifier}")
+        return result
+    except Exception as e:
+        typer.echo(f"Error deleting forwarding profile destination: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("forwarding-profile-destination")
+def load_forwarding_profile_destination(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+):
+    """Load forwarding profile destinations from a YAML file.
+
+    Examples
+    --------
+        scm load mobile-agent forwarding-profile-destination --file config/destinations.yml
+
+    """
+    try:
+        config = load_from_yaml(str(file), "forwarding_profile_destinations")
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            typer.echo(yaml.dump(config["forwarding_profile_destinations"]))
+            return None
+
+        results = []
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+
+        for destination_data in config["forwarding_profile_destinations"]:
+            try:
+                if folder:
+                    destination_data["folder"] = folder
+
+                destination = ForwardingProfileDestination(**destination_data)
+                sdk_data = destination.to_sdk_model()
+
+                result = scm_client.create_forwarding_profile_destination(**sdk_data)
+
+                action = result.pop("__action__", "created")
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created forwarding profile destination: {result.get('name', 'N/A')}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated forwarding profile destination: {result.get('name', 'N/A')}")
+                elif action == "no_change":
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for forwarding profile destination: {result.get('name', 'N/A')}")
+
+                results.append(result)
+
+            except Exception as e:
+                typer.echo(f"Error loading forwarding profile destination '{destination_data.get('name', 'unknown')}': {str(e)}", err=True)
+
+        typer.echo(f"\nSummary: {created_count} created, {updated_count} updated, {no_change_count} unchanged")
+
+        return results
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error loading forwarding profile destinations: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("forwarding-profile-destination")
+def set_forwarding_profile_destination(
+    folder: str = FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    description: str | None = DESCRIPTION_OPTION,
+    fqdn: list[str] | None = FQDN_OPTION,
+    ip_address: list[str] | None = IP_ADDRESS_OPTION,
+):
+    r"""Create or update a forwarding profile destination.
+
+    The folder must be "Mobile Users" (the only folder supported by the API).
+    Entries accept an optional ':port' suffix.
+
+    Examples
+    --------
+        scm set mobile-agent forwarding-profile-destination \
+        --folder "Mobile Users" \
+        --name "internal-apps" \
+        --fqdn "*.example.com:8080" \
+        --ip-address "10.0.0.0/8"
+
+    """
+    try:
+        destination_data: dict[str, Any] = {
+            "name": name,
+        }
+
+        if folder:
+            destination_data["folder"] = folder
+        if description is not None:
+            destination_data["description"] = description
+        if fqdn:
+            destination_data["fqdn"] = fqdn
+        if ip_address:
+            destination_data["ip_addresses"] = ip_address
+
+        destination = ForwardingProfileDestination(**destination_data)
+        sdk_data = destination.to_sdk_model()
+
+        result = scm_client.create_forwarding_profile_destination(**sdk_data)
+
+        action = result.pop("__action__", "created")
+
+        if action == "created":
+            typer.echo(f"Created forwarding profile destination: {result.get('name', name)}")
+        elif action == "updated":
+            typer.echo(f"Updated forwarding profile destination: {result.get('name', name)}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for forwarding profile destination: {result.get('name', name)}")
+
+        return result
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating forwarding profile destination: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("forwarding-profile-destination")
+def show_forwarding_profile_destination(
+    folder: str = FOLDER_OPTION,
+    name: str | None = typer.Option(None, "--name", help="Name of the forwarding profile destination to show"),
+    destination_id: str | None = PROFILE_ID_OPTION,
+):
+    """Display forwarding profile destinations.
+
+    Examples
+    --------
+        # List all forwarding profile destinations (default behavior)
+        scm show mobile-agent forwarding-profile-destination --folder "Mobile Users"
+
+        # Show a specific destination by name
+        scm show mobile-agent forwarding-profile-destination --folder "Mobile Users" --name "internal-apps"
+
+        # Show a specific destination by UUID
+        scm show mobile-agent forwarding-profile-destination --id "123e4567-e89b-12d3-a456-426655440000"
+
+    """
+    try:
+        show_context_info()
+
+        if destination_id or name:
+            destination = scm_client.get_forwarding_profile_destination(folder=folder, name=name, destination_id=destination_id)
+
+            typer.echo(f"\nForwarding Profile Destination: {destination.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+
+            if destination.get("description"):
+                typer.echo(f"Description: {destination['description']}")
+            if destination.get("fqdn"):
+                typer.echo("FQDN Entries:")
+                for entry in destination["fqdn"]:
+                    port_suffix = f":{entry['port']}" if entry.get("port") else ""
+                    typer.echo(f"  - {entry.get('name', 'N/A')}{port_suffix}")
+            if destination.get("ip_addresses"):
+                typer.echo("IP Address Entries:")
+                for entry in destination["ip_addresses"]:
+                    port_suffix = f":{entry['port']}" if entry.get("port") else ""
+                    typer.echo(f"  - {entry.get('name', 'N/A')}{port_suffix}")
+            if destination.get("id"):
+                typer.echo(f"ID: {destination['id']}")
+
+            return destination
+
+        else:
+            destinations = scm_client.list_forwarding_profile_destinations(folder=folder)
+
+            if not destinations:
+                typer.echo(f"No forwarding profile destinations found in folder '{folder or 'Mobile Users'}'")
+                return None
+
+            typer.echo(f"\nForwarding Profile Destinations in folder '{folder or 'Mobile Users'}':")
+            typer.echo("-" * 60)
+
+            for destination in destinations:
+                typer.echo(f"Name: {destination.get('name', 'N/A')}")
+                if destination.get("fqdn"):
+                    typer.echo(f"  FQDN Entries: {len(destination['fqdn'])}")
+                if destination.get("ip_addresses"):
+                    typer.echo(f"  IP Address Entries: {len(destination['ip_addresses'])}")
+                if destination.get("description"):
+                    typer.echo(f"  Description: {destination['description']}")
+                if destination.get("id"):
+                    typer.echo(f"  ID: {destination['id']}")
+                typer.echo("-" * 60)
+
+            return destinations
+
+    except Exception as e:
+        typer.echo(f"Error showing forwarding profile destination: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -16467,6 +16467,407 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("fetching", "N/A", f"incident {incident_id}", e)
 
+    # ======================================================================================================================================================================================
+    # GLOBALPROTECT FORWARDING PROFILE METHODS (mobile-agent, SDK 0.15.0)
+    # ======================================================================================================================================================================================
+
+    # Forwarding Profile ----------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+    def create_forwarding_profile(
+        self,
+        folder: str | None = None,
+        name: str = None,
+        description: str | None = None,
+        definition_method: str | None = None,
+        type: dict[str, Any] | None = None,  # noqa: A002 - matches SDK field name
+    ) -> dict[str, Any]:
+        """Create or update a GlobalProtect forwarding profile using smart upsert logic.
+
+        Args:
+            folder: Folder for the profile (must be 'Mobile Users'; sent as query param)
+            name: Name of the forwarding profile
+            description: Optional description
+            definition_method: How the profile is defined (rules or pac-file)
+            type: Profile type configuration ({pac_file|global_protect_proxy|ztna_agent: {...}})
+
+        Returns:
+            dict[str, Any]: The created/updated forwarding profile with __action__ field
+
+        """
+        folder = folder or "Mobile Users"
+        self.logger.info(f"Creating or updating forwarding profile: {name} in folder {folder}")
+
+        if not self.client:
+            result = {
+                "id": f"fp-{name}",
+                "name": name,
+                "description": description,
+                "definition_method": definition_method,
+                "type": type,
+                "__action__": "created",
+            }
+            return {k: v for k, v in result.items() if v is not None}
+
+        try:
+            # Step 1: Try to fetch existing profile by name (SDK fetch raises a 404-style
+            # InvalidObjectError when missing, which lands in the generic handler below)
+            existing = None
+            try:
+                existing = self.client.forwarding_profile.fetch(name=name, folder=folder)
+                self.logger.info(f"Found existing forwarding profile '{name}' in folder '{folder}'")
+            except NotFoundError:
+                self.logger.info(f"Forwarding profile '{name}' not found in folder '{folder}', will create new")
+            except Exception as fetch_error:
+                self.logger.info(f"Forwarding profile '{name}' lookup did not match ({fetch_error}), will create new")
+
+            if existing:
+                existing_dump = json.loads(existing.model_dump_json(exclude_unset=True))
+
+                # Step 2: Compare provided fields and update if needed
+                provided: dict[str, Any] = {}
+                if description is not None:
+                    provided["description"] = description
+                if definition_method is not None:
+                    provided["definition_method"] = definition_method
+                if type is not None:
+                    provided["type"] = type
+
+                needs_update = any(existing_dump.get(field) != value for field, value in provided.items())
+
+                if needs_update:
+                    payload = {k: v for k, v in existing_dump.items() if k != "id"}
+                    payload.update(provided)
+                    result = self.client.forwarding_profile.update(str(existing.id), payload)
+                    self.logger.info(f"Successfully updated forwarding profile '{name}' in folder '{folder}'")
+                    response = json.loads(result.model_dump_json(exclude_unset=True))
+                    response["__action__"] = "updated"
+                    return response
+                else:
+                    self.logger.info(f"No changes detected for forwarding profile '{name}', skipping update")
+                    response = existing_dump
+                    response["__action__"] = "no_change"
+                    return response
+            else:
+                # Step 3: Create new profile (folder goes as query param via the service)
+                profile_data: dict[str, Any] = {"name": name}
+                if description is not None:
+                    profile_data["description"] = description
+                if definition_method is not None:
+                    profile_data["definition_method"] = definition_method
+                if type is not None:
+                    profile_data["type"] = type
+
+                result = self.client.forwarding_profile.create(profile_data, folder=folder)
+                self.logger.info(f"Successfully created forwarding profile '{name}' in folder '{folder}'")
+                response = json.loads(result.model_dump_json(exclude_unset=True))
+                response["__action__"] = "created"
+                return response
+
+        except Exception as e:
+            self._handle_api_exception("create/update", folder, name or "", e)
+
+    def get_forwarding_profile(
+        self,
+        folder: str | None = None,
+        name: str | None = None,
+        profile_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Get a forwarding profile by name (fetch) or UUID (direct get).
+
+        Args:
+            folder: Folder containing the profile (used with name)
+            name: Name of the forwarding profile
+            profile_id: UUID of the forwarding profile (takes precedence over name)
+
+        Returns:
+            dict[str, Any]: The forwarding profile object
+
+        """
+        folder = folder or "Mobile Users"
+        self.logger.info(f"Getting forwarding profile: {profile_id or name} from folder {folder}")
+
+        if not self.client:
+            return {
+                "id": profile_id or f"fp-{name}",
+                "name": name or "mock-profile",
+                "description": f"Mock forwarding profile {name or profile_id}",
+                "definition_method": "rules",
+                "type": {"ztna_agent": {"pac_upload": False}},
+            }
+
+        try:
+            result = self.client.forwarding_profile.get(profile_id) if profile_id else self.client.forwarding_profile.fetch(name=name, folder=folder)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", folder, profile_id or name or "", e)
+
+    def list_forwarding_profiles(
+        self,
+        folder: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List forwarding profiles.
+
+        Args:
+            folder: Folder to list from (must be 'Mobile Users')
+
+        Returns:
+            list[dict[str, Any]]: List of forwarding profile objects
+
+        """
+        folder = folder or "Mobile Users"
+        self.logger.info(f"Listing forwarding profiles in folder: {folder}")
+
+        if not self.client:
+            return [
+                {
+                    "id": "fp-mock1",
+                    "name": "ztna-profile",
+                    "definition_method": "rules",
+                    "type": {"ztna_agent": {"pac_upload": False}},
+                },
+                {
+                    "id": "fp-mock2",
+                    "name": "pac-profile",
+                    "definition_method": "pac-file",
+                    "type": {"pac_file": {"pac_upload": True}},
+                },
+            ]
+
+        try:
+            results = self.client.forwarding_profile.list(folder=folder)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder, "forwarding profiles", e)
+
+    def delete_forwarding_profile(
+        self,
+        folder: str | None = None,
+        name: str | None = None,
+        profile_id: str | None = None,
+    ) -> bool:
+        """Delete a forwarding profile by name or UUID.
+
+        Args:
+            folder: Folder containing the profile (used with name)
+            name: Name of the forwarding profile to delete
+            profile_id: UUID of the forwarding profile (takes precedence over name)
+
+        Returns:
+            bool: True if deletion was successful
+
+        """
+        folder = folder or "Mobile Users"
+        self.logger.info(f"Deleting forwarding profile: {profile_id or name} from folder {folder}")
+
+        if not self.client:
+            return True
+
+        try:
+            if not profile_id:
+                profile = self.client.forwarding_profile.fetch(name=name, folder=folder)
+                profile_id = str(profile.id)
+            self.client.forwarding_profile.delete(profile_id)
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", folder, profile_id or name or "", e)
+
+    # Forwarding Profile Destination ----------------------------------------------------------------------------------------------------------------------------------------------------
+
+    def create_forwarding_profile_destination(
+        self,
+        folder: str | None = None,
+        name: str = None,
+        description: str | None = None,
+        fqdn: list[dict[str, Any]] | None = None,
+        ip_addresses: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Create or update a forwarding profile destination using smart upsert logic.
+
+        Args:
+            folder: Folder for the destination (must be 'Mobile Users'; sent as query param)
+            name: Name of the destination
+            description: Optional description
+            fqdn: FQDN entries ({name, port?})
+            ip_addresses: IP address entries ({name, port?})
+
+        Returns:
+            dict[str, Any]: The created/updated destination with __action__ field
+
+        """
+        folder = folder or "Mobile Users"
+        self.logger.info(f"Creating or updating forwarding profile destination: {name} in folder {folder}")
+
+        if not self.client:
+            result = {
+                "id": f"fpd-{name}",
+                "name": name,
+                "description": description,
+                "fqdn": fqdn,
+                "ip_addresses": ip_addresses,
+                "__action__": "created",
+            }
+            return {k: v for k, v in result.items() if v is not None}
+
+        try:
+            # Step 1: Try to fetch existing destination by name (SDK fetch raises a 404-style
+            # InvalidObjectError when missing, which lands in the generic handler below)
+            existing = None
+            try:
+                existing = self.client.forwarding_profile_destination.fetch(name=name, folder=folder)
+                self.logger.info(f"Found existing forwarding profile destination '{name}' in folder '{folder}'")
+            except NotFoundError:
+                self.logger.info(f"Forwarding profile destination '{name}' not found in folder '{folder}', will create new")
+            except Exception as fetch_error:
+                self.logger.info(f"Forwarding profile destination '{name}' lookup did not match ({fetch_error}), will create new")
+
+            if existing:
+                existing_dump = json.loads(existing.model_dump_json(exclude_unset=True))
+
+                # Step 2: Compare provided fields and update if needed
+                provided: dict[str, Any] = {}
+                if description is not None:
+                    provided["description"] = description
+                if fqdn is not None:
+                    provided["fqdn"] = fqdn
+                if ip_addresses is not None:
+                    provided["ip_addresses"] = ip_addresses
+
+                needs_update = any(existing_dump.get(field) != value for field, value in provided.items())
+
+                if needs_update:
+                    payload = {k: v for k, v in existing_dump.items() if k != "id"}
+                    payload.update(provided)
+                    result = self.client.forwarding_profile_destination.update(str(existing.id), payload)
+                    self.logger.info(f"Successfully updated forwarding profile destination '{name}' in folder '{folder}'")
+                    response = json.loads(result.model_dump_json(exclude_unset=True))
+                    response["__action__"] = "updated"
+                    return response
+                else:
+                    self.logger.info(f"No changes detected for forwarding profile destination '{name}', skipping update")
+                    response = existing_dump
+                    response["__action__"] = "no_change"
+                    return response
+            else:
+                # Step 3: Create new destination (folder goes as query param via the service)
+                destination_data: dict[str, Any] = {"name": name}
+                if description is not None:
+                    destination_data["description"] = description
+                if fqdn is not None:
+                    destination_data["fqdn"] = fqdn
+                if ip_addresses is not None:
+                    destination_data["ip_addresses"] = ip_addresses
+
+                result = self.client.forwarding_profile_destination.create(destination_data, folder=folder)
+                self.logger.info(f"Successfully created forwarding profile destination '{name}' in folder '{folder}'")
+                response = json.loads(result.model_dump_json(exclude_unset=True))
+                response["__action__"] = "created"
+                return response
+
+        except Exception as e:
+            self._handle_api_exception("create/update", folder, name or "", e)
+
+    def get_forwarding_profile_destination(
+        self,
+        folder: str | None = None,
+        name: str | None = None,
+        destination_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Get a forwarding profile destination by name (fetch) or UUID (direct get).
+
+        Args:
+            folder: Folder containing the destination (used with name)
+            name: Name of the destination
+            destination_id: UUID of the destination (takes precedence over name)
+
+        Returns:
+            dict[str, Any]: The destination object
+
+        """
+        folder = folder or "Mobile Users"
+        self.logger.info(f"Getting forwarding profile destination: {destination_id or name} from folder {folder}")
+
+        if not self.client:
+            return {
+                "id": destination_id or f"fpd-{name}",
+                "name": name or "mock-destination",
+                "description": f"Mock destination {name or destination_id}",
+                "fqdn": [{"name": "app.internal", "port": 443}],
+            }
+
+        try:
+            result = self.client.forwarding_profile_destination.get(destination_id) if destination_id else self.client.forwarding_profile_destination.fetch(name=name, folder=folder)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", folder, destination_id or name or "", e)
+
+    def list_forwarding_profile_destinations(
+        self,
+        folder: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List forwarding profile destinations.
+
+        Args:
+            folder: Folder to list from (must be 'Mobile Users')
+
+        Returns:
+            list[dict[str, Any]]: List of destination objects
+
+        """
+        folder = folder or "Mobile Users"
+        self.logger.info(f"Listing forwarding profile destinations in folder: {folder}")
+
+        if not self.client:
+            return [
+                {
+                    "id": "fpd-mock1",
+                    "name": "internal-apps",
+                    "fqdn": [{"name": "app.internal", "port": 443}],
+                },
+                {
+                    "id": "fpd-mock2",
+                    "name": "corp-ranges",
+                    "ip_addresses": [{"name": "10.0.0.0/8"}],
+                },
+            ]
+
+        try:
+            results = self.client.forwarding_profile_destination.list(folder=folder)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder, "forwarding profile destinations", e)
+
+    def delete_forwarding_profile_destination(
+        self,
+        folder: str | None = None,
+        name: str | None = None,
+        destination_id: str | None = None,
+    ) -> bool:
+        """Delete a forwarding profile destination by name or UUID.
+
+        Args:
+            folder: Folder containing the destination (used with name)
+            name: Name of the destination to delete
+            destination_id: UUID of the destination (takes precedence over name)
+
+        Returns:
+            bool: True if deletion was successful
+
+        """
+        folder = folder or "Mobile Users"
+        self.logger.info(f"Deleting forwarding profile destination: {destination_id or name} from folder {folder}")
+
+        if not self.client:
+            return True
+
+        try:
+            if not destination_id:
+                destination = self.client.forwarding_profile_destination.fetch(name=name, folder=folder)
+                destination_id = str(destination.id)
+            self.client.forwarding_profile_destination.delete(destination_id)
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", folder, destination_id or name or "", e)
+
 
 class LazyClient:
     """Lazy wrapper for SCMClient that delays initialization until first use."""

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -4918,3 +4918,133 @@ class BpaStatusResponse(BaseModel):
         if v not in allowed:
             raise ValueError(f"status must be one of {allowed}, got '{v}'")
         return v
+
+
+# =============================================================================================================================================================================================
+# GLOBALPROTECT FORWARDING PROFILE MODELS (mobile-agent, SDK 0.15.0)
+# =============================================================================================================================================================================================
+
+_FORWARDING_PROFILE_TYPE_KEYS = {"pac_file", "global_protect_proxy", "ztna_agent"}
+_FORWARDING_PROFILE_DEFINITION_METHODS = {"rules", "pac-file"}
+
+
+class ForwardingProfile(BaseModel):
+    """Model for GlobalProtect forwarding profile configurations.
+
+    Forwarding profiles are folder-scoped to "Mobile Users" only; the SDK sends the
+    folder as a query parameter rather than in the request body.
+    """
+
+    name: str = Field(..., max_length=64, pattern=r"^[0-9a-zA-Z._-]+$", description="Name of the forwarding profile")
+    folder: str | None = Field(None, description="Folder path (must be 'Mobile Users')")
+    description: str | None = Field(None, max_length=1023, description="Description of the forwarding profile")
+    definition_method: str | None = Field(None, description="How the profile is defined (rules or pac-file)")
+    type: dict[str, Any] | None = Field(None, description="Profile type configuration (pac_file, global_protect_proxy, or ztna_agent)")
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "ForwardingProfile":
+        """Validate that a folder is provided (only supported container)."""
+        if not self.folder:
+            raise ValueError("folder must be provided (forwarding profiles only support the 'Mobile Users' folder)")
+        return self
+
+    @field_validator("definition_method")
+    @classmethod
+    def validate_definition_method(cls, v: str | None) -> str | None:
+        """Validate definition_method value."""
+        if v is not None and v not in _FORWARDING_PROFILE_DEFINITION_METHODS:
+            raise ValueError(f"definition_method must be one of: {', '.join(sorted(_FORWARDING_PROFILE_DEFINITION_METHODS))}")
+        return v
+
+    @field_validator("type")
+    @classmethod
+    def validate_type(cls, v: dict[str, Any] | None) -> dict[str, Any] | None:
+        """Validate the profile type wrapper has exactly one known key."""
+        if v is not None:
+            keys = set(v.keys())
+            if len(keys) != 1 or not keys.issubset(_FORWARDING_PROFILE_TYPE_KEYS):
+                raise ValueError(f"type must contain exactly one of: {', '.join(sorted(_FORWARDING_PROFILE_TYPE_KEYS))}")
+        return v
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "name": self.name,
+        }
+        if self.folder:
+            model_data["folder"] = self.folder
+        if self.description is not None:
+            model_data["description"] = self.description
+        if self.definition_method is not None:
+            model_data["definition_method"] = self.definition_method
+        if self.type is not None:
+            model_data["type"] = self.type
+        return model_data
+
+
+def _parse_destination_entries(entries: Any) -> list[dict[str, Any]] | None:
+    """Normalize destination entries to [{name, port?}] dicts.
+
+    Accepts plain strings ("host" or "host:port") from CLI flags and dicts from YAML.
+    """
+    if entries is None:
+        return None
+    parsed: list[dict[str, Any]] = []
+    for entry in entries:
+        if isinstance(entry, dict):
+            parsed.append(dict(entry))
+            continue
+        if not isinstance(entry, str):
+            raise ValueError(f"destination entry must be a string or mapping, got {type(entry).__name__}")
+        name, sep, port = entry.rpartition(":")
+        if sep and port.isdigit():
+            parsed.append({"name": name, "port": int(port)})
+        else:
+            parsed.append({"name": entry})
+    for item in parsed:
+        port_value = item.get("port")
+        if port_value is not None and not (1 <= int(port_value) <= 65535):
+            raise ValueError(f"port must be between 1 and 65535, got {port_value}")
+    return parsed
+
+
+class ForwardingProfileDestination(BaseModel):
+    """Model for GlobalProtect forwarding profile destination configurations.
+
+    Destinations are folder-scoped to "Mobile Users" only; the SDK sends the folder
+    as a query parameter rather than in the request body.
+    """
+
+    name: str = Field(..., max_length=64, pattern=r"^[0-9a-zA-Z._-]+$", description="Name of the destination")
+    folder: str | None = Field(None, description="Folder path (must be 'Mobile Users')")
+    description: str | None = Field(None, max_length=1023, description="Description of the destination")
+    fqdn: list[dict[str, Any]] | None = Field(None, description="FQDN entries ({name, port?})")
+    ip_addresses: list[dict[str, Any]] | None = Field(None, description="IP address entries ({name, port?})")
+
+    @field_validator("fqdn", "ip_addresses", mode="before")
+    @classmethod
+    def parse_entries(cls, v: Any) -> list[dict[str, Any]] | None:
+        """Parse string ('host[:port]') or dict entries into {name, port?} dicts."""
+        return _parse_destination_entries(v)
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "ForwardingProfileDestination":
+        """Validate that a folder is provided (only supported container)."""
+        if not self.folder:
+            raise ValueError("folder must be provided (forwarding profile destinations only support the 'Mobile Users' folder)")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format."""
+        model_data: dict[str, Any] = {
+            "name": self.name,
+        }
+        if self.folder:
+            model_data["folder"] = self.folder
+        if self.description is not None:
+            model_data["description"] = self.description
+        if self.fqdn is not None:
+            model_data["fqdn"] = self.fqdn
+        if self.ip_addresses is not None:
+            model_data["ip_addresses"] = self.ip_addresses
+        return model_data

--- a/tests/test_mobile_agent_forwarding_commands.py
+++ b/tests/test_mobile_agent_forwarding_commands.py
@@ -1,0 +1,802 @@
+"""Tests for the mobile agent forwarding profile and destination commands."""
+
+import pytest
+import typer  # noqa: I001
+from pydantic import ValidationError
+
+from scm_cli.commands.mobile_agent import (
+    backup_forwarding_profile,
+    backup_forwarding_profile_destination,
+    delete_forwarding_profile,
+    delete_forwarding_profile_destination,
+    load_forwarding_profile,
+    load_forwarding_profile_destination,
+    set_forwarding_profile,
+    set_forwarding_profile_destination,
+    show_forwarding_profile,
+    show_forwarding_profile_destination,
+)
+from scm_cli.utils.validators import ForwardingProfile, ForwardingProfileDestination
+
+# =============================================================================================================================================================================================
+# VALIDATOR TESTS
+# =============================================================================================================================================================================================
+
+
+class TestForwardingProfileValidator:
+    """Test the ForwardingProfile validator model."""
+
+    def test_requires_folder(self):
+        """Test that a missing folder raises a validation error."""
+        with pytest.raises(ValidationError):
+            ForwardingProfile(name="profile1")
+
+    def test_invalid_definition_method(self):
+        """Test that an invalid definition method is rejected."""
+        with pytest.raises(ValidationError):
+            ForwardingProfile(name="profile1", folder="Mobile Users", definition_method="bogus")
+
+    def test_invalid_type_key(self):
+        """Test that an unknown profile type key is rejected."""
+        with pytest.raises(ValidationError):
+            ForwardingProfile(name="profile1", folder="Mobile Users", type={"bogus_type": {}})
+
+    def test_multiple_type_keys_rejected(self):
+        """Test that more than one profile type key is rejected."""
+        with pytest.raises(ValidationError):
+            ForwardingProfile(
+                name="profile1",
+                folder="Mobile Users",
+                type={"pac_file": {}, "ztna_agent": {}},
+            )
+
+    def test_to_sdk_model(self):
+        """Test conversion to SDK model format."""
+        profile = ForwardingProfile(
+            name="ztna-profile",
+            folder="Mobile Users",
+            description="ZTNA profile",
+            definition_method="rules",
+            type={"ztna_agent": {"pac_upload": False}},
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["name"] == "ztna-profile"
+        assert sdk_data["folder"] == "Mobile Users"
+        assert sdk_data["description"] == "ZTNA profile"
+        assert sdk_data["definition_method"] == "rules"
+        assert sdk_data["type"] == {"ztna_agent": {"pac_upload": False}}
+
+    def test_rules_and_block_rule_pass_through(self):
+        """Test that nested forwarding rules and block rule validate."""
+        profile = ForwardingProfile(
+            name="pac-profile",
+            folder="Mobile Users",
+            type={
+                "pac_file": {
+                    "pac_upload": True,
+                    "forwarding_rules": [
+                        {"name": "rule1", "enabled": True, "connectivity": "direct"},
+                    ],
+                    "block_rule": {"enable": True},
+                }
+            },
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["type"]["pac_file"]["forwarding_rules"][0]["name"] == "rule1"
+
+
+class TestForwardingProfileDestinationValidator:
+    """Test the ForwardingProfileDestination validator model."""
+
+    def test_requires_folder(self):
+        """Test that a missing folder raises a validation error."""
+        with pytest.raises(ValidationError):
+            ForwardingProfileDestination(name="dest1")
+
+    def test_fqdn_string_with_port_parsed(self):
+        """Test that 'host:port' fqdn strings are parsed into entries."""
+        dest = ForwardingProfileDestination(
+            name="dest1",
+            folder="Mobile Users",
+            fqdn=["*.example.com:8080", "app.internal"],
+        )
+        sdk_data = dest.to_sdk_model()
+        assert sdk_data["fqdn"] == [
+            {"name": "*.example.com", "port": 8080},
+            {"name": "app.internal"},
+        ]
+
+    def test_ip_string_with_port_parsed(self):
+        """Test that 'ip:port' strings are parsed into entries."""
+        dest = ForwardingProfileDestination(
+            name="dest1",
+            folder="Mobile Users",
+            ip_addresses=["10.0.0.0/8", "192.168.1.1:443"],
+        )
+        sdk_data = dest.to_sdk_model()
+        assert sdk_data["ip_addresses"] == [
+            {"name": "10.0.0.0/8"},
+            {"name": "192.168.1.1", "port": 443},
+        ]
+
+    def test_fqdn_dict_entries_accepted(self):
+        """Test that dict-style fqdn entries (YAML load path) are accepted."""
+        dest = ForwardingProfileDestination(
+            name="dest1",
+            folder="Mobile Users",
+            fqdn=[{"name": "app.example.com", "port": 443}],
+        )
+        sdk_data = dest.to_sdk_model()
+        assert sdk_data["fqdn"] == [{"name": "app.example.com", "port": 443}]
+
+    def test_invalid_port_rejected(self):
+        """Test that an out-of-range port is rejected."""
+        with pytest.raises(ValidationError):
+            ForwardingProfileDestination(
+                name="dest1",
+                folder="Mobile Users",
+                fqdn=["app.example.com:99999"],
+            )
+
+
+# =============================================================================================================================================================================================
+# FORWARDING PROFILE COMMAND TESTS
+# =============================================================================================================================================================================================
+
+
+class TestForwardingProfileCommands:
+    """Test the forwarding profile commands."""
+
+    def test_set_forwarding_profile(self, runner, monkeypatch):
+        """Test creating a forwarding profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "name": kwargs.get("name"),
+                "definition_method": kwargs.get("definition_method"),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder", "Mobile Users",
+                "--name", "ztna-profile",
+                "--profile-type", "ztna-agent",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created forwarding profile" in result.stdout
+        assert "ztna-profile" in result.stdout
+
+    def test_set_forwarding_profile_builds_type_skeleton(self, runner, monkeypatch):
+        """Test that --profile-type builds the correct type wrapper."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured = {}
+
+        def mock_create(*args, **kwargs):
+            captured.update(kwargs)
+            return {"name": kwargs.get("name"), "__action__": "created"}
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder", "Mobile Users",
+                "--name", "proxy-profile",
+                "--profile-type", "global-protect-proxy",
+                "--pac-upload",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert captured["type"] == {"global_protect_proxy": {"pac_upload": True}}
+
+    def test_set_forwarding_profile_updated(self, runner, monkeypatch):
+        """Test updating a forwarding profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {"name": kwargs.get("name"), "__action__": "updated"}
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "ztna-profile"],
+        )
+
+        assert result.exit_code == 0
+        assert "Updated forwarding profile" in result.stdout
+
+    def test_set_forwarding_profile_no_change(self, runner, monkeypatch):
+        """Test set forwarding profile with no changes."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {"name": kwargs.get("name"), "__action__": "no_change"}
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "ztna-profile"],
+        )
+
+        assert result.exit_code == 0
+        assert "No changes needed" in result.stdout
+
+    def test_set_forwarding_profile_missing_folder(self, runner, monkeypatch):
+        """Test that a missing folder fails container validation."""
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile)
+
+        result = runner.invoke(test_app, ["--name", "ztna-profile"])
+
+        assert result.exit_code == 1
+
+    def test_set_forwarding_profile_error(self, runner, monkeypatch):
+        """Test set forwarding profile with an API error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "fail-profile"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_show_forwarding_profile_list(self, runner, monkeypatch):
+        """Test listing forwarding profiles."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "name": "ztna-profile",
+                    "definition_method": "rules",
+                },
+                {
+                    "id": "22222222-2222-2222-2222-222222222222",
+                    "name": "pac-profile",
+                    "definition_method": "pac-file",
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_forwarding_profiles", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "ztna-profile" in result.stdout
+        assert "pac-profile" in result.stdout
+
+    def test_show_forwarding_profile_by_name(self, runner, monkeypatch):
+        """Test showing a forwarding profile by name."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "name": "ztna-profile",
+                "description": "ZTNA profile",
+                "definition_method": "rules",
+                "type": {"ztna_agent": {"pac_upload": False}},
+            }
+
+        monkeypatch.setattr(scm_client, "get_forwarding_profile", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "ztna-profile"],
+        )
+
+        assert result.exit_code == 0
+        assert "ztna-profile" in result.stdout
+        assert "ztna_agent" in result.stdout
+
+    def test_show_forwarding_profile_by_id(self, runner, monkeypatch):
+        """Test showing a forwarding profile by UUID."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured = {}
+
+        def mock_get(*args, **kwargs):
+            captured.update(kwargs)
+            return {
+                "id": "11111111-1111-1111-1111-111111111111",
+                "name": "ztna-profile",
+            }
+
+        monkeypatch.setattr(scm_client, "get_forwarding_profile", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--id", "11111111-1111-1111-1111-111111111111"],
+        )
+
+        assert result.exit_code == 0
+        assert captured["profile_id"] == "11111111-1111-1111-1111-111111111111"
+        assert "ztna-profile" in result.stdout
+
+    def test_show_forwarding_profile_empty(self, runner, monkeypatch):
+        """Test listing forwarding profiles when none exist."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(scm_client, "list_forwarding_profiles", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "No forwarding profiles found" in result.stdout
+
+    def test_show_forwarding_profile_error(self, runner, monkeypatch):
+        """Test showing forwarding profiles with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(scm_client, "list_forwarding_profiles", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 1
+
+    def test_delete_forwarding_profile(self, runner, monkeypatch):
+        """Test deleting a forwarding profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "delete_forwarding_profile", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "ztna-profile", "--force"],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted forwarding profile" in result.stdout
+
+    def test_delete_forwarding_profile_error(self, runner, monkeypatch):
+        """Test deleting a forwarding profile with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("Not found")
+
+        monkeypatch.setattr(scm_client, "delete_forwarding_profile", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_forwarding_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "nonexistent", "--force"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_load_forwarding_profile(self, runner, monkeypatch, tmp_path):
+        """Test loading forwarding profiles from YAML."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_content = """
+forwarding_profiles:
+  - name: ztna-profile
+    folder: "Mobile Users"
+    definition_method: rules
+    type:
+      ztna_agent:
+        pac_upload: false
+        forwarding_rules:
+          - name: rule1
+            traffic_type: dns
+        block_rule:
+          block_all_other_unmatched_outbound_connections: true
+  - name: pac-profile
+    folder: "Mobile Users"
+    definition_method: pac-file
+    type:
+      pac_file:
+        pac_upload: true
+"""
+        test_file = tmp_path / "forwarding_profiles.yml"
+        test_file.write_text(yaml_content)
+
+        def mock_create(*args, **kwargs):
+            return {"name": kwargs.get("name"), "__action__": "created"}
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_forwarding_profile)
+
+        result = runner.invoke(test_app, ["--file", str(test_file)])
+
+        assert result.exit_code == 0
+        assert "Created forwarding profile" in result.stdout
+        assert "2 created" in result.stdout
+
+    def test_load_forwarding_profile_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test loading forwarding profiles in dry run mode."""
+        yaml_content = """
+forwarding_profiles:
+  - name: ztna-profile
+    folder: "Mobile Users"
+"""
+        test_file = tmp_path / "forwarding_profiles.yml"
+        test_file.write_text(yaml_content)
+
+        test_app = typer.Typer()
+        test_app.command()(load_forwarding_profile)
+
+        result = runner.invoke(test_app, ["--file", str(test_file), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+    def test_backup_forwarding_profile(self, runner, monkeypatch, tmp_path):
+        """Test backing up forwarding profiles."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "11111111-1111-1111-1111-111111111111",
+                    "name": "ztna-profile",
+                    "definition_method": "rules",
+                    "type": {"ztna_agent": {"pac_upload": False}},
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_forwarding_profiles", mock_list)
+        monkeypatch.chdir(tmp_path)
+
+        test_app = typer.Typer()
+        test_app.command()(backup_forwarding_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "Successfully backed up" in result.stdout
+        assert "1 forwarding profiles" in result.stdout
+
+
+# =============================================================================================================================================================================================
+# FORWARDING PROFILE DESTINATION COMMAND TESTS
+# =============================================================================================================================================================================================
+
+
+class TestForwardingProfileDestinationCommands:
+    """Test the forwarding profile destination commands."""
+
+    def test_set_forwarding_profile_destination(self, runner, monkeypatch):
+        """Test creating a forwarding profile destination."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured = {}
+
+        def mock_create(*args, **kwargs):
+            captured.update(kwargs)
+            return {
+                "id": "33333333-3333-3333-3333-333333333333",
+                "name": kwargs.get("name"),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile_destination", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile_destination)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder", "Mobile Users",
+                "--name", "internal-apps",
+                "--fqdn", "*.example.com:8080",
+                "--fqdn", "app.internal",
+                "--ip-address", "10.0.0.0/8",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created forwarding profile destination" in result.stdout
+        assert captured["fqdn"] == [
+            {"name": "*.example.com", "port": 8080},
+            {"name": "app.internal"},
+        ]
+        assert captured["ip_addresses"] == [{"name": "10.0.0.0/8"}]
+
+    def test_set_forwarding_profile_destination_missing_folder(self, runner):
+        """Test that a missing folder fails container validation."""
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile_destination)
+
+        result = runner.invoke(test_app, ["--name", "internal-apps"])
+
+        assert result.exit_code == 1
+
+    def test_set_forwarding_profile_destination_error(self, runner, monkeypatch):
+        """Test set destination with an API error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile_destination", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_forwarding_profile_destination)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "fail-dest"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_show_forwarding_profile_destination_list(self, runner, monkeypatch):
+        """Test listing forwarding profile destinations."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "33333333-3333-3333-3333-333333333333",
+                    "name": "internal-apps",
+                    "fqdn": [{"name": "app.internal"}],
+                },
+                {
+                    "id": "44444444-4444-4444-4444-444444444444",
+                    "name": "corp-ranges",
+                    "ip_addresses": [{"name": "10.0.0.0/8"}],
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_forwarding_profile_destinations", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile_destination)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "internal-apps" in result.stdout
+        assert "corp-ranges" in result.stdout
+
+    def test_show_forwarding_profile_destination_by_name(self, runner, monkeypatch):
+        """Test showing a forwarding profile destination by name."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "33333333-3333-3333-3333-333333333333",
+                "name": "internal-apps",
+                "description": "Internal applications",
+                "fqdn": [{"name": "app.internal", "port": 443}],
+            }
+
+        monkeypatch.setattr(scm_client, "get_forwarding_profile_destination", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile_destination)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "internal-apps"],
+        )
+
+        assert result.exit_code == 0
+        assert "internal-apps" in result.stdout
+        assert "app.internal" in result.stdout
+
+    def test_show_forwarding_profile_destination_by_id(self, runner, monkeypatch):
+        """Test showing a forwarding profile destination by UUID."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured = {}
+
+        def mock_get(*args, **kwargs):
+            captured.update(kwargs)
+            return {
+                "id": "33333333-3333-3333-3333-333333333333",
+                "name": "internal-apps",
+            }
+
+        monkeypatch.setattr(scm_client, "get_forwarding_profile_destination", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile_destination)
+
+        result = runner.invoke(
+            test_app,
+            ["--id", "33333333-3333-3333-3333-333333333333"],
+        )
+
+        assert result.exit_code == 0
+        assert captured["destination_id"] == "33333333-3333-3333-3333-333333333333"
+
+    def test_show_forwarding_profile_destination_empty(self, runner, monkeypatch):
+        """Test listing destinations when none exist."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(scm_client, "list_forwarding_profile_destinations", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_forwarding_profile_destination)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "No forwarding profile destinations found" in result.stdout
+
+    def test_delete_forwarding_profile_destination(self, runner, monkeypatch):
+        """Test deleting a forwarding profile destination."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "delete_forwarding_profile_destination", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_forwarding_profile_destination)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "internal-apps", "--force"],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted forwarding profile destination" in result.stdout
+
+    def test_delete_forwarding_profile_destination_error(self, runner, monkeypatch):
+        """Test deleting a destination with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("Not found")
+
+        monkeypatch.setattr(scm_client, "delete_forwarding_profile_destination", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_forwarding_profile_destination)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "nonexistent", "--force"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_load_forwarding_profile_destination(self, runner, monkeypatch, tmp_path):
+        """Test loading forwarding profile destinations from YAML."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_content = """
+forwarding_profile_destinations:
+  - name: internal-apps
+    folder: "Mobile Users"
+    fqdn:
+      - name: app.internal
+        port: 443
+  - name: corp-ranges
+    folder: "Mobile Users"
+    ip_addresses:
+      - name: 10.0.0.0/8
+"""
+        test_file = tmp_path / "destinations.yml"
+        test_file.write_text(yaml_content)
+
+        def mock_create(*args, **kwargs):
+            return {"name": kwargs.get("name"), "__action__": "created"}
+
+        monkeypatch.setattr(scm_client, "create_forwarding_profile_destination", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_forwarding_profile_destination)
+
+        result = runner.invoke(test_app, ["--file", str(test_file)])
+
+        assert result.exit_code == 0
+        assert "Created forwarding profile destination" in result.stdout
+        assert "2 created" in result.stdout
+
+    def test_load_forwarding_profile_destination_dry_run(self, runner, tmp_path):
+        """Test loading destinations in dry run mode."""
+        yaml_content = """
+forwarding_profile_destinations:
+  - name: internal-apps
+    folder: "Mobile Users"
+"""
+        test_file = tmp_path / "destinations.yml"
+        test_file.write_text(yaml_content)
+
+        test_app = typer.Typer()
+        test_app.command()(load_forwarding_profile_destination)
+
+        result = runner.invoke(test_app, ["--file", str(test_file), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+    def test_backup_forwarding_profile_destination(self, runner, monkeypatch, tmp_path):
+        """Test backing up forwarding profile destinations."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "33333333-3333-3333-3333-333333333333",
+                    "name": "internal-apps",
+                    "fqdn": [{"name": "app.internal"}],
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_forwarding_profile_destinations", mock_list)
+        monkeypatch.chdir(tmp_path)
+
+        test_app = typer.Typer()
+        test_app.command()(backup_forwarding_profile_destination)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "Successfully backed up" in result.stdout
+        assert "1 forwarding profile destinations" in result.stdout


### PR DESCRIPTION
## What

CLI coverage for two of the nine new GlobalProtect mobile-agent services in pan-scm-sdk 0.15.0:

- `scm set|show|delete|backup|load mobile-agent forwarding-profile`
- `scm set|show|delete|backup|load mobile-agent forwarding-profile-destination`

## Why

Part of the SDK 0.15.0 adoption (follows #224). Agent4 scope per orchestration plan.

## Details

- **Validators** (`validators.py`, appended block): `ForwardingProfile` (definition-method + single-key type wrapper validation: `pac_file` / `global_protect_proxy` / `ztna_agent`), `ForwardingProfileDestination` (`host[:port]` string parsing for FQDN/IP entries, port range check). Folder-only container — these services support only the `Mobile Users` folder.
- **SDK wrappers** (`sdk_client.py`, appended block): create (smart upsert), get, list, delete per service. These services are UUID-addressed: `update(uuid, data)` / `delete(uuid)` / `get(uuid)`; wrappers resolve `--name` via `fetch()` and also accept `--id` directly. Fetch-miss raises a 404-style `InvalidObjectError` (not `NotFoundError`) — upsert handles both.
- **Commands** (`mobile_agent.py`, appended sections): scalars via flags; full forwarding/block rules via `load` YAML (documented).
- **Tests**: new file `tests/test_mobile_agent_forwarding_commands.py` (39 tests — validators, set created/updated/no_change/error, container-validation error, show list/by-name/by-id/empty/error, delete, load, dry-run, backup).
- **Docs**: `docs/cli/mobile-agent/forwarding-profile{,-destination}.md` + 2 mkdocs nav lines.

Shared files touched append-only per orchestration boundary rules.

## Validation

- `make quality` green (lint, format, mypy, pytest — 996 passed)
- Full `pytest`: 1014 passed, 29 skipped
- Smoke: `poetry run scm show mobile-agent forwarding-profile --help` and `set ... forwarding-profile-destination --help` render

🤖 Generated with [Claude Code](https://claude.com/claude-code)