### PR TITLE
feat: mobile-agent infrastructure-setting + global-setting commands (SDK 0.15.0)

### DIFF
--- a/docs/cli/mobile-agent/global-setting.md
+++ b/docs/cli/mobile-agent/global-setting.md
@@ -1,0 +1,66 @@
+# Global Setting
+
+Global settings are the tenant-wide GlobalProtect configuration singleton in Strata Cloud Manager — the agent version and manual gateway regions. The `scm` CLI provides commands to show and update them.
+
+## Overview
+
+The `global-setting` commands allow you to:
+
+- Show the current GlobalProtect global settings
+- Update the agent version and manual gateway configuration
+
+!!! note "Singleton semantics"
+    Global settings always exist for the tenant and are updated in place. There are no `delete`, `backup`, or `load` commands, and no `--folder` or `--name` options.
+
+## Show Global Setting
+
+Display the current GlobalProtect global settings.
+
+### Syntax
+
+```bash
+scm show mobile-agent global-setting
+```
+
+### Examples
+
+```bash
+$ scm show mobile-agent global-setting
+
+GlobalProtect Global Settings
+================================================================================
+Agent Version: 6.2.0
+Manual Gateway: {region: [{name: americas, locations: [us-east-1]}]}
+```
+
+## Set Global Setting
+
+Update the GlobalProtect global settings. At least one option is required.
+
+### Syntax
+
+```bash
+scm set mobile-agent global-setting [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--agent-version TEXT` | GlobalProtect agent version | No* |
+| `--manual-gateway JSON` | Manual gateway configuration as JSON | No* |
+
+*At least one of the two options must be provided.
+
+### Examples
+
+```bash
+$ scm set mobile-agent global-setting --agent-version "6.2.0"
+Updated GlobalProtect global settings
+```
+
+```bash
+$ scm set mobile-agent global-setting \
+    --manual-gateway '{"region": [{"name": "americas", "locations": ["us-east-1"]}]}'
+Updated GlobalProtect global settings
+```

--- a/docs/cli/mobile-agent/infrastructure-setting.md
+++ b/docs/cli/mobile-agent/infrastructure-setting.md
@@ -1,0 +1,169 @@
+# Infrastructure Setting
+
+Infrastructure settings configure the GlobalProtect mobile users environment in Strata Cloud Manager — DNS servers, IP pools, the portal hostname, WINS, IPv6, and UDP query behavior. The `scm` CLI provides commands to create, update, delete, show, back up, and load infrastructure settings.
+
+## Overview
+
+The `infrastructure-setting` commands allow you to:
+
+- Create or update infrastructure settings with DNS servers, IP pools, and a portal hostname
+- Show a named infrastructure setting
+- Delete infrastructure settings
+- Back up a named infrastructure setting to YAML
+- Bulk import infrastructure settings from YAML files
+
+!!! note "Folder constraint"
+    Infrastructure settings live only in the `Mobile Users` folder. The `--folder` option defaults to `Mobile Users` and any other value is rejected.
+
+!!! note "Name required for show and backup"
+    The SCM API addresses this resource by name everywhere, including list. There is no list-all mode, so `show` and `backup` require `--name`.
+
+## Set Infrastructure Setting
+
+Create or update an infrastructure setting.
+
+### Syntax
+
+```bash
+scm set mobile-agent infrastructure-setting [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--name TEXT` | Name of the infrastructure setting | Yes |
+| `--folder TEXT` | Folder location (must be `Mobile Users`, the default) | No |
+| `--dns-servers JSON` | DNS server entries as a JSON list | Yes |
+| `--ip-pools JSON` | IP pools as a JSON list | Yes |
+| `--portal-hostname JSON` | Portal hostname configuration as JSON | Yes |
+| `--enable-wins JSON` | WINS configuration as JSON | No |
+| `--ipv6 / --no-ipv6` | Enable or disable IPv6 | No |
+| `--udp-queries JSON` | UDP query retry configuration as JSON | No |
+| `--static-ip-pools JSON` | Static IP pools as a JSON list | No |
+
+### Examples
+
+```bash
+$ scm set mobile-agent infrastructure-setting \
+    --name "gp-infra" \
+    --dns-servers '[{"name": "dns-1", "dns_suffix": ["example.com"], "primary_public_dns": {"dns_server": "8.8.8.8"}}]' \
+    --ip-pools '[{"name": "pool-1", "ip_pool": ["10.0.0.0/16"]}]' \
+    --portal-hostname '{"default_domain": {"hostname": "acme"}}'
+Created infrastructure setting: gp-infra in folder Mobile Users
+```
+
+```bash
+$ scm set mobile-agent infrastructure-setting \
+    --name "gp-infra" \
+    --dns-servers '[{"name": "dns-1", "dns_suffix": ["example.com"]}]' \
+    --ip-pools '[{"name": "pool-1", "ip_pool": ["10.0.0.0/16"]}]' \
+    --portal-hostname '{"custom_domain": {"hostname": "vpn.acme.com", "cname": "acme.gpcloudservice.com", "ssl_tls_service_profile": "acme-profile"}}' \
+    --ipv6 \
+    --udp-queries '{"retries": {"attempts": 5, "interval": 2}}'
+Updated infrastructure setting: gp-infra in folder Mobile Users
+```
+
+## Show Infrastructure Setting
+
+Display a named infrastructure setting.
+
+### Syntax
+
+```bash
+scm show mobile-agent infrastructure-setting --name NAME
+```
+
+### Examples
+
+```bash
+$ scm show mobile-agent infrastructure-setting --name "gp-infra"
+
+Infrastructure Setting: gp-infra
+================================================================================
+Location: Folder 'Mobile Users'
+Portal Hostname: {default_domain: {hostname: acme}}
+DNS Servers: [{name: dns-1, dns_suffix: [example.com]}]
+IP Pools: [{name: pool-1, ip_pool: [10.0.0.0/16]}]
+```
+
+## Delete Infrastructure Setting
+
+Delete an infrastructure setting.
+
+### Syntax
+
+```bash
+scm delete mobile-agent infrastructure-setting --name NAME [--force]
+```
+
+### Examples
+
+```bash
+$ scm delete mobile-agent infrastructure-setting --name "gp-infra" --force
+Deleted infrastructure setting: gp-infra from folder Mobile Users
+```
+
+## Backup Infrastructure Setting
+
+Back up a named infrastructure setting to a YAML file.
+
+### Syntax
+
+```bash
+scm backup mobile-agent infrastructure-setting --name NAME [--file FILE]
+```
+
+### Examples
+
+```bash
+$ scm backup mobile-agent infrastructure-setting --name "gp-infra"
+Successfully backed up 1 infrastructure settings to infrastructure-setting-mobile-users.yaml
+```
+
+## Load Infrastructure Setting
+
+Load infrastructure settings from a YAML file.
+
+### Syntax
+
+```bash
+scm load mobile-agent infrastructure-setting --file FILE [--dry-run] [--folder FOLDER]
+```
+
+### YAML Format
+
+```yaml
+infrastructure_settings:
+  - name: gp-infra
+    folder: "Mobile Users"
+    dns_servers:
+      - name: dns-1
+        dns_suffix:
+          - example.com
+        primary_public_dns:
+          dns_server: 8.8.8.8
+    ip_pools:
+      - name: pool-1
+        ip_pool:
+          - 10.0.0.0/16
+    portal_hostname:
+      default_domain:
+        hostname: acme
+    ipv6: false
+```
+
+### Examples
+
+```bash
+$ scm load mobile-agent infrastructure-setting --file infrastructure_settings.yml
+Created infrastructure setting: gp-infra
+
+Summary: 1 created, 0 updated, 0 unchanged
+```
+
+```bash
+$ scm load mobile-agent infrastructure-setting --file infrastructure_settings.yml --dry-run
+Dry run mode: would apply the following configurations:
+...
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -164,6 +164,8 @@ nav:
           - Forwarding Profile: cli/mobile-agent/forwarding-profile.md
           - Forwarding Profile Destination: cli/mobile-agent/forwarding-profile-destination.md
           - Tunnel Profile: cli/mobile-agent/tunnel-profile.md
+          - Global Setting: cli/mobile-agent/global-setting.md
+          - Infrastructure Setting: cli/mobile-agent/infrastructure-setting.md
           - SDK Reference: cli/mobile-agent/sdk-mobile-agent.md
       - Local Config:
           - Overview: cli/local/index.md

--- a/src/scm_cli/commands/mobile_agent.py
+++ b/src/scm_cli/commands/mobile_agent.py
@@ -15,7 +15,7 @@ from ..utils import validate_location_params
 from ..utils.config import load_from_yaml, settings
 from ..utils.context import get_current_context
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AgentProfile, AuthSetting, ForwardingProfile, ForwardingProfileDestination, TunnelProfile
+from ..utils.validators import AgentProfile, AuthSetting, ForwardingProfile, ForwardingProfileDestination, GlobalSetting, InfrastructureSetting, TunnelProfile
 
 # =============================================================================================================================================================================================
 # HELPER FUNCTIONS
@@ -1777,4 +1777,357 @@ def show_tunnel_profile(
 
     except Exception as e:
         typer.echo(f"Error showing tunnel profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# =============================================================================================================================================================================================
+# INFRASTRUCTURE SETTING COMMANDS
+# =============================================================================================================================================================================================
+
+# Infrastructure settings live only in the 'Mobile Users' folder, and the SCM
+# API addresses them by name everywhere (including list), so show/backup need --name.
+INFRA_FOLDER_OPTION = typer.Option(
+    "Mobile Users",
+    "--folder",
+    help="Folder path (must be 'Mobile Users')",
+)
+INFRA_NAME_OPTION = typer.Option(
+    ...,
+    "--name",
+    help="Name of the infrastructure setting",
+)
+
+
+@set_app.command("infrastructure-setting")
+def set_infrastructure_setting(
+    folder: str = INFRA_FOLDER_OPTION,
+    name: str = INFRA_NAME_OPTION,
+    dns_servers: str = typer.Option(..., "--dns-servers", help="DNS server entries as JSON list"),
+    ip_pools: str = typer.Option(..., "--ip-pools", help="IP pools as JSON list"),
+    portal_hostname: str = typer.Option(..., "--portal-hostname", help="Portal hostname configuration as JSON"),
+    enable_wins: str | None = typer.Option(None, "--enable-wins", help="WINS configuration as JSON"),
+    ipv6: bool | None = typer.Option(None, "--ipv6/--no-ipv6", help="Enable or disable IPv6"),
+    udp_queries: str | None = typer.Option(None, "--udp-queries", help="UDP query retry configuration as JSON"),
+    static_ip_pools: str | None = typer.Option(None, "--static-ip-pools", help="Static IP pools as JSON list"),
+):
+    r"""Create or update an infrastructure setting.
+
+    Examples
+    --------
+        scm set mobile-agent infrastructure-setting \
+        --name "gp-infra" \
+        --dns-servers '[{"name": "dns-1", "dns_suffix": ["example.com"]}]' \
+        --ip-pools '[{"name": "pool-1", "ip_pool": ["10.0.0.0/16"]}]' \
+        --portal-hostname '{"default_domain": {"hostname": "acme"}}'
+
+    """
+    try:
+        # Build setting data; the Pydantic model parses JSON strings into structures
+        setting_data: dict[str, Any] = {
+            "name": name,
+            "folder": folder,
+            "dns_servers": dns_servers,
+            "ip_pools": ip_pools,
+            "portal_hostname": portal_hostname,
+        }
+        if enable_wins is not None:
+            setting_data["enable_wins"] = enable_wins
+        if ipv6 is not None:
+            setting_data["ipv6"] = ipv6
+        if udp_queries is not None:
+            setting_data["udp_queries"] = udp_queries
+        if static_ip_pools is not None:
+            setting_data["static_ip_pools"] = static_ip_pools
+
+        # Validate using the Pydantic model
+        infrastructure_setting = InfrastructureSetting(**setting_data)
+        sdk_data = infrastructure_setting.to_sdk_model()
+
+        # Call the SDK client
+        result = scm_client.create_infrastructure_setting(**sdk_data)
+
+        # Get the action performed
+        action = result.pop("__action__", "created")
+
+        if action == "created":
+            typer.echo(f"Created infrastructure setting: {result.get('name', name)} in folder {folder}")
+        elif action == "updated":
+            typer.echo(f"Updated infrastructure setting: {result.get('name', name)} in folder {folder}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for infrastructure setting: {result.get('name', name)} in folder {folder}")
+
+        return result
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating infrastructure setting: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("infrastructure-setting")
+def show_infrastructure_setting(
+    folder: str = INFRA_FOLDER_OPTION,
+    name: str = INFRA_NAME_OPTION,
+):
+    """Display an infrastructure setting.
+
+    The SCM API requires a name for this endpoint; there is no list-all mode.
+
+    Examples
+    --------
+        scm show mobile-agent infrastructure-setting --name "gp-infra"
+
+    """
+    try:
+        show_context_info()
+
+        setting = scm_client.get_infrastructure_setting(folder=folder, name=name)
+
+        typer.echo(f"\nInfrastructure Setting: {setting.get('name', 'N/A')}")
+        typer.echo("=" * 80)
+        typer.echo(f"Location: Folder '{folder}'")
+
+        if setting.get("portal_hostname"):
+            typer.echo(f"Portal Hostname: {yaml.dump(setting['portal_hostname'], default_flow_style=True).strip()}")
+        if setting.get("dns_servers"):
+            typer.echo(f"DNS Servers: {yaml.dump(setting['dns_servers'], default_flow_style=True).strip()}")
+        if setting.get("ip_pools"):
+            typer.echo(f"IP Pools: {yaml.dump(setting['ip_pools'], default_flow_style=True).strip()}")
+        if setting.get("enable_wins"):
+            typer.echo(f"WINS: {yaml.dump(setting['enable_wins'], default_flow_style=True).strip()}")
+        if setting.get("ipv6") is not None:
+            typer.echo(f"IPv6: {setting['ipv6']}")
+        if setting.get("udp_queries"):
+            typer.echo(f"UDP Queries: {yaml.dump(setting['udp_queries'], default_flow_style=True).strip()}")
+        if setting.get("static_ip_pools"):
+            typer.echo(f"Static IP Pools: {yaml.dump(setting['static_ip_pools'], default_flow_style=True).strip()}")
+        if setting.get("id"):
+            typer.echo(f"ID: {setting['id']}")
+
+        return setting
+
+    except Exception as e:
+        typer.echo(f"Error showing infrastructure setting: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("infrastructure-setting")
+def delete_infrastructure_setting(
+    folder: str = INFRA_FOLDER_OPTION,
+    name: str = INFRA_NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+):
+    """Delete an infrastructure setting.
+
+    Examples
+    --------
+        scm delete mobile-agent infrastructure-setting --name "gp-infra"
+
+    """
+    try:
+        if not force:
+            typer.confirm(f"Delete infrastructure setting '{name}' from folder '{folder}'?", abort=True)
+        result = scm_client.delete_infrastructure_setting(folder=folder, name=name)
+        if result:
+            typer.echo(f"Deleted infrastructure setting: {name} from folder {folder}")
+        return result
+    except Exception as e:
+        typer.echo(f"Error deleting infrastructure setting: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@backup_app.command("infrastructure-setting")
+def backup_infrastructure_setting(
+    folder: str = INFRA_FOLDER_OPTION,
+    name: str = INFRA_NAME_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+):
+    """Backup an infrastructure setting to a YAML file.
+
+    The SCM API requires a name for this endpoint, so backups cover the
+    named setting rather than every setting in the folder.
+
+    Examples
+    --------
+        scm backup mobile-agent infrastructure-setting --name "gp-infra"
+
+    """
+    try:
+        settings_list = scm_client.list_infrastructure_settings(folder=folder, name=name)
+
+        if not settings_list:
+            typer.echo(f"No infrastructure settings named '{name}' found in folder '{folder}'")
+            return
+
+        # Convert to backup format, stripping system fields
+        backup_data = []
+        for setting in settings_list:
+            setting_dict = {k: v for k, v in setting.items() if v is not None}
+            setting_dict.pop("id", None)
+            backup_data.append(setting_dict)
+
+        yaml_data = {"infrastructure_settings": backup_data}
+
+        if file is None:
+            file = Path(get_default_backup_filename("infrastructure-setting", "folder", folder))
+
+        with file.open("w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} infrastructure settings to {file}")
+        return str(file)
+
+    except Exception as e:
+        typer.echo(f"Error backing up infrastructure settings: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("infrastructure-setting")
+def load_infrastructure_setting(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+):
+    """Load infrastructure settings from a YAML file.
+
+    Examples
+    --------
+        scm load mobile-agent infrastructure-setting --file config/infrastructure_settings.yml
+
+    """
+    try:
+        # Load and parse the YAML file
+        config = load_from_yaml(str(file), "infrastructure_settings")
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            typer.echo(yaml.dump(config["infrastructure_settings"]))
+            return None
+
+        results = []
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+
+        for setting_data in config["infrastructure_settings"]:
+            try:
+                # Apply folder override if specified (only valid value is 'Mobile Users')
+                if folder:
+                    setting_data["folder"] = folder
+
+                # Validate using the Pydantic model
+                infrastructure_setting = InfrastructureSetting(**setting_data)
+                sdk_data = infrastructure_setting.to_sdk_model()
+
+                result = scm_client.create_infrastructure_setting(**sdk_data)
+
+                action = result.pop("__action__", "created")
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created infrastructure setting: {result.get('name', 'N/A')}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated infrastructure setting: {result.get('name', 'N/A')}")
+                elif action == "no_change":
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for infrastructure setting: {result.get('name', 'N/A')}")
+
+                results.append(result)
+
+            except Exception as e:
+                typer.echo(f"Error loading infrastructure setting '{setting_data.get('name', 'unknown')}': {str(e)}", err=True)
+
+        typer.echo(f"\nSummary: {created_count} created, {updated_count} updated, {no_change_count} unchanged")
+
+        return results
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error loading infrastructure settings: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# =============================================================================================================================================================================================
+# GLOBAL SETTING COMMANDS (SINGLETON — SHOW/SET ONLY)
+# =============================================================================================================================================================================================
+
+
+@show_app.command("global-setting")
+def show_global_setting():
+    """Display the GlobalProtect global settings.
+
+    Global settings are a tenant-wide singleton; there is nothing to filter by.
+
+    Examples
+    --------
+        scm show mobile-agent global-setting
+
+    """
+    try:
+        show_context_info()
+
+        setting = scm_client.get_global_settings()
+
+        typer.echo("\nGlobalProtect Global Settings")
+        typer.echo("=" * 80)
+
+        if setting.get("agent_version"):
+            typer.echo(f"Agent Version: {setting['agent_version']}")
+        if setting.get("manual_gateway"):
+            typer.echo(f"Manual Gateway: {yaml.dump(setting['manual_gateway'], default_flow_style=True).strip()}")
+        if not setting:
+            typer.echo("No global settings configured")
+
+        return setting
+
+    except Exception as e:
+        typer.echo(f"Error showing global settings: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("global-setting")
+def set_global_setting(
+    agent_version: str | None = typer.Option(None, "--agent-version", help="GlobalProtect agent version"),
+    manual_gateway: str | None = typer.Option(None, "--manual-gateway", help="Manual gateway configuration as JSON"),
+):
+    r"""Update the GlobalProtect global settings.
+
+    Global settings are a singleton: they always exist and are updated in
+    place. There are no delete, backup, or load operations.
+
+    Examples
+    --------
+        scm set mobile-agent global-setting --agent-version "6.2.0"
+
+        scm set mobile-agent global-setting \
+        --manual-gateway '{"region": [{"name": "americas", "locations": ["us-east-1"]}]}'
+
+    """
+    try:
+        # Build setting data; the Pydantic model parses JSON strings into structures
+        setting_data: dict[str, Any] = {}
+        if agent_version is not None:
+            setting_data["agent_version"] = agent_version
+        if manual_gateway is not None:
+            setting_data["manual_gateway"] = manual_gateway
+
+        # Validate using the Pydantic model (requires at least one field)
+        global_setting = GlobalSetting(**setting_data)
+        sdk_data = global_setting.to_sdk_model()
+
+        result = scm_client.update_global_settings(**sdk_data)
+        result.pop("__action__", None)
+
+        typer.echo("Updated GlobalProtect global settings")
+        return result
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error updating global settings: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -11506,6 +11506,277 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("deletion", folder or "", name or "", e)
 
+    # ---------------------------------------------------------------- agent2: Infrastructure Setting (begin) ----------------------------------------------------------------
+
+    def create_infrastructure_setting(
+        self,
+        name: str = None,
+        folder: str = "Mobile Users",
+        dns_servers: list[dict[str, Any]] | None = None,
+        ip_pools: list[dict[str, Any]] | None = None,
+        portal_hostname: dict[str, Any] | None = None,
+        enable_wins: dict[str, Any] | None = None,
+        ipv6: bool | None = None,
+        udp_queries: dict[str, Any] | None = None,
+        static_ip_pools: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Create or update an infrastructure setting using smart upsert logic.
+
+        Infrastructure settings have no ID-based paths; the SDK addresses them
+        by name and the 'Mobile Users' folder query parameter. Create and update
+        may return an empty body, in which case the validated payload is echoed.
+
+        Args:
+            name: Name of the infrastructure setting
+            folder: Folder (must be 'Mobile Users')
+            dns_servers: DNS server entries
+            ip_pools: IP pools
+            portal_hostname: Portal hostname configuration
+            enable_wins: WINS configuration
+            ipv6: Whether IPv6 is enabled
+            udp_queries: UDP query retry configuration
+            static_ip_pools: Static IP pools
+
+        Returns:
+            dict[str, Any]: The created/updated infrastructure setting with __action__ field
+
+        """
+        self.logger.info(f"Creating or updating infrastructure setting: {name} in folder {folder}")
+
+        setting_data: dict[str, Any] = {"name": name}
+        if dns_servers is not None:
+            setting_data["dns_servers"] = dns_servers
+        if ip_pools is not None:
+            setting_data["ip_pools"] = ip_pools
+        if portal_hostname is not None:
+            setting_data["portal_hostname"] = portal_hostname
+        if enable_wins is not None:
+            setting_data["enable_wins"] = enable_wins
+        if ipv6 is not None:
+            setting_data["ipv6"] = ipv6
+        if udp_queries is not None:
+            setting_data["udp_queries"] = udp_queries
+        if static_ip_pools is not None:
+            setting_data["static_ip_pools"] = static_ip_pools
+
+        if not self.client:
+            # Return mock data if no client is available
+            result = dict(setting_data)
+            result["id"] = f"is-{name}"
+            result["folder"] = folder
+            result["__action__"] = "created"
+            return result
+
+        try:
+            # Step 1: Try to fetch the existing infrastructure setting. The SDK raises
+            # InvalidObjectError (404) rather than NotFoundError when absent.
+            existing = None
+            try:
+                existing = self.client.infrastructure_settings.fetch(name=name, folder=folder)
+                self.logger.info(f"Found existing infrastructure setting '{name}' in folder '{folder}'")
+            except NotFoundError:
+                self.logger.info(f"Infrastructure setting '{name}' not found in folder '{folder}', will create new")
+            except Exception as fetch_error:
+                if getattr(fetch_error, "http_status_code", None) == 404:
+                    self.logger.info(f"Infrastructure setting '{name}' not found in folder '{folder}', will create new")
+                else:
+                    self.logger.warning(f"Error fetching infrastructure setting '{name}': {str(fetch_error)}")
+
+            if existing:
+                # Step 2: Compare the desired payload against the existing object
+                existing_data = json.loads(existing.model_dump_json(exclude_unset=True))
+                existing_data.pop("id", None)
+                if all(existing_data.get(key) == value for key, value in setting_data.items()):
+                    self.logger.info(f"No changes detected for infrastructure setting '{name}', skipping update")
+                    response = json.loads(existing.model_dump_json(exclude_unset=True))
+                    response["__action__"] = "no_change"
+                    return response
+
+                result = self.client.infrastructure_settings.update(setting_data, folder=folder)
+                self.logger.info(f"Successfully updated infrastructure setting '{name}' in folder '{folder}'")
+                # The API may respond with an empty body; echo the payload then
+                response = json.loads(result.model_dump_json(exclude_unset=True)) if result is not None else dict(setting_data)
+                response["__action__"] = "updated"
+                return response
+            else:
+                # Step 3: Create a new infrastructure setting
+                result = self.client.infrastructure_settings.create(setting_data, folder=folder)
+                self.logger.info(f"Successfully created infrastructure setting '{name}' in folder '{folder}'")
+                # The API responds with 201 Created and may have no body; echo the payload then
+                response = json.loads(result.model_dump_json(exclude_unset=True)) if result is not None else dict(setting_data)
+                response["__action__"] = "created"
+                return response
+
+        except Exception as e:
+            self._handle_api_exception("create/update", folder, name or "", e)
+
+    def get_infrastructure_setting(
+        self,
+        name: str = None,
+        folder: str = "Mobile Users",
+    ) -> dict[str, Any]:
+        """Get an infrastructure setting by name.
+
+        Args:
+            name: Name of the infrastructure setting to get
+            folder: Folder (must be 'Mobile Users')
+
+        Returns:
+            dict[str, Any]: The infrastructure setting object
+
+        """
+        self.logger.info(f"Getting infrastructure setting: {name} from folder {folder}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "id": f"is-{name}",
+                "folder": folder,
+                "name": name,
+                "dns_servers": [{"name": "dns-1", "dns_suffix": ["example.com"]}],
+                "ip_pools": [{"name": "pool-1", "ip_pool": ["10.0.0.0/16"]}],
+                "portal_hostname": {"default_domain": {"hostname": "example"}},
+            }
+
+        try:
+            result = self.client.infrastructure_settings.fetch(name=name, folder=folder)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", folder, name or "", e)
+
+    def list_infrastructure_settings(
+        self,
+        name: str = None,
+        folder: str = "Mobile Users",
+    ) -> list[dict[str, Any]]:
+        """List infrastructure settings matching a name.
+
+        The SCM API requires the 'name' query parameter for this endpoint;
+        there is no enumerate-all listing.
+
+        Args:
+            name: Name of the infrastructure settings (required by the API)
+            folder: Folder (must be 'Mobile Users')
+
+        Returns:
+            list[dict[str, Any]]: List of infrastructure setting objects
+
+        """
+        self.logger.info(f"Listing infrastructure settings named '{name}' in folder: {folder}")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return [
+                {
+                    "id": "is-mock1",
+                    "folder": folder,
+                    "name": name or "gp-infra",
+                    "dns_servers": [{"name": "dns-1", "dns_suffix": ["example.com"]}],
+                    "ip_pools": [{"name": "pool-1", "ip_pool": ["10.0.0.0/16"]}],
+                    "portal_hostname": {"default_domain": {"hostname": "example"}},
+                },
+            ]
+
+        try:
+            results = self.client.infrastructure_settings.list(name=name, folder=folder)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder, "infrastructure settings", e)
+
+    def delete_infrastructure_setting(
+        self,
+        name: str = None,
+        folder: str = "Mobile Users",
+    ) -> bool:
+        """Delete an infrastructure setting.
+
+        Args:
+            name: Name of the infrastructure setting to delete
+            folder: Folder (must be 'Mobile Users')
+
+        Returns:
+            bool: True if deletion was successful
+
+        """
+        self.logger.info(f"Deleting infrastructure setting: {name} from folder {folder}")
+
+        if not self.client:
+            return True
+
+        try:
+            self.client.infrastructure_settings.delete(name=name, folder=folder)
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", folder, name or "", e)
+
+    # ---------------------------------------------------------------- agent2: Infrastructure Setting (end) ----------------------------------------------------------------
+
+    # ---------------------------------------------------------------- agent2: Global Settings (begin) ----------------------------------------------------------------
+
+    def get_global_settings(self) -> dict[str, Any]:
+        """Get the GlobalProtect global settings singleton.
+
+        Returns:
+            dict[str, Any]: The global settings object
+
+        """
+        self.logger.info("Getting GlobalProtect global settings")
+
+        if not self.client:
+            # Return mock data if no client is available
+            return {
+                "agent_version": "6.2.0",
+                "manual_gateway": {"region": [{"name": "americas", "locations": ["us-east-1"]}]},
+            }
+
+        try:
+            result = self.client.global_settings.get()
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", "global", "global settings", e)
+
+    def update_global_settings(
+        self,
+        agent_version: str | None = None,
+        manual_gateway: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Update the GlobalProtect global settings singleton.
+
+        Global settings always exist for the tenant, so this is a plain PUT;
+        there is no create path and the action is always reported as updated.
+
+        Args:
+            agent_version: GlobalProtect agent version
+            manual_gateway: Manual gateway configuration
+
+        Returns:
+            dict[str, Any]: The updated global settings with __action__ field
+
+        """
+        self.logger.info("Updating GlobalProtect global settings")
+
+        settings_data: dict[str, Any] = {}
+        if agent_version is not None:
+            settings_data["agent_version"] = agent_version
+        if manual_gateway is not None:
+            settings_data["manual_gateway"] = manual_gateway
+
+        if not self.client:
+            # Return mock data if no client is available
+            result = dict(settings_data)
+            result["__action__"] = "updated"
+            return result
+
+        try:
+            result = self.client.global_settings.update(settings_data)
+            response = json.loads(result.model_dump_json(exclude_unset=True))
+            response["__action__"] = "updated"
+            return response
+        except Exception as e:
+            self._handle_api_exception("updating", "global", "global settings", e)
+
+    # ---------------------------------------------------------------- agent2: Global Settings (end) ----------------------------------------------------------------
+
     # ======================================================================================================================================================================================
     # SETUP CONFIGURATION METHODS
     # ======================================================================================================================================================================================

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -8,6 +8,7 @@ that all required fields are present and correctly formatted.
 from typing import Any, ClassVar, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+from pydantic_core import from_json
 
 # =============================================================================================================================================================================================
 # TYPE DEFINITIONS
@@ -4850,6 +4851,240 @@ class TunnelProfile(BaseModel):
                 model_data["split_tunneling"] = split_tunneling
 
         return model_data
+
+
+# ---------------------------------------------------- agent2: GlobalProtect infrastructure/global settings (begin) ----------------------------------------------------
+
+
+def _parse_json_value(value: Any) -> Any:
+    """Parse a JSON string into a structure, passing through non-strings.
+
+    Lets the same Pydantic models accept raw JSON strings from CLI options and
+    already-parsed structures from YAML loads.
+    """
+    if isinstance(value, str):
+        return from_json(value)
+    return value
+
+
+class InfraDnsServerSelection(BaseModel):
+    """Primary/secondary DNS server selection for an internal DNS match entry."""
+
+    dns_server: dict[str, Any] | None = Field(None, description="DNS server configuration")
+    use_cloud_default: dict[str, Any] | None = Field(None, description="Use the cloud default DNS server")
+
+
+class InfraInternalDnsMatch(BaseModel):
+    """Internal DNS match entry for a DNS server configuration."""
+
+    name: str | None = Field(None, description="Name of the internal DNS match entry")
+    domain_list: list[str] | None = Field(None, description="Domains to resolve with internal DNS servers")
+    primary: InfraDnsServerSelection | None = Field(None, description="Primary DNS server selection")
+    secondary: InfraDnsServerSelection | None = Field(None, description="Secondary DNS server selection")
+
+
+class InfraPublicDnsServer(BaseModel):
+    """Public DNS server configuration."""
+
+    dns_server: str | None = Field(None, description="IP address of the public DNS server")
+
+
+class InfraDnsServer(BaseModel):
+    """DNS server entry for infrastructure settings."""
+
+    name: str | None = Field(None, description="Name of the DNS server entry")
+    dns_suffix: list[str] | None = Field(None, description="DNS suffixes for the mobile users environment")
+    internal_dns_match: list[InfraInternalDnsMatch] | None = Field(None, description="Internal DNS match entries")
+    primary_public_dns: InfraPublicDnsServer | None = Field(None, description="Primary public DNS server")
+    secondary_public_dns: InfraPublicDnsServer | None = Field(None, description="Secondary public DNS server")
+
+
+class InfraIpPool(BaseModel):
+    """IP pool entry for infrastructure settings."""
+
+    name: str | None = Field(None, description="Name of the IP pool")
+    ip_pool: list[str] | None = Field(None, description="IP subnets of the pool")
+
+
+class InfraCustomDomain(BaseModel):
+    """Custom domain configuration for the portal hostname."""
+
+    cname: str | None = Field(None, description="CNAME record of the custom domain")
+    hostname: str | None = Field(None, description="Hostname of the custom domain")
+    ssl_tls_service_profile: str | None = Field(None, description="SSL/TLS service profile name")
+
+
+class InfraDefaultDomain(BaseModel):
+    """Default domain configuration for the portal hostname."""
+
+    hostname: str | None = Field(None, description="Hostname of the default domain")
+
+
+class InfraPortalHostname(BaseModel):
+    """Portal hostname configuration for infrastructure settings."""
+
+    custom_domain: InfraCustomDomain | None = Field(None, description="Custom domain configuration")
+    default_domain: InfraDefaultDomain | None = Field(None, description="Default domain configuration")
+
+
+class InfraWinsServer(BaseModel):
+    """WINS server entry for infrastructure settings."""
+
+    name: str | None = Field(None, description="Name of the WINS server entry")
+    primary: str | None = Field(None, description="Primary WINS server")
+    secondary: str | None = Field(None, description="Secondary WINS server")
+
+
+class InfraEnableWinsYes(BaseModel):
+    """Configuration when WINS is enabled."""
+
+    wins_servers: list[InfraWinsServer] | None = Field(None, description="WINS servers")
+
+
+class InfraEnableWins(BaseModel):
+    """Enable or disable WINS; exactly one of 'yes' or 'no' is expected by the API."""
+
+    no: dict[str, Any] | None = Field(None, description="WINS is disabled")
+    yes: InfraEnableWinsYes | None = Field(None, description="WINS is enabled with the given WINS servers")
+
+
+class InfraUdpQueryRetries(BaseModel):
+    """UDP query retry configuration."""
+
+    attempts: int | None = Field(None, ge=1, le=30, description="Maximum retries before trying the next name server")
+    interval: int | None = Field(None, ge=1, le=30, description="Time in seconds for another request to be sent")
+
+
+class InfraUdpQueries(BaseModel):
+    """UDP query configuration for infrastructure settings."""
+
+    retries: InfraUdpQueryRetries | None = Field(None, description="UDP query retry configuration")
+
+
+class InfraUserGroup(BaseModel):
+    """User group entry for a static IP pool."""
+
+    name: str | None = Field(None, max_length=320, description="Distinguished Name of the group")
+    directory: str | None = Field(None, description="Directory of the group")
+
+
+class InfraStaticIpPool(BaseModel):
+    """Static IP pool entry for infrastructure settings."""
+
+    name: str | None = Field(None, max_length=128, description="Name of the static IP pool entry")
+    pool_type: str | None = Field(None, description="Type of the pool (Static-IP)")
+    ip_pool: list[str] | None = Field(None, description="IP subnets")
+    theatres: list[str] | None = Field(None, description="IP pools on theatres")
+    users: list[str] | None = Field(None, description="IP pools on users")
+    user_groups: list[InfraUserGroup] | None = Field(None, description="IP pools on user groups")
+
+
+class InfrastructureSetting(BaseModel):
+    """Model for mobile agent infrastructure setting configurations.
+
+    Infrastructure settings are addressed by name within the 'Mobile Users'
+    folder only; the SCM API rejects any other container. Complex fields accept
+    either parsed structures (YAML load) or JSON strings (CLI options).
+    """
+
+    name: str = Field(..., description="Name of the infrastructure setting")
+    folder: str = Field("Mobile Users", description="Folder path (must be 'Mobile Users')")
+    dns_servers: list[InfraDnsServer] = Field(..., description="DNS server entries")
+    ip_pools: list[InfraIpPool] = Field(..., description="IP pools")
+    portal_hostname: InfraPortalHostname = Field(..., description="Portal hostname configuration")
+    enable_wins: InfraEnableWins | None = Field(None, description="WINS configuration")
+    ipv6: bool | None = Field(None, description="Whether IPv6 is enabled")
+    udp_queries: InfraUdpQueries | None = Field(None, description="UDP query retry configuration")
+    static_ip_pools: list[InfraStaticIpPool] | None = Field(None, description="Static IP pools")
+
+    @field_validator("dns_servers", "ip_pools", "portal_hostname", "enable_wins", "udp_queries", "static_ip_pools", mode="before")
+    @classmethod
+    def parse_json_strings(cls, value: Any) -> Any:
+        """Accept JSON strings for structured fields and parse them before validation."""
+        return _parse_json_value(value)
+
+    @model_validator(mode="after")
+    def validate_container(self) -> "InfrastructureSetting":
+        """Validate that the folder is 'Mobile Users'.
+
+        Returns:
+            The validated infrastructure setting model
+
+        Raises:
+            ValueError: If the folder is not 'Mobile Users'
+
+        """
+        if self.folder != "Mobile Users":
+            raise ValueError("Folder must be 'Mobile Users' for infrastructure settings")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format.
+
+        Returns:
+            dict[str, Any]: SDK-compatible dictionary
+
+        """
+        model_data: dict[str, Any] = self.model_dump(exclude_none=True)
+        return model_data
+
+
+class GlobalSettingManualGatewayRegion(BaseModel):
+    """Manual gateway region entry for global settings."""
+
+    name: str | None = Field(None, description="Name of the region")
+    locations: list[str] | None = Field(None, description="Locations within the region")
+
+
+class GlobalSettingManualGateway(BaseModel):
+    """Manual gateway configuration for global settings."""
+
+    region: list[GlobalSettingManualGatewayRegion] | None = Field(None, description="Manual gateway regions")
+
+
+class GlobalSetting(BaseModel):
+    """Model for mobile agent global setting configurations.
+
+    Global settings are a tenant-wide singleton with GET/PUT semantics only;
+    there is no container and no name.
+    """
+
+    agent_version: str | None = Field(None, description="GlobalProtect agent version")
+    manual_gateway: GlobalSettingManualGateway | None = Field(None, description="Manual gateway configuration")
+
+    @field_validator("manual_gateway", mode="before")
+    @classmethod
+    def parse_json_strings(cls, value: Any) -> Any:
+        """Accept JSON strings for structured fields and parse them before validation."""
+        return _parse_json_value(value)
+
+    @model_validator(mode="after")
+    def validate_not_empty(self) -> "GlobalSetting":
+        """Validate that at least one field is provided.
+
+        Returns:
+            The validated global setting model
+
+        Raises:
+            ValueError: If no fields are provided
+
+        """
+        if self.agent_version is None and self.manual_gateway is None:
+            raise ValueError("At least one of agent_version or manual_gateway must be provided")
+        return self
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format.
+
+        Returns:
+            dict[str, Any]: SDK-compatible dictionary
+
+        """
+        model_data: dict[str, Any] = self.model_dump(exclude_none=True)
+        return model_data
+
+
+# ---------------------------------------------------- agent2: GlobalProtect infrastructure/global settings (end) ----------------------------------------------------
 
 
 # =============================================================================================================================================================================================

--- a/tests/test_infrastructure_global_settings_commands.py
+++ b/tests/test_infrastructure_global_settings_commands.py
@@ -1,0 +1,509 @@
+"""Tests for the mobile agent infrastructure setting and global setting commands."""
+
+import typer  # noqa: I001
+from scm_cli.commands.mobile_agent import (
+    backup_infrastructure_setting,
+    delete_infrastructure_setting,
+    load_infrastructure_setting,
+    set_global_setting,
+    set_infrastructure_setting,
+    show_global_setting,
+    show_infrastructure_setting,
+)
+
+DNS_SERVERS_JSON = '[{"name": "dns-1", "dns_suffix": ["example.com"]}]'
+IP_POOLS_JSON = '[{"name": "pool-1", "ip_pool": ["10.0.0.0/16"]}]'
+PORTAL_HOSTNAME_JSON = '{"default_domain": {"hostname": "acme"}}'
+
+
+class TestInfrastructureSettingCommands:
+    """Test the infrastructure setting commands."""
+
+    def test_set_infrastructure_setting(self, runner, monkeypatch):
+        """Test creating an infrastructure setting."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "is-gp-infra",
+                "folder": kwargs.get("folder"),
+                "name": kwargs.get("name"),
+                "dns_servers": kwargs.get("dns_servers"),
+                "ip_pools": kwargs.get("ip_pools"),
+                "portal_hostname": kwargs.get("portal_hostname"),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_infrastructure_setting", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--name", "gp-infra",
+                "--dns-servers", DNS_SERVERS_JSON,
+                "--ip-pools", IP_POOLS_JSON,
+                "--portal-hostname", PORTAL_HOSTNAME_JSON,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created infrastructure setting" in result.stdout
+        assert "gp-infra" in result.stdout
+
+    def test_set_infrastructure_setting_update(self, runner, monkeypatch):
+        """Test updating an infrastructure setting."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "is-gp-infra",
+                "folder": kwargs.get("folder"),
+                "name": kwargs.get("name"),
+                "__action__": "updated",
+            }
+
+        monkeypatch.setattr(scm_client, "create_infrastructure_setting", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--name", "gp-infra",
+                "--dns-servers", DNS_SERVERS_JSON,
+                "--ip-pools", IP_POOLS_JSON,
+                "--portal-hostname", PORTAL_HOSTNAME_JSON,
+                "--ipv6",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Updated infrastructure setting" in result.stdout
+
+    def test_set_infrastructure_setting_no_change(self, runner, monkeypatch):
+        """Test set infrastructure setting with no changes."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {
+                "id": "is-gp-infra",
+                "folder": kwargs.get("folder"),
+                "name": kwargs.get("name"),
+                "__action__": "no_change",
+            }
+
+        monkeypatch.setattr(scm_client, "create_infrastructure_setting", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--name", "gp-infra",
+                "--dns-servers", DNS_SERVERS_JSON,
+                "--ip-pools", IP_POOLS_JSON,
+                "--portal-hostname", PORTAL_HOSTNAME_JSON,
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "No changes needed" in result.stdout
+
+    def test_set_infrastructure_setting_invalid_json(self, runner, monkeypatch):
+        """Test set infrastructure setting with malformed JSON option."""
+        test_app = typer.Typer()
+        test_app.command()(set_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--name", "gp-infra",
+                "--dns-servers", "not-json",
+                "--ip-pools", IP_POOLS_JSON,
+                "--portal-hostname", PORTAL_HOSTNAME_JSON,
+            ],
+        )
+
+        assert result.exit_code == 1
+
+    def test_set_infrastructure_setting_invalid_folder(self, runner, monkeypatch):
+        """Test set infrastructure setting with a folder other than Mobile Users."""
+        test_app = typer.Typer()
+        test_app.command()(set_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder", "Texas",
+                "--name", "gp-infra",
+                "--dns-servers", DNS_SERVERS_JSON,
+                "--ip-pools", IP_POOLS_JSON,
+                "--portal-hostname", PORTAL_HOSTNAME_JSON,
+            ],
+        )
+
+        assert result.exit_code == 1
+
+    def test_set_infrastructure_setting_error(self, runner, monkeypatch):
+        """Test set infrastructure setting with an API error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(scm_client, "create_infrastructure_setting", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--name", "gp-infra",
+                "--dns-servers", DNS_SERVERS_JSON,
+                "--ip-pools", IP_POOLS_JSON,
+                "--portal-hostname", PORTAL_HOSTNAME_JSON,
+            ],
+        )
+
+        assert result.exit_code == 1
+
+    def test_show_infrastructure_setting(self, runner, monkeypatch):
+        """Test showing an infrastructure setting."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "is-gp-infra",
+                "folder": "Mobile Users",
+                "name": "gp-infra",
+                "dns_servers": [{"name": "dns-1", "dns_suffix": ["example.com"]}],
+                "ip_pools": [{"name": "pool-1", "ip_pool": ["10.0.0.0/16"]}],
+                "portal_hostname": {"default_domain": {"hostname": "acme"}},
+                "ipv6": True,
+            }
+
+        monkeypatch.setattr(scm_client, "get_infrastructure_setting", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--name", "gp-infra"],
+        )
+
+        assert result.exit_code == 0
+        assert "gp-infra" in result.stdout
+        assert "10.0.0.0/16" in result.stdout
+        assert "IPv6: True" in result.stdout
+
+    def test_show_infrastructure_setting_error(self, runner, monkeypatch):
+        """Test showing an infrastructure setting with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("Not found")
+
+        monkeypatch.setattr(scm_client, "get_infrastructure_setting", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(show_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--name", "nonexistent"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_delete_infrastructure_setting(self, runner, monkeypatch):
+        """Test deleting an infrastructure setting."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(*args, **kwargs):
+            return True
+
+        monkeypatch.setattr(scm_client, "delete_infrastructure_setting", mock_delete)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--name", "gp-infra", "--force"],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted infrastructure setting" in result.stdout
+
+    def test_delete_infrastructure_setting_error(self, runner, monkeypatch):
+        """Test deleting an infrastructure setting with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("Not found")
+
+        monkeypatch.setattr(scm_client, "delete_infrastructure_setting", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--name", "nonexistent", "--force"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_backup_infrastructure_setting(self, runner, monkeypatch, tmp_path):
+        """Test backing up an infrastructure setting."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {
+                    "id": "is-gp-infra",
+                    "folder": "Mobile Users",
+                    "name": "gp-infra",
+                    "dns_servers": [{"name": "dns-1", "dns_suffix": ["example.com"]}],
+                    "ip_pools": [{"name": "pool-1", "ip_pool": ["10.0.0.0/16"]}],
+                    "portal_hostname": {"default_domain": {"hostname": "acme"}},
+                },
+            ]
+
+        monkeypatch.setattr(scm_client, "list_infrastructure_settings", mock_list)
+        monkeypatch.chdir(tmp_path)
+
+        test_app = typer.Typer()
+        test_app.command()(backup_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--name", "gp-infra"],
+        )
+
+        assert result.exit_code == 0
+        assert "Successfully backed up" in result.stdout
+        assert "1 infrastructure settings" in result.stdout
+
+    def test_backup_infrastructure_setting_empty(self, runner, monkeypatch, tmp_path):
+        """Test backing up when no infrastructure setting matches."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return []
+
+        monkeypatch.setattr(scm_client, "list_infrastructure_settings", mock_list)
+        monkeypatch.chdir(tmp_path)
+
+        test_app = typer.Typer()
+        test_app.command()(backup_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--name", "missing"],
+        )
+
+        assert result.exit_code == 0
+        assert "No infrastructure settings named" in result.stdout
+
+    def test_load_infrastructure_setting(self, runner, monkeypatch, tmp_path):
+        """Test loading infrastructure settings from YAML."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_content = """
+infrastructure_settings:
+  - name: gp-infra
+    folder: "Mobile Users"
+    dns_servers:
+      - name: dns-1
+        dns_suffix:
+          - example.com
+    ip_pools:
+      - name: pool-1
+        ip_pool:
+          - 10.0.0.0/16
+    portal_hostname:
+      default_domain:
+        hostname: acme
+"""
+        test_file = tmp_path / "infrastructure_settings.yml"
+        test_file.write_text(yaml_content)
+
+        def mock_create(*args, **kwargs):
+            return {
+                "name": kwargs.get("name"),
+                "folder": kwargs.get("folder"),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_infrastructure_setting", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--file", str(test_file)],
+        )
+
+        assert result.exit_code == 0
+        assert "Created infrastructure setting" in result.stdout
+        assert "1 created" in result.stdout
+
+    def test_load_infrastructure_setting_dry_run(self, runner, monkeypatch, tmp_path):
+        """Test loading infrastructure settings in dry run mode."""
+        yaml_content = """
+infrastructure_settings:
+  - name: gp-infra
+    folder: "Mobile Users"
+    dns_servers: []
+    ip_pools: []
+    portal_hostname: {}
+"""
+        test_file = tmp_path / "infrastructure_settings.yml"
+        test_file.write_text(yaml_content)
+
+        test_app = typer.Typer()
+        test_app.command()(load_infrastructure_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--file", str(test_file), "--dry-run"],
+        )
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+
+class TestGlobalSettingCommands:
+    """Test the global setting commands."""
+
+    def test_show_global_setting(self, runner, monkeypatch):
+        """Test showing the global settings."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "agent_version": "6.2.0",
+                "manual_gateway": {"region": [{"name": "americas", "locations": ["us-east-1"]}]},
+            }
+
+        monkeypatch.setattr(scm_client, "get_global_settings", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_global_setting)
+
+        result = runner.invoke(test_app, [])
+
+        assert result.exit_code == 0
+        assert "6.2.0" in result.stdout
+        assert "americas" in result.stdout
+
+    def test_show_global_setting_error(self, runner, monkeypatch):
+        """Test showing global settings with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(scm_client, "get_global_settings", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(show_global_setting)
+
+        result = runner.invoke(test_app, [])
+
+        assert result.exit_code == 1
+
+    def test_set_global_setting_agent_version(self, runner, monkeypatch):
+        """Test updating the global settings agent version."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_update(*args, **kwargs):
+            return {
+                "agent_version": kwargs.get("agent_version"),
+                "__action__": "updated",
+            }
+
+        monkeypatch.setattr(scm_client, "update_global_settings", mock_update)
+
+        test_app = typer.Typer()
+        test_app.command()(set_global_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--agent-version", "6.2.0"],
+        )
+
+        assert result.exit_code == 0
+        assert "Updated GlobalProtect global settings" in result.stdout
+
+    def test_set_global_setting_manual_gateway(self, runner, monkeypatch):
+        """Test updating the global settings manual gateway."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_update(*args, **kwargs):
+            return {
+                "manual_gateway": kwargs.get("manual_gateway"),
+                "__action__": "updated",
+            }
+
+        monkeypatch.setattr(scm_client, "update_global_settings", mock_update)
+
+        test_app = typer.Typer()
+        test_app.command()(set_global_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--manual-gateway", '{"region": [{"name": "americas", "locations": ["us-east-1"]}]}'],
+        )
+
+        assert result.exit_code == 0
+        assert "Updated GlobalProtect global settings" in result.stdout
+
+    def test_set_global_setting_no_fields(self, runner, monkeypatch):
+        """Test set global setting with no fields fails validation."""
+        test_app = typer.Typer()
+        test_app.command()(set_global_setting)
+
+        result = runner.invoke(test_app, [])
+
+        assert result.exit_code == 1
+
+    def test_set_global_setting_invalid_json(self, runner, monkeypatch):
+        """Test set global setting with malformed JSON option."""
+        test_app = typer.Typer()
+        test_app.command()(set_global_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--manual-gateway", "not-json"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_set_global_setting_error(self, runner, monkeypatch):
+        """Test set global setting with an API error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(scm_client, "update_global_settings", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_global_setting)
+
+        result = runner.invoke(
+            test_app,
+            ["--agent-version", "6.2.0"],
+        )
+
+        assert result.exit_code == 1


### PR DESCRIPTION
## What

CLI coverage for two pan-scm-sdk 0.15.0 GlobalProtect services:

- **infrastructure-setting**: `set` / `delete` / `show` / `backup` / `load` under `scm <action> mobile-agent infrastructure-setting`
- **global-setting**: `show` / `set` only (tenant-wide singleton — no delete/backup/load)

## Why

Phase 1 of the SDK 0.15.0 adoption plan (agent2 scope). Follows the existing auth-setting end-to-end pattern: Typer command → Pydantic validator → sdk_client upsert wrapper.

## Notes

- Structured fields are typed Pydantic models mirroring the SDK shapes; JSON-string CLI options are parsed via `pydantic_core.from_json` in `mode="before"` validators (no untyped `json.loads` dicts), so the same models accept YAML-loaded structures in `load`.
- SCM API constraints honored: folder locked to `Mobile Users`; list/fetch require `name` (no enumerate-all), so `show`/`backup` take a required `--name`; create/update may return an empty body (payload echoed); fetch 404s surface as `InvalidObjectError`, handled in the upsert.
- Shared files (`validators.py`, `sdk_client.py`, `mobile_agent.py`, `mkdocs.yml`) touched in append-only delimited blocks.

## Validation

- `make quality` green locally (flake8, ruff format, mypy, pytest — 978 passed, 29 skipped)
- 21 new tests in `tests/test_infrastructure_global_settings_commands.py` (happy paths, no-change, validation errors, bad JSON, API errors, backup/load/dry-run)
- `scm <action> mobile-agent <object> --help` smoke-tested for all 7 new commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)