### PR TITLE
feat: GlobalProtect agent-profile and tunnel-profile commands (SDK 0.15.0)

### DIFF
--- a/docs/cli/mobile-agent/agent-profile.md
+++ b/docs/cli/mobile-agent/agent-profile.md
@@ -1,0 +1,203 @@
+# Agent Profile
+
+Agent profiles (called "App Settings" / "Application Settings" in the SCM UI) configure GlobalProtect app behavior for mobile users in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, show, backup, and load agent profiles.
+
+## Overview
+
+The `agent-profile` commands allow you to:
+
+- Create agent profiles with connect method, tunnel MTU, and OS targeting
+- Update existing agent profile configurations
+- Delete agent profiles that are no longer needed
+- Bulk import agent profiles from YAML files (including nested settings)
+- Export agent profiles for backup or migration
+
+!!! note "Folder restriction"
+    Agent profiles only exist in the `Mobile Users` folder. The `--folder` option defaults to `Mobile Users` and any other value is rejected. Snippet and device containers are not supported.
+
+## Set Agent Profile
+
+Create or update an agent profile.
+
+### Syntax
+
+```bash
+scm set mobile-agent agent-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location (defaults to `Mobile Users`) | No |
+| `--name TEXT` | Name of the agent profile | Yes |
+| `--connect-method TEXT` | Connect method (`user-logon`, `pre-logon`, `on-demand`, `pre-logon-then-on-demand`) | No |
+| `--tunnel-mtu INT` | GlobalProtect connection MTU in bytes (1000-1420) | No |
+| `--os TEXT` | Operating system, repeatable (`Android`, `Chrome`, `IoT`, `Linux`, `Mac`, `Windows`, `WindowsUWP`, `iOS`) | No |
+| `--save-user-credentials TEXT` | `0`=No, `1`=Yes, `2`=Save username only, `3`=Only with user fingerprint | No |
+| `--source-user TEXT` | Source user, repeatable | No |
+| `--third-party-vpn-client TEXT` | Third party VPN client, repeatable | No |
+
+Nested settings (agent UI, gateways, HIP collection, authentication override, certificates, custom checks, internal host detection) are supported through `scm load mobile-agent agent-profile`.
+
+### Examples
+
+#### Create Agent Profile
+
+```bash
+$ scm set mobile-agent agent-profile \
+    --folder "Mobile Users" \
+    --name "corp-app-settings" \
+    --connect-method user-logon \
+    --tunnel-mtu 1400 \
+    --os Windows --os Mac
+Created agent profile: corp-app-settings in folder Mobile Users
+```
+
+#### Update Save Credentials Behavior
+
+```bash
+$ scm set mobile-agent agent-profile \
+    --name "corp-app-settings" \
+    --save-user-credentials 3
+Updated agent profile: corp-app-settings in folder Mobile Users
+```
+
+## Show Agent Profile
+
+Display one or all agent profiles.
+
+### Syntax
+
+```bash
+scm show mobile-agent agent-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location (defaults to `Mobile Users`) | No |
+| `--name TEXT` | Name of the agent profile to show (lists all when omitted) | No |
+
+### Examples
+
+```bash
+# List all agent profiles
+$ scm show mobile-agent agent-profile
+
+# Show a specific agent profile
+$ scm show mobile-agent agent-profile --name "corp-app-settings"
+```
+
+## Delete Agent Profile
+
+Remove an agent profile.
+
+### Syntax
+
+```bash
+scm delete mobile-agent agent-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location (defaults to `Mobile Users`) | No |
+| `--name TEXT` | Name of the agent profile to delete | Yes |
+| `--force` | Skip the confirmation prompt | No |
+
+### Examples
+
+```bash
+$ scm delete mobile-agent agent-profile --name "corp-app-settings" --force
+Deleted agent profile: corp-app-settings from folder Mobile Users
+```
+
+## Backup Agent Profile
+
+Export all agent profiles in a folder to a YAML file.
+
+### Syntax
+
+```bash
+scm backup mobile-agent agent-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup from (defaults to `Mobile Users`) | No |
+| `--file PATH` | Output file path (defaults to `agent-profile-mobile-users.yaml`) | No |
+
+### Examples
+
+```bash
+$ scm backup mobile-agent agent-profile
+Successfully backed up 2 agent profiles to agent-profile-mobile-users.yaml
+```
+
+## Load Agent Profile
+
+Bulk create or update agent profiles from a YAML file. The YAML supports the full nested SDK structure.
+
+### Syntax
+
+```bash
+scm load mobile-agent agent-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file PATH` | YAML file to load configurations from | Yes |
+| `--dry-run` | Simulate execution without applying changes | No |
+| `--folder TEXT` | Override folder location for all objects | No |
+
+### YAML Schema
+
+```yaml
+agent_profiles:
+  - name: corp-app-settings
+    folder: "Mobile Users"
+    connect_method: user-logon   # convenience key, folded into gp_app_config
+    tunnel_mtu: 1400             # convenience key, folded into gp_app_config
+    os:
+      - Windows
+      - Mac
+    save_user_credentials: "0"
+    agent_ui:
+      max_agent_user_overrides: 5
+      agent_user_override_timeout: 60
+    gateways:
+      external:
+        list:
+          - name: gw-us-east
+            choice:
+              fqdn: gw-us-east.example.com
+            priority_rule:
+              - name: default
+                priority: "1"
+    hip_collection:
+      collect_hip_data: true
+      max_wait_time: 20
+```
+
+!!! tip "gp_app_config precedence"
+    If a profile specifies `gp_app_config` directly, it takes precedence and the `connect_method` / `tunnel_mtu` convenience keys are ignored.
+
+### Examples
+
+```bash
+# Validate without applying
+$ scm load mobile-agent agent-profile --file agent_profiles.yml --dry-run
+
+# Apply
+$ scm load mobile-agent agent-profile --file agent_profiles.yml
+Created agent profile: corp-app-settings
+
+Summary: 1 created, 0 updated, 0 unchanged
+```

--- a/docs/cli/mobile-agent/tunnel-profile.md
+++ b/docs/cli/mobile-agent/tunnel-profile.md
@@ -1,0 +1,192 @@
+# Tunnel Profile
+
+Tunnel profiles configure GlobalProtect tunnel settings (split tunneling, framed IP retrieval, local network access) for mobile users in Strata Cloud Manager. The `scm` CLI provides commands to create, update, delete, show, backup, and load tunnel profiles.
+
+## Overview
+
+The `tunnel-profile` commands allow you to:
+
+- Create tunnel profiles with split tunneling routes and applications
+- Update existing tunnel profile configurations
+- Delete tunnel profiles that are no longer needed
+- Bulk import tunnel profiles from YAML files (including nested settings)
+- Export tunnel profiles for backup or migration
+
+!!! note "Folder restriction"
+    Tunnel profiles only exist in the `Mobile Users` folder. The `--folder` option defaults to `Mobile Users` and any other value is rejected. Snippet and device containers are not supported. Profile names are limited to 31 characters.
+
+## Set Tunnel Profile
+
+Create or update a tunnel profile.
+
+### Syntax
+
+```bash
+scm set mobile-agent tunnel-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location (defaults to `Mobile Users`) | No |
+| `--name TEXT` | Name of the tunnel profile (max 31 chars) | Yes |
+| `--no-direct-access-to-local-network / --allow-direct-access-to-local-network` | Disable/allow direct access to the local network | No |
+| `--retrieve-framed-ip-address / --no-retrieve-framed-ip-address` | Retrieve the framed IP address from the authentication server | No |
+| `--os TEXT` | Operating system, repeatable (`Android`, `Chrome`, `IoT`, `Linux`, `Mac`, `Windows`, `WindowsUWP`, `iOS`) | No |
+| `--source-user TEXT` | Source user, repeatable | No |
+| `--access-route TEXT` | Route included in the tunnel, repeatable | No |
+| `--exclude-access-route TEXT` | Route excluded from the tunnel, repeatable | No |
+| `--include-application TEXT` | Application included in the tunnel, repeatable | No |
+| `--exclude-application TEXT` | Application excluded from the tunnel, repeatable | No |
+
+Nested settings (authentication override cookies, source address, split tunneling domains) are supported through `scm load mobile-agent tunnel-profile`.
+
+### Examples
+
+#### Create Tunnel Profile with Split Tunneling
+
+```bash
+$ scm set mobile-agent tunnel-profile \
+    --folder "Mobile Users" \
+    --name "corp-tunnel" \
+    --access-route 10.0.0.0/8 \
+    --exclude-access-route 192.168.1.0/24 \
+    --no-direct-access-to-local-network
+Created tunnel profile: corp-tunnel in folder Mobile Users
+```
+
+## Show Tunnel Profile
+
+Display one or all tunnel profiles.
+
+### Syntax
+
+```bash
+scm show mobile-agent tunnel-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location (defaults to `Mobile Users`) | No |
+| `--name TEXT` | Name of the tunnel profile to show (lists all when omitted) | No |
+
+### Examples
+
+```bash
+# List all tunnel profiles
+$ scm show mobile-agent tunnel-profile
+
+# Show a specific tunnel profile
+$ scm show mobile-agent tunnel-profile --name "corp-tunnel"
+```
+
+## Delete Tunnel Profile
+
+Remove a tunnel profile.
+
+### Syntax
+
+```bash
+scm delete mobile-agent tunnel-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder location (defaults to `Mobile Users`) | No |
+| `--name TEXT` | Name of the tunnel profile to delete | Yes |
+| `--force` | Skip the confirmation prompt | No |
+
+### Examples
+
+```bash
+$ scm delete mobile-agent tunnel-profile --name "corp-tunnel" --force
+Deleted tunnel profile: corp-tunnel from folder Mobile Users
+```
+
+## Backup Tunnel Profile
+
+Export all tunnel profiles in a folder to a YAML file.
+
+### Syntax
+
+```bash
+scm backup mobile-agent tunnel-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--folder TEXT` | Folder to backup from (defaults to `Mobile Users`) | No |
+| `--file PATH` | Output file path (defaults to `tunnel-profile-mobile-users.yaml`) | No |
+
+### Examples
+
+```bash
+$ scm backup mobile-agent tunnel-profile
+Successfully backed up 2 tunnel profiles to tunnel-profile-mobile-users.yaml
+```
+
+## Load Tunnel Profile
+
+Bulk create or update tunnel profiles from a YAML file. The YAML supports the full nested SDK structure.
+
+### Syntax
+
+```bash
+scm load mobile-agent tunnel-profile [OPTIONS]
+```
+
+### Options
+
+| Option | Description | Required |
+| --- | --- | --- |
+| `--file PATH` | YAML file to load configurations from | Yes |
+| `--dry-run` | Simulate execution without applying changes | No |
+| `--folder TEXT` | Override folder location for all objects | No |
+
+### YAML Schema
+
+```yaml
+tunnel_profiles:
+  - name: corp-tunnel
+    folder: "Mobile Users"
+    no_direct_access_to_local_network: true
+    retrieve_framed_ip_address: false
+    os:
+      - Windows
+      - Mac
+    access_route:            # convenience key, folded into split_tunneling
+      - 10.0.0.0/8
+    exclude_access_route:    # convenience key, folded into split_tunneling
+      - 192.168.1.0/24
+    authentication_override:
+      accept_cookie:
+        generate_cookie: true
+        cookie_lifetime:
+          lifetime_in_hours: 24
+    source_address:
+      region:
+        - US
+```
+
+!!! tip "split_tunneling precedence"
+    If a profile specifies `split_tunneling` directly, it takes precedence and the `access_route` / `exclude_access_route` / `include_applications` / `exclude_applications` convenience keys are ignored.
+
+### Examples
+
+```bash
+# Validate without applying
+$ scm load mobile-agent tunnel-profile --file tunnel_profiles.yml --dry-run
+
+# Apply
+$ scm load mobile-agent tunnel-profile --file tunnel_profiles.yml
+Created tunnel profile: corp-tunnel
+
+Summary: 1 created, 0 updated, 0 unchanged
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,9 +159,11 @@ nav:
           - TACACS+ Server Profile: cli/identity/tacacs-server-profile.md
       - Mobile Agent:
           - Agent Version: cli/mobile-agent/agent-version.md
+          - Agent Profile: cli/mobile-agent/agent-profile.md
           - Auth Setting: cli/mobile-agent/auth-setting.md
           - Forwarding Profile: cli/mobile-agent/forwarding-profile.md
           - Forwarding Profile Destination: cli/mobile-agent/forwarding-profile-destination.md
+          - Tunnel Profile: cli/mobile-agent/tunnel-profile.md
           - SDK Reference: cli/mobile-agent/sdk-mobile-agent.md
       - Local Config:
           - Overview: cli/local/index.md

--- a/src/scm_cli/commands/mobile_agent.py
+++ b/src/scm_cli/commands/mobile_agent.py
@@ -15,7 +15,7 @@ from ..utils import validate_location_params
 from ..utils.config import load_from_yaml, settings
 from ..utils.context import get_current_context
 from ..utils.sdk_client import scm_client
-from ..utils.validators import AuthSetting, ForwardingProfile, ForwardingProfileDestination
+from ..utils.validators import AgentProfile, AuthSetting, ForwardingProfile, ForwardingProfileDestination, TunnelProfile
 
 # =============================================================================================================================================================================================
 # HELPER FUNCTIONS
@@ -1142,4 +1142,639 @@ def show_forwarding_profile_destination(
 
     except Exception as e:
         typer.echo(f"Error showing forwarding profile destination: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# =============================================================================================================================================================================================
+# AGENT PROFILE COMMANDS (agent3)
+# =============================================================================================================================================================================================
+
+# Agent/tunnel profiles live only in the 'Mobile Users' folder (no snippet/device)
+GP_FOLDER_OPTION = typer.Option(
+    "Mobile Users",
+    "--folder",
+    help="Folder path (GlobalProtect profiles only support 'Mobile Users')",
+)
+
+# Module-level option constants for repeatable list options (avoids B008 lint errors)
+GP_OS_OPTION: list[str] | None = typer.Option(
+    None,
+    "--os",
+    help="Operating system (repeatable: Android, Chrome, IoT, Linux, Mac, Windows, WindowsUWP, iOS)",
+)
+GP_SOURCE_USER_OPTION: list[str] | None = typer.Option(
+    None,
+    "--source-user",
+    help="Source user this profile applies to (repeatable)",
+)
+GP_THIRD_PARTY_VPN_CLIENT_OPTION: list[str] | None = typer.Option(
+    None,
+    "--third-party-vpn-client",
+    help="Third party VPN client supported by this profile (repeatable)",
+)
+GP_ACCESS_ROUTE_OPTION: list[str] | None = typer.Option(
+    None,
+    "--access-route",
+    help="Route included in the tunnel (repeatable)",
+)
+GP_EXCLUDE_ACCESS_ROUTE_OPTION: list[str] | None = typer.Option(
+    None,
+    "--exclude-access-route",
+    help="Route excluded from the tunnel (repeatable)",
+)
+GP_INCLUDE_APPLICATION_OPTION: list[str] | None = typer.Option(
+    None,
+    "--include-application",
+    help="Application included in the tunnel (repeatable)",
+)
+GP_EXCLUDE_APPLICATION_OPTION: list[str] | None = typer.Option(
+    None,
+    "--exclude-application",
+    help="Application excluded from the tunnel (repeatable)",
+)
+
+
+def _echo_nested(profile: dict[str, Any], keys: tuple[str, ...]) -> None:
+    """Echo nested dict fields of a profile as indented YAML blocks."""
+    for key in keys:
+        if profile.get(key):
+            typer.echo(f"{key.replace('_', ' ').title()}:")
+            block = yaml.dump(profile[key], default_flow_style=False, sort_keys=False)
+            typer.echo("\n".join(f"  {line}" for line in block.splitlines()))
+
+
+@backup_app.command("agent-profile")
+def backup_agent_profile(
+    folder: str = GP_FOLDER_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+):
+    """Backup all agent profiles from a folder to a YAML file.
+
+    Examples
+    --------
+        # Backup from the Mobile Users folder
+        scm backup mobile-agent agent-profile --folder "Mobile Users"
+
+        # Backup with custom output file
+        scm backup mobile-agent agent-profile --file agent-profiles-backup.yaml
+
+    """
+    try:
+        profiles = scm_client.list_agent_profiles(folder=folder)
+
+        if not profiles:
+            typer.echo(f"No agent profiles found in folder '{folder}'")
+            return
+
+        backup_data = []
+        for profile in profiles:
+            profile_dict = {k: v for k, v in profile.items() if v is not None}
+            profile_dict.pop("id", None)
+            backup_data.append(profile_dict)
+
+        yaml_data = {"agent_profiles": backup_data}
+
+        if file is None:
+            file = Path(get_default_backup_filename("agent-profile", "folder", folder))
+
+        with file.open("w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} agent profiles to {file}")
+        return str(file)
+
+    except Exception as e:
+        typer.echo(f"Error backing up agent profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("agent-profile")
+def delete_agent_profile(
+    folder: str = GP_FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+):
+    """Delete an agent profile.
+
+    Examples
+    --------
+        scm delete mobile-agent agent-profile --folder "Mobile Users" --name "corp-app-settings"
+
+    """
+    try:
+        if not force:
+            typer.confirm(f"Delete agent profile '{name}' from folder '{folder}'?", abort=True)
+        result = scm_client.delete_agent_profile(folder=folder, name=name)
+        if result:
+            typer.echo(f"Deleted agent profile: {name} from folder {folder}")
+        return result
+    except Exception as e:
+        typer.echo(f"Error deleting agent profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("agent-profile")
+def load_agent_profile(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+):
+    """Load agent profiles from a YAML file.
+
+    Examples
+    --------
+        # Load from file
+        scm load mobile-agent agent-profile --file config/agent_profiles.yml
+
+        # Load with folder override
+        scm load mobile-agent agent-profile --file config/agent_profiles.yml --folder "Mobile Users"
+
+    """
+    try:
+        config = load_from_yaml(str(file), "agent_profiles")
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            typer.echo(yaml.dump(config["agent_profiles"]))
+            return None
+
+        results = []
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+
+        for profile_data in config["agent_profiles"]:
+            try:
+                if folder:
+                    profile_data["folder"] = folder
+
+                agent_profile = AgentProfile(**profile_data)
+                sdk_data = agent_profile.to_sdk_model()
+
+                result = scm_client.create_agent_profile(**sdk_data)
+
+                action = result.pop("__action__", "created")
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created agent profile: {result.get('name', 'N/A')}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated agent profile: {result.get('name', 'N/A')}")
+                elif action == "no_change":
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for agent profile: {result.get('name', 'N/A')}")
+
+                results.append(result)
+
+            except Exception as e:
+                typer.echo(f"Error loading agent profile '{profile_data.get('name', 'unknown')}': {str(e)}", err=True)
+
+        typer.echo(f"\nSummary: {created_count} created, {updated_count} updated, {no_change_count} unchanged")
+
+        return results
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error loading agent profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("agent-profile")
+def set_agent_profile(
+    folder: str = GP_FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    os: list[str] | None = GP_OS_OPTION,
+    connect_method: str | None = typer.Option(None, "--connect-method", help="Connect method (user-logon, pre-logon, on-demand, pre-logon-then-on-demand)"),
+    tunnel_mtu: int | None = typer.Option(None, "--tunnel-mtu", help="GlobalProtect connection MTU in bytes (1000-1420)"),
+    save_user_credentials: str | None = typer.Option(None, "--save-user-credentials", help="Save user credentials: 0=No, 1=Yes, 2=Save username only, 3=Only with user fingerprint"),
+    source_user: list[str] | None = GP_SOURCE_USER_OPTION,
+    third_party_vpn_clients: list[str] | None = GP_THIRD_PARTY_VPN_CLIENT_OPTION,
+):
+    r"""Create or update an agent profile (GlobalProtect app settings).
+
+    Nested settings (agent UI, gateways, HIP collection, ...) are supported via
+    `scm load mobile-agent agent-profile`.
+
+    Examples
+    --------
+        scm set mobile-agent agent-profile \
+        --folder "Mobile Users" \
+        --name "corp-app-settings" \
+        --connect-method user-logon \
+        --tunnel-mtu 1400 \
+        --os Windows --os Mac
+
+    """
+    try:
+        profile_data: dict[str, Any] = {
+            "name": name,
+            "folder": folder,
+        }
+
+        if os:
+            profile_data["os"] = os
+        if connect_method is not None:
+            profile_data["connect_method"] = connect_method
+        if tunnel_mtu is not None:
+            profile_data["tunnel_mtu"] = tunnel_mtu
+        if save_user_credentials is not None:
+            profile_data["save_user_credentials"] = save_user_credentials
+        if source_user:
+            profile_data["source_user"] = source_user
+        if third_party_vpn_clients:
+            profile_data["third_party_vpn_clients"] = third_party_vpn_clients
+
+        agent_profile = AgentProfile(**profile_data)
+        sdk_data = agent_profile.to_sdk_model()
+
+        result = scm_client.create_agent_profile(**sdk_data)
+
+        action = result.pop("__action__", "created")
+
+        if action == "created":
+            typer.echo(f"Created agent profile: {result.get('name', name)} in folder {result.get('folder', folder)}")
+        elif action == "updated":
+            typer.echo(f"Updated agent profile: {result.get('name', name)} in folder {result.get('folder', folder)}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for agent profile: {result.get('name', name)} in folder {result.get('folder', folder)}")
+
+        return result
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating agent profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("agent-profile")
+def show_agent_profile(
+    folder: str = GP_FOLDER_OPTION,
+    name: str | None = typer.Option(None, "--name", help="Name of the agent profile to show"),
+):
+    """Display agent profiles (GlobalProtect app settings).
+
+    Examples
+    --------
+        # List all agent profiles (default behavior)
+        scm show mobile-agent agent-profile --folder "Mobile Users"
+
+        # Show a specific agent profile by name
+        scm show mobile-agent agent-profile --folder "Mobile Users" --name "corp-app-settings"
+
+    """
+    try:
+        show_context_info()
+
+        if name:
+            profile = scm_client.get_agent_profile(folder=folder, name=name)
+
+            typer.echo(f"\nAgent Profile: {profile.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+            typer.echo(f"Location: Folder '{profile.get('folder', folder)}'")
+
+            if profile.get("os"):
+                typer.echo(f"OS: {', '.join(profile['os'])}")
+            if profile.get("save_user_credentials") is not None:
+                typer.echo(f"Save User Credentials: {profile['save_user_credentials']}")
+            if profile.get("source_user"):
+                typer.echo(f"Source Users: {', '.join(profile['source_user'])}")
+            if profile.get("third_party_vpn_clients"):
+                typer.echo(f"Third Party VPN Clients: {', '.join(profile['third_party_vpn_clients'])}")
+            _echo_nested(
+                profile,
+                (
+                    "gp_app_config",
+                    "agent_ui",
+                    "authentication_override",
+                    "certificate",
+                    "client_certificate",
+                    "custom_checks",
+                    "gateways",
+                    "hip_collection",
+                    "internal_host_detection",
+                    "internal_host_detection_v6",
+                    "machine_account_exists_with_serialno",
+                ),
+            )
+            if profile.get("id"):
+                typer.echo(f"ID: {profile['id']}")
+
+            return profile
+
+        else:
+            profiles = scm_client.list_agent_profiles(folder=folder)
+
+            if not profiles:
+                typer.echo(f"No agent profiles found in folder '{folder}'")
+                return
+
+            typer.echo(f"\nAgent Profiles in folder '{folder}':")
+            typer.echo("-" * 60)
+
+            for profile in profiles:
+                typer.echo(f"Name: {profile.get('name', 'N/A')}")
+                if profile.get("os"):
+                    typer.echo(f"  OS: {', '.join(profile['os'])}")
+                if profile.get("save_user_credentials") is not None:
+                    typer.echo(f"  Save User Credentials: {profile['save_user_credentials']}")
+                typer.echo("-" * 60)
+
+            return profiles
+
+    except Exception as e:
+        typer.echo(f"Error showing agent profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+# =============================================================================================================================================================================================
+# TUNNEL PROFILE COMMANDS (agent3)
+# =============================================================================================================================================================================================
+
+
+@backup_app.command("tunnel-profile")
+def backup_tunnel_profile(
+    folder: str = GP_FOLDER_OPTION,
+    file: Path | None = BACKUP_FILE_OPTION,
+):
+    """Backup all tunnel profiles from a folder to a YAML file.
+
+    Examples
+    --------
+        # Backup from the Mobile Users folder
+        scm backup mobile-agent tunnel-profile --folder "Mobile Users"
+
+        # Backup with custom output file
+        scm backup mobile-agent tunnel-profile --file tunnel-profiles-backup.yaml
+
+    """
+    try:
+        profiles = scm_client.list_tunnel_profiles(folder=folder)
+
+        if not profiles:
+            typer.echo(f"No tunnel profiles found in folder '{folder}'")
+            return
+
+        backup_data = []
+        for profile in profiles:
+            profile_dict = {k: v for k, v in profile.items() if v is not None}
+            profile_dict.pop("id", None)
+            backup_data.append(profile_dict)
+
+        yaml_data = {"tunnel_profiles": backup_data}
+
+        if file is None:
+            file = Path(get_default_backup_filename("tunnel-profile", "folder", folder))
+
+        with file.open("w") as f:
+            yaml.dump(yaml_data, f, default_flow_style=False, sort_keys=False)
+
+        typer.echo(f"Successfully backed up {len(backup_data)} tunnel profiles to {file}")
+        return str(file)
+
+    except Exception as e:
+        typer.echo(f"Error backing up tunnel profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@delete_app.command("tunnel-profile")
+def delete_tunnel_profile(
+    folder: str = GP_FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
+):
+    """Delete a tunnel profile.
+
+    Examples
+    --------
+        scm delete mobile-agent tunnel-profile --folder "Mobile Users" --name "corp-tunnel"
+
+    """
+    try:
+        if not force:
+            typer.confirm(f"Delete tunnel profile '{name}' from folder '{folder}'?", abort=True)
+        result = scm_client.delete_tunnel_profile(folder=folder, name=name)
+        if result:
+            typer.echo(f"Deleted tunnel profile: {name} from folder {folder}")
+        return result
+    except Exception as e:
+        typer.echo(f"Error deleting tunnel profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@load_app.command("tunnel-profile")
+def load_tunnel_profile(
+    file: Path = FILE_OPTION,
+    dry_run: bool = DRY_RUN_OPTION,
+    folder: str = LOAD_FOLDER_OPTION,
+):
+    """Load tunnel profiles from a YAML file.
+
+    Examples
+    --------
+        # Load from file
+        scm load mobile-agent tunnel-profile --file config/tunnel_profiles.yml
+
+        # Load with folder override
+        scm load mobile-agent tunnel-profile --file config/tunnel_profiles.yml --folder "Mobile Users"
+
+    """
+    try:
+        config = load_from_yaml(str(file), "tunnel_profiles")
+
+        if dry_run:
+            typer.echo("Dry run mode: would apply the following configurations:")
+            typer.echo(yaml.dump(config["tunnel_profiles"]))
+            return None
+
+        results = []
+        created_count = 0
+        updated_count = 0
+        no_change_count = 0
+
+        for profile_data in config["tunnel_profiles"]:
+            try:
+                if folder:
+                    profile_data["folder"] = folder
+
+                tunnel_profile = TunnelProfile(**profile_data)
+                sdk_data = tunnel_profile.to_sdk_model()
+
+                result = scm_client.create_tunnel_profile(**sdk_data)
+
+                action = result.pop("__action__", "created")
+                if action == "created":
+                    created_count += 1
+                    typer.echo(f"Created tunnel profile: {result.get('name', 'N/A')}")
+                elif action == "updated":
+                    updated_count += 1
+                    typer.echo(f"Updated tunnel profile: {result.get('name', 'N/A')}")
+                elif action == "no_change":
+                    no_change_count += 1
+                    typer.echo(f"No changes needed for tunnel profile: {result.get('name', 'N/A')}")
+
+                results.append(result)
+
+            except Exception as e:
+                typer.echo(f"Error loading tunnel profile '{profile_data.get('name', 'unknown')}': {str(e)}", err=True)
+
+        typer.echo(f"\nSummary: {created_count} created, {updated_count} updated, {no_change_count} unchanged")
+
+        return results
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error loading tunnel profiles: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@set_app.command("tunnel-profile")
+def set_tunnel_profile(
+    folder: str = GP_FOLDER_OPTION,
+    name: str = NAME_OPTION,
+    no_direct_access_to_local_network: bool | None = typer.Option(
+        None,
+        "--no-direct-access-to-local-network/--allow-direct-access-to-local-network",
+        help="Disable direct access to the local network",
+    ),
+    retrieve_framed_ip_address: bool | None = typer.Option(
+        None,
+        "--retrieve-framed-ip-address/--no-retrieve-framed-ip-address",
+        help="Retrieve the framed IP address from the authentication server",
+    ),
+    os: list[str] | None = GP_OS_OPTION,
+    source_user: list[str] | None = GP_SOURCE_USER_OPTION,
+    access_route: list[str] | None = GP_ACCESS_ROUTE_OPTION,
+    exclude_access_route: list[str] | None = GP_EXCLUDE_ACCESS_ROUTE_OPTION,
+    include_applications: list[str] | None = GP_INCLUDE_APPLICATION_OPTION,
+    exclude_applications: list[str] | None = GP_EXCLUDE_APPLICATION_OPTION,
+):
+    r"""Create or update a tunnel profile (GlobalProtect tunnel settings).
+
+    Nested settings (authentication override, source address, split tunneling
+    domains) are supported via `scm load mobile-agent tunnel-profile`.
+
+    Examples
+    --------
+        scm set mobile-agent tunnel-profile \
+        --folder "Mobile Users" \
+        --name "corp-tunnel" \
+        --access-route 10.0.0.0/8 \
+        --no-direct-access-to-local-network
+
+    """
+    try:
+        profile_data: dict[str, Any] = {
+            "name": name,
+            "folder": folder,
+        }
+
+        if no_direct_access_to_local_network is not None:
+            profile_data["no_direct_access_to_local_network"] = no_direct_access_to_local_network
+        if retrieve_framed_ip_address is not None:
+            profile_data["retrieve_framed_ip_address"] = retrieve_framed_ip_address
+        if os:
+            profile_data["os"] = os
+        if source_user:
+            profile_data["source_user"] = source_user
+        if access_route:
+            profile_data["access_route"] = access_route
+        if exclude_access_route:
+            profile_data["exclude_access_route"] = exclude_access_route
+        if include_applications:
+            profile_data["include_applications"] = include_applications
+        if exclude_applications:
+            profile_data["exclude_applications"] = exclude_applications
+
+        tunnel_profile = TunnelProfile(**profile_data)
+        sdk_data = tunnel_profile.to_sdk_model()
+
+        result = scm_client.create_tunnel_profile(**sdk_data)
+
+        action = result.pop("__action__", "created")
+
+        if action == "created":
+            typer.echo(f"Created tunnel profile: {result.get('name', name)} in folder {result.get('folder', folder)}")
+        elif action == "updated":
+            typer.echo(f"Updated tunnel profile: {result.get('name', name)} in folder {result.get('folder', folder)}")
+        elif action == "no_change":
+            typer.echo(f"No changes needed for tunnel profile: {result.get('name', name)} in folder {result.get('folder', folder)}")
+
+        return result
+
+    except ValidationError as e:
+        typer.echo(f"Validation error: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+    except Exception as e:
+        typer.echo(f"Error creating/updating tunnel profile: {str(e)}", err=True)
+        raise typer.Exit(code=1) from e
+
+
+@show_app.command("tunnel-profile")
+def show_tunnel_profile(
+    folder: str = GP_FOLDER_OPTION,
+    name: str | None = typer.Option(None, "--name", help="Name of the tunnel profile to show"),
+):
+    """Display tunnel profiles (GlobalProtect tunnel settings).
+
+    Examples
+    --------
+        # List all tunnel profiles (default behavior)
+        scm show mobile-agent tunnel-profile --folder "Mobile Users"
+
+        # Show a specific tunnel profile by name
+        scm show mobile-agent tunnel-profile --folder "Mobile Users" --name "corp-tunnel"
+
+    """
+    try:
+        show_context_info()
+
+        if name:
+            profile = scm_client.get_tunnel_profile(folder=folder, name=name)
+
+            typer.echo(f"\nTunnel Profile: {profile.get('name', 'N/A')}")
+            typer.echo("=" * 80)
+            typer.echo(f"Location: Folder '{profile.get('folder', folder)}'")
+
+            if profile.get("no_direct_access_to_local_network") is not None:
+                typer.echo(f"No Direct Access To Local Network: {profile['no_direct_access_to_local_network']}")
+            if profile.get("retrieve_framed_ip_address") is not None:
+                typer.echo(f"Retrieve Framed IP Address: {profile['retrieve_framed_ip_address']}")
+            if profile.get("os"):
+                typer.echo(f"OS: {', '.join(profile['os'])}")
+            if profile.get("source_user"):
+                typer.echo(f"Source Users: {', '.join(profile['source_user'])}")
+            _echo_nested(profile, ("split_tunneling", "source_address", "authentication_override"))
+            if profile.get("id"):
+                typer.echo(f"ID: {profile['id']}")
+
+            return profile
+
+        else:
+            profiles = scm_client.list_tunnel_profiles(folder=folder)
+
+            if not profiles:
+                typer.echo(f"No tunnel profiles found in folder '{folder}'")
+                return
+
+            typer.echo(f"\nTunnel Profiles in folder '{folder}':")
+            typer.echo("-" * 60)
+
+            for profile in profiles:
+                typer.echo(f"Name: {profile.get('name', 'N/A')}")
+                if profile.get("os"):
+                    typer.echo(f"  OS: {', '.join(profile['os'])}")
+                if profile.get("no_direct_access_to_local_network") is not None:
+                    typer.echo(f"  No Direct Access To Local Network: {profile['no_direct_access_to_local_network']}")
+                typer.echo("-" * 60)
+
+            return profiles
+
+    except Exception as e:
+        typer.echo(f"Error showing tunnel profile: {str(e)}", err=True)
         raise typer.Exit(code=1) from e

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -11081,6 +11081,431 @@ class SCMClient:
         except Exception as e:
             self._handle_api_exception("deletion", container or "", name or "", e)
 
+    # ------------------------------------------------------------------------------ GlobalProtect Agent Profile (agent3) ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_not_found_error(exception: Exception) -> bool:
+        """Check whether an SDK exception represents a 404 / not-found condition.
+
+        The mobile-agent profile services raise InvalidObjectError with
+        http_status_code 404 (rather than NotFoundError) when a fetch matches
+        nothing.
+        """
+        if isinstance(exception, NotFoundError):
+            return True
+        return getattr(exception, "http_status_code", None) == 404
+
+    def create_agent_profile(
+        self,
+        folder: str | None = None,
+        name: str = None,
+        os: list[str] | None = None,
+        save_user_credentials: str | None = None,
+        source_user: list[str] | None = None,
+        third_party_vpn_clients: list[str] | None = None,
+        agent_ui: dict[str, Any] | None = None,
+        authentication_override: dict[str, Any] | None = None,
+        certificate: dict[str, Any] | None = None,
+        client_certificate: dict[str, Any] | None = None,
+        custom_checks: dict[str, Any] | None = None,
+        gateways: dict[str, Any] | None = None,
+        gp_app_config: dict[str, Any] | None = None,
+        hip_collection: dict[str, Any] | None = None,
+        internal_host_detection: dict[str, Any] | None = None,
+        internal_host_detection_v6: dict[str, Any] | None = None,
+        machine_account_exists_with_serialno: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create or update a GlobalProtect agent profile using smart upsert logic.
+
+        Agent profiles live only in the 'Mobile Users' folder and are addressed by
+        name (the API exposes no ID-based endpoints). Updates send the merged field
+        set; each provided field replaces the existing value wholesale.
+
+        Args:
+            folder: Folder containing the agent profile (must be 'Mobile Users')
+            name: Name of the agent profile
+            os: Operating systems this profile applies to
+            save_user_credentials: Save user credentials behavior ('0'-'3')
+            source_user: Source users this profile applies to
+            third_party_vpn_clients: Supported third party VPN clients
+            agent_ui: Agent UI configuration settings
+            authentication_override: Authentication override settings
+            certificate: Certificate settings
+            client_certificate: Client certificate settings
+            custom_checks: Custom checks settings
+            gateways: Gateways configuration
+            gp_app_config: GlobalProtect app configuration (connect-method / tunnel-mtu)
+            hip_collection: HIP collection settings
+            internal_host_detection: Internal host detection (IPv4) settings
+            internal_host_detection_v6: Internal host detection (IPv6) settings
+            machine_account_exists_with_serialno: Machine account / serial number setting
+
+        Returns:
+            dict[str, Any]: The created/updated agent profile object with __action__ field
+
+        """
+        provided_fields: dict[str, Any] = {
+            key: value
+            for key, value in {
+                "os": os,
+                "save_user_credentials": save_user_credentials,
+                "source_user": source_user,
+                "third_party_vpn_clients": third_party_vpn_clients,
+                "agent_ui": agent_ui,
+                "authentication_override": authentication_override,
+                "certificate": certificate,
+                "client_certificate": client_certificate,
+                "custom_checks": custom_checks,
+                "gateways": gateways,
+                "gp_app_config": gp_app_config,
+                "hip_collection": hip_collection,
+                "internal_host_detection": internal_host_detection,
+                "internal_host_detection_v6": internal_host_detection_v6,
+                "machine_account_exists_with_serialno": machine_account_exists_with_serialno,
+            }.items()
+            if value is not None
+        }
+
+        self.logger.info(f"Creating or updating agent profile: {name} in folder {folder}")
+
+        if not self.client:
+            result = {"id": f"ap-{name}", "folder": folder, "name": name, **provided_fields, "__action__": "created"}
+            return {k: v for k, v in result.items() if v is not None}
+
+        try:
+            existing = None
+            try:
+                existing = self.client.agent_profile.fetch(name=name, folder=folder)
+                self.logger.info(f"Found existing agent profile '{name}' in folder '{folder}'")
+            except Exception as fetch_error:
+                if self._is_not_found_error(fetch_error):
+                    self.logger.info(f"Agent profile '{name}' not found in folder '{folder}', will create new")
+                else:
+                    self.logger.warning(f"Error fetching agent profile '{name}': {str(fetch_error)}")
+
+            if existing:
+                existing_data = json.loads(existing.model_dump_json(exclude_unset=True))
+                changed_fields = [key for key, value in provided_fields.items() if existing_data.get(key) != value]
+
+                if changed_fields:
+                    self.logger.info(f"Updating agent profile fields: {', '.join(changed_fields)}")
+                    update_data = {"name": name, "folder": folder, **provided_fields}
+                    result = self.client.agent_profile.update(update_data)
+                    if result is None:
+                        # The API may return 200 with no body; re-fetch for the response
+                        result = self.client.agent_profile.fetch(name=name, folder=folder)
+                    self.logger.info(f"Successfully updated agent profile '{name}' in folder '{folder}'")
+                    response = json.loads(result.model_dump_json(exclude_unset=True))
+                    response["__action__"] = "updated"
+                    return response
+                else:
+                    self.logger.info(f"No changes detected for agent profile '{name}', skipping update")
+                    response = existing_data
+                    response["__action__"] = "no_change"
+                    return response
+            else:
+                profile_data = {"name": name, "folder": folder, **provided_fields}
+                result = self.client.agent_profile.create(profile_data)
+                self.logger.info(f"Successfully created agent profile '{name}' in folder '{folder}'")
+                response = json.loads(result.model_dump_json(exclude_unset=True))
+                response["__action__"] = "created"
+                return response
+
+        except Exception as e:
+            self._handle_api_exception("create/update", folder or "", name or "", e)
+
+    def get_agent_profile(
+        self,
+        folder: str | None = None,
+        name: str = None,
+    ) -> dict[str, Any]:
+        """Get a GlobalProtect agent profile by name.
+
+        Args:
+            folder: Folder containing the agent profile (must be 'Mobile Users')
+            name: Name of the agent profile to get
+
+        Returns:
+            dict[str, Any]: The agent profile object
+
+        """
+        self.logger.info(f"Getting agent profile: {name} from folder {folder}")
+
+        if not self.client:
+            return {
+                "id": f"ap-{name}",
+                "folder": folder or "Mobile Users",
+                "name": name,
+                "os": ["Windows", "Mac"],
+                "save_user_credentials": "0",
+                "gp_app_config": {"config": [{"name": "connect-method", "value": ["user-logon"]}]},
+            }
+
+        try:
+            result = self.client.agent_profile.fetch(name=name, folder=folder)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", folder or "", name or "", e)
+
+    def list_agent_profiles(
+        self,
+        folder: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List GlobalProtect agent profiles.
+
+        Args:
+            folder: Folder to list from (must be 'Mobile Users')
+
+        Returns:
+            list[dict[str, Any]]: List of agent profile objects
+
+        """
+        self.logger.info(f"Listing agent profiles in folder: {folder}")
+
+        if not self.client:
+            return [
+                {
+                    "id": "ap-mock1",
+                    "folder": folder or "Mobile Users",
+                    "name": "corp-app-settings",
+                    "os": ["Windows"],
+                    "save_user_credentials": "0",
+                },
+                {
+                    "id": "ap-mock2",
+                    "folder": folder or "Mobile Users",
+                    "name": "byod-app-settings",
+                    "os": ["iOS", "Android"],
+                    "save_user_credentials": "3",
+                },
+            ]
+
+        try:
+            results = self.client.agent_profile.list(folder=folder)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or "", "agent profiles", e)
+
+    def delete_agent_profile(
+        self,
+        folder: str | None = None,
+        name: str = None,
+    ) -> bool:
+        """Delete a GlobalProtect agent profile.
+
+        The API deletes by name and folder query parameters; no ID is involved.
+
+        Args:
+            folder: Folder containing the agent profile (must be 'Mobile Users')
+            name: Name of the agent profile to delete
+
+        Returns:
+            bool: True if deletion was successful
+
+        """
+        self.logger.info(f"Deleting agent profile: {name} from folder {folder}")
+
+        if not self.client:
+            return True
+
+        try:
+            self.client.agent_profile.delete(name=name, folder=folder)
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", folder or "", name or "", e)
+
+    # ------------------------------------------------------------------------------ GlobalProtect Tunnel Profile (agent3) -----------------------------------------------------------------
+
+    def create_tunnel_profile(
+        self,
+        folder: str | None = None,
+        name: str = None,
+        no_direct_access_to_local_network: bool | None = None,
+        retrieve_framed_ip_address: bool | None = None,
+        os: list[str] | None = None,
+        source_user: list[str] | None = None,
+        authentication_override: dict[str, Any] | None = None,
+        source_address: dict[str, Any] | None = None,
+        split_tunneling: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create or update a GlobalProtect tunnel profile using smart upsert logic.
+
+        Tunnel profiles live only in the 'Mobile Users' folder and are addressed by
+        name. The folder travels as a query parameter and must NOT appear in the
+        request body.
+
+        Args:
+            folder: Folder containing the tunnel profile (must be 'Mobile Users')
+            name: Name of the tunnel profile
+            no_direct_access_to_local_network: Disable direct access to the local network
+            retrieve_framed_ip_address: Retrieve framed IP address from the auth server
+            os: Operating systems this profile applies to
+            source_user: Source users this profile applies to
+            authentication_override: Authentication override configuration
+            source_address: Source address configuration
+            split_tunneling: Split tunneling configuration
+
+        Returns:
+            dict[str, Any]: The created/updated tunnel profile object with __action__ field
+
+        """
+        provided_fields: dict[str, Any] = {
+            key: value
+            for key, value in {
+                "no_direct_access_to_local_network": no_direct_access_to_local_network,
+                "retrieve_framed_ip_address": retrieve_framed_ip_address,
+                "os": os,
+                "source_user": source_user,
+                "authentication_override": authentication_override,
+                "source_address": source_address,
+                "split_tunneling": split_tunneling,
+            }.items()
+            if value is not None
+        }
+
+        self.logger.info(f"Creating or updating tunnel profile: {name} in folder {folder}")
+
+        if not self.client:
+            result = {"id": f"tp-{name}", "folder": folder, "name": name, **provided_fields, "__action__": "created"}
+            return {k: v for k, v in result.items() if v is not None}
+
+        try:
+            existing = None
+            try:
+                existing = self.client.tunnel_profile.fetch(name=name, folder=folder)
+                self.logger.info(f"Found existing tunnel profile '{name}' in folder '{folder}'")
+            except Exception as fetch_error:
+                if self._is_not_found_error(fetch_error):
+                    self.logger.info(f"Tunnel profile '{name}' not found in folder '{folder}', will create new")
+                else:
+                    self.logger.warning(f"Error fetching tunnel profile '{name}': {str(fetch_error)}")
+
+            # The tunnel-profiles API rejects folder in the request body
+            body = {"name": name, **provided_fields}
+
+            if existing:
+                existing_data = json.loads(existing.model_dump_json(exclude_unset=True))
+                changed_fields = [key for key, value in provided_fields.items() if existing_data.get(key) != value]
+
+                if changed_fields:
+                    self.logger.info(f"Updating tunnel profile fields: {', '.join(changed_fields)}")
+                    result = self.client.tunnel_profile.update(body, folder=folder)
+                    self.logger.info(f"Successfully updated tunnel profile '{name}' in folder '{folder}'")
+                    response = json.loads(result.model_dump_json(exclude_unset=True))
+                    response["__action__"] = "updated"
+                    return response
+                else:
+                    self.logger.info(f"No changes detected for tunnel profile '{name}', skipping update")
+                    response = existing_data
+                    response["__action__"] = "no_change"
+                    return response
+            else:
+                result = self.client.tunnel_profile.create(body, folder=folder)
+                self.logger.info(f"Successfully created tunnel profile '{name}' in folder '{folder}'")
+                response = json.loads(result.model_dump_json(exclude_unset=True))
+                response["__action__"] = "created"
+                return response
+
+        except Exception as e:
+            self._handle_api_exception("create/update", folder or "", name or "", e)
+
+    def get_tunnel_profile(
+        self,
+        folder: str | None = None,
+        name: str = None,
+    ) -> dict[str, Any]:
+        """Get a GlobalProtect tunnel profile by name.
+
+        Args:
+            folder: Folder containing the tunnel profile (must be 'Mobile Users')
+            name: Name of the tunnel profile to get
+
+        Returns:
+            dict[str, Any]: The tunnel profile object
+
+        """
+        self.logger.info(f"Getting tunnel profile: {name} from folder {folder}")
+
+        if not self.client:
+            return {
+                "id": f"tp-{name}",
+                "folder": folder or "Mobile Users",
+                "name": name,
+                "no_direct_access_to_local_network": False,
+                "split_tunneling": {"access_route": ["10.0.0.0/8"]},
+            }
+
+        try:
+            result = self.client.tunnel_profile.fetch(name=name, folder=folder)
+            return json.loads(result.model_dump_json(exclude_unset=True))
+        except Exception as e:
+            self._handle_api_exception("getting", folder or "", name or "", e)
+
+    def list_tunnel_profiles(
+        self,
+        folder: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """List GlobalProtect tunnel profiles.
+
+        Args:
+            folder: Folder to list from (must be 'Mobile Users')
+
+        Returns:
+            list[dict[str, Any]]: List of tunnel profile objects
+
+        """
+        self.logger.info(f"Listing tunnel profiles in folder: {folder}")
+
+        if not self.client:
+            return [
+                {
+                    "id": "tp-mock1",
+                    "folder": folder or "Mobile Users",
+                    "name": "corp-tunnel",
+                    "split_tunneling": {"access_route": ["10.0.0.0/8"]},
+                },
+                {
+                    "id": "tp-mock2",
+                    "folder": folder or "Mobile Users",
+                    "name": "byod-tunnel",
+                    "no_direct_access_to_local_network": True,
+                },
+            ]
+
+        try:
+            results = self.client.tunnel_profile.list(folder=folder)
+            return [json.loads(result.model_dump_json(exclude_unset=True)) for result in results]
+        except Exception as e:
+            self._handle_api_exception("listing", folder or "", "tunnel profiles", e)
+
+    def delete_tunnel_profile(
+        self,
+        folder: str | None = None,
+        name: str = None,
+    ) -> bool:
+        """Delete a GlobalProtect tunnel profile.
+
+        The API deletes by name and folder query parameters; no ID is involved.
+
+        Args:
+            folder: Folder containing the tunnel profile (must be 'Mobile Users')
+            name: Name of the tunnel profile to delete
+
+        Returns:
+            bool: True if deletion was successful
+
+        """
+        self.logger.info(f"Deleting tunnel profile: {name} from folder {folder}")
+
+        if not self.client:
+            return True
+
+        try:
+            self.client.tunnel_profile.delete(name=name, folder=folder)
+            return True
+        except Exception as e:
+            self._handle_api_exception("deletion", folder or "", name or "", e)
+
     # ======================================================================================================================================================================================
     # SETUP CONFIGURATION METHODS
     # ======================================================================================================================================================================================

--- a/src/scm_cli/utils/validators.py
+++ b/src/scm_cli/utils/validators.py
@@ -4636,6 +4636,222 @@ class AuthSetting(BaseModel):
         return model_data
 
 
+# --------------------------------------------------------------------------------------------- GlobalProtect Agent / Tunnel Profiles (agent3) ----------------------------------------------
+
+GP_PROFILE_OS_VALUES = {"Android", "Chrome", "IoT", "Linux", "Mac", "Windows", "WindowsUWP", "iOS"}
+GP_CONNECT_METHODS = {"user-logon", "pre-logon", "on-demand", "pre-logon-then-on-demand"}
+GP_SAVE_USER_CREDENTIALS = {"0", "1", "2", "3"}
+GP_THIRD_PARTY_VPN_CLIENTS = {
+    "PAN Virtual Ethernet Adapter",
+    "Juniper Network Virtual Adapter",
+    "Cisco Systems VPN Adapter",
+}
+
+
+class AgentProfile(BaseModel):
+    """Model for GlobalProtect agent profile (app settings) configurations.
+
+    Agent profiles are folder-scoped and only valid in the 'Mobile Users' folder.
+    Nested SDK structures (agent_ui, gateways, hip_collection, ...) are accepted
+    as dicts and passed through; the SDK models perform deep validation.
+    """
+
+    name: str = Field(..., description="Name of the agent profile")
+    folder: str = Field("Mobile Users", description="Folder path (must be 'Mobile Users')")
+    os: list[str] | None = Field(None, description="Operating systems this profile applies to (Android, Chrome, IoT, Linux, Mac, Windows, WindowsUWP, iOS)")
+    connect_method: str | None = Field(None, description="Connect method (user-logon, pre-logon, on-demand, pre-logon-then-on-demand)")
+    tunnel_mtu: int | None = Field(None, ge=1000, le=1420, description="GlobalProtect connection MTU in bytes (1000-1420)")
+    save_user_credentials: str | None = Field(None, description="Save user credentials (0=No, 1=Yes, 2=Save username only, 3=Only with user fingerprint)")
+    source_user: list[str] | None = Field(None, description="Source users this profile applies to")
+    third_party_vpn_clients: list[str] | None = Field(None, description="Third party VPN clients supported by this profile")
+    agent_ui: dict[str, Any] | None = Field(None, description="Agent UI configuration settings")
+    authentication_override: dict[str, Any] | None = Field(None, description="Authentication override settings")
+    certificate: dict[str, Any] | None = Field(None, description="Certificate settings")
+    client_certificate: dict[str, Any] | None = Field(None, description="Client certificate settings")
+    custom_checks: dict[str, Any] | None = Field(None, description="Custom checks settings")
+    gateways: dict[str, Any] | None = Field(None, description="Gateways configuration")
+    gp_app_config: dict[str, Any] | None = Field(None, description="GlobalProtect app configuration (takes precedence over connect_method/tunnel_mtu)")
+    hip_collection: dict[str, Any] | None = Field(None, description="HIP collection settings")
+    internal_host_detection: dict[str, Any] | None = Field(None, description="Internal host detection (IPv4) settings")
+    internal_host_detection_v6: dict[str, Any] | None = Field(None, description="Internal host detection (IPv6) settings")
+    machine_account_exists_with_serialno: dict[str, Any] | None = Field(None, description="Machine account exists with serial number setting")
+
+    @field_validator("folder")
+    @classmethod
+    def validate_folder(cls, v: str) -> str:
+        """Validate that folder is 'Mobile Users'."""
+        if v != "Mobile Users":
+            raise ValueError("folder must be 'Mobile Users' for GlobalProtect agent profiles")
+        return v
+
+    @field_validator("os")
+    @classmethod
+    def validate_os(cls, v: list[str] | None) -> list[str] | None:
+        """Validate operating system values."""
+        if v is not None:
+            invalid = [item for item in v if item not in GP_PROFILE_OS_VALUES]
+            if invalid:
+                raise ValueError(f"os values must be one of: {', '.join(sorted(GP_PROFILE_OS_VALUES))}; got: {', '.join(invalid)}")
+        return v
+
+    @field_validator("connect_method")
+    @classmethod
+    def validate_connect_method(cls, v: str | None) -> str | None:
+        """Validate connect_method value."""
+        if v is not None and v not in GP_CONNECT_METHODS:
+            raise ValueError(f"connect_method must be one of: {', '.join(sorted(GP_CONNECT_METHODS))}")
+        return v
+
+    @field_validator("save_user_credentials")
+    @classmethod
+    def validate_save_user_credentials(cls, v: str | None) -> str | None:
+        """Validate save_user_credentials value."""
+        if v is not None and v not in GP_SAVE_USER_CREDENTIALS:
+            raise ValueError("save_user_credentials must be one of: 0 (No), 1 (Yes), 2 (Save username only), 3 (Only with user fingerprint)")
+        return v
+
+    @field_validator("third_party_vpn_clients")
+    @classmethod
+    def validate_third_party_vpn_clients(cls, v: list[str] | None) -> list[str] | None:
+        """Validate third party VPN client values."""
+        if v is not None:
+            invalid = [item for item in v if item not in GP_THIRD_PARTY_VPN_CLIENTS]
+            if invalid:
+                raise ValueError(f"third_party_vpn_clients values must be one of: {', '.join(sorted(GP_THIRD_PARTY_VPN_CLIENTS))}; got: {', '.join(invalid)}")
+        return v
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format.
+
+        Returns:
+            dict[str, Any]: SDK-compatible dictionary
+
+        """
+        model_data: dict[str, Any] = {
+            "name": self.name,
+            "folder": self.folder,
+        }
+
+        for field_name in (
+            "os",
+            "save_user_credentials",
+            "source_user",
+            "third_party_vpn_clients",
+            "agent_ui",
+            "authentication_override",
+            "certificate",
+            "client_certificate",
+            "custom_checks",
+            "gateways",
+            "hip_collection",
+            "internal_host_detection",
+            "internal_host_detection_v6",
+            "machine_account_exists_with_serialno",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                model_data[field_name] = value
+
+        # Explicit gp_app_config wins over the convenience flags
+        if self.gp_app_config is not None:
+            model_data["gp_app_config"] = self.gp_app_config
+        elif self.connect_method is not None or self.tunnel_mtu is not None:
+            entries: list[dict[str, Any]] = []
+            if self.connect_method is not None:
+                entries.append({"name": "connect-method", "value": [self.connect_method]})
+            if self.tunnel_mtu is not None:
+                entries.append({"name": "tunnel-mtu", "value": [self.tunnel_mtu]})
+            model_data["gp_app_config"] = {"config": entries}
+
+        return model_data
+
+
+class TunnelProfile(BaseModel):
+    """Model for GlobalProtect tunnel profile configurations.
+
+    Tunnel profiles are folder-scoped and only valid in the 'Mobile Users' folder.
+    Nested SDK structures (authentication_override, source_address, split_tunneling)
+    are accepted as dicts and passed through; the SDK models perform deep validation.
+    """
+
+    name: str = Field(..., min_length=1, max_length=31, description="Name of the tunnel profile")
+    folder: str = Field("Mobile Users", description="Folder path (must be 'Mobile Users')")
+    no_direct_access_to_local_network: bool | None = Field(None, description="Disable direct access to the local network")
+    retrieve_framed_ip_address: bool | None = Field(None, description="Retrieve the framed IP address from the authentication server")
+    os: list[str] | None = Field(None, description="Operating systems this profile applies to (Android, Chrome, IoT, Linux, Mac, Windows, WindowsUWP, iOS)")
+    source_user: list[str] | None = Field(None, description="Source users this profile applies to")
+    access_route: list[str] | None = Field(None, description="Routes included in the tunnel")
+    exclude_access_route: list[str] | None = Field(None, description="Routes excluded from the tunnel")
+    include_applications: list[str] | None = Field(None, description="Applications included in the tunnel")
+    exclude_applications: list[str] | None = Field(None, description="Applications excluded from the tunnel")
+    authentication_override: dict[str, Any] | None = Field(None, description="Authentication override configuration")
+    source_address: dict[str, Any] | None = Field(None, description="Source address configuration")
+    split_tunneling: dict[str, Any] | None = Field(None, description="Split tunneling configuration (takes precedence over the route/application list fields)")
+
+    @field_validator("folder")
+    @classmethod
+    def validate_folder(cls, v: str) -> str:
+        """Validate that folder is 'Mobile Users'."""
+        if v != "Mobile Users":
+            raise ValueError("folder must be 'Mobile Users' for GlobalProtect tunnel profiles")
+        return v
+
+    @field_validator("os")
+    @classmethod
+    def validate_os(cls, v: list[str] | None) -> list[str] | None:
+        """Validate operating system values."""
+        if v is not None:
+            invalid = [item for item in v if item not in GP_PROFILE_OS_VALUES]
+            if invalid:
+                raise ValueError(f"os values must be one of: {', '.join(sorted(GP_PROFILE_OS_VALUES))}; got: {', '.join(invalid)}")
+        return v
+
+    def to_sdk_model(self) -> dict[str, Any]:
+        """Convert CLI model to SDK model format.
+
+        The folder is included for the SDK client wrapper to consume as a query
+        parameter; the tunnel-profiles API does not accept folder in the body.
+
+        Returns:
+            dict[str, Any]: SDK-compatible dictionary
+
+        """
+        model_data: dict[str, Any] = {
+            "name": self.name,
+            "folder": self.folder,
+        }
+
+        for field_name in (
+            "no_direct_access_to_local_network",
+            "retrieve_framed_ip_address",
+            "os",
+            "source_user",
+            "authentication_override",
+            "source_address",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                model_data[field_name] = value
+
+        # Explicit split_tunneling wins over the convenience list fields
+        if self.split_tunneling is not None:
+            model_data["split_tunneling"] = self.split_tunneling
+        else:
+            split_tunneling: dict[str, Any] = {}
+            if self.access_route is not None:
+                split_tunneling["access_route"] = self.access_route
+            if self.exclude_access_route is not None:
+                split_tunneling["exclude_access_route"] = self.exclude_access_route
+            if self.include_applications is not None:
+                split_tunneling["include_applications"] = self.include_applications
+            if self.exclude_applications is not None:
+                split_tunneling["exclude_applications"] = self.exclude_applications
+            if split_tunneling:
+                model_data["split_tunneling"] = split_tunneling
+
+        return model_data
+
+
 # =============================================================================================================================================================================================
 # INSIGHTS AND MONITORING MODELS
 # =============================================================================================================================================================================================

--- a/tests/test_mobile_agent_profile_commands.py
+++ b/tests/test_mobile_agent_profile_commands.py
@@ -1,0 +1,671 @@
+"""Tests for the mobile agent agent-profile and tunnel-profile commands."""
+
+import pytest  # noqa: I001
+import typer
+from pydantic import ValidationError
+from scm_cli.commands.mobile_agent import (
+    backup_agent_profile,
+    backup_tunnel_profile,
+    delete_agent_profile,
+    delete_tunnel_profile,
+    load_agent_profile,
+    load_tunnel_profile,
+    set_agent_profile,
+    set_tunnel_profile,
+    show_agent_profile,
+    show_tunnel_profile,
+)
+from scm_cli.utils.validators import AgentProfile, TunnelProfile
+
+
+class TestAgentProfileValidator:
+    """Test the AgentProfile validator model."""
+
+    def test_to_sdk_model_folds_app_config_flags(self):
+        """Test connect_method and tunnel_mtu fold into gp_app_config."""
+        profile = AgentProfile(
+            name="corp-app-settings",
+            folder="Mobile Users",
+            connect_method="user-logon",
+            tunnel_mtu=1400,
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["gp_app_config"] == {
+            "config": [
+                {"name": "connect-method", "value": ["user-logon"]},
+                {"name": "tunnel-mtu", "value": [1400]},
+            ]
+        }
+
+    def test_to_sdk_model_explicit_gp_app_config_wins(self):
+        """Test explicit gp_app_config takes precedence over convenience flags."""
+        explicit = {"config": [{"name": "connect-method", "value": ["on-demand"]}]}
+        profile = AgentProfile(
+            name="corp-app-settings",
+            connect_method="user-logon",
+            gp_app_config=explicit,
+        )
+        assert profile.to_sdk_model()["gp_app_config"] == explicit
+
+    def test_invalid_folder_rejected(self):
+        """Test folder other than 'Mobile Users' is rejected."""
+        with pytest.raises(ValidationError, match="Mobile Users"):
+            AgentProfile(name="x", folder="Shared")
+
+    def test_invalid_connect_method_rejected(self):
+        """Test invalid connect_method is rejected."""
+        with pytest.raises(ValidationError, match="connect_method"):
+            AgentProfile(name="x", connect_method="always-on")
+
+    def test_invalid_os_rejected(self):
+        """Test invalid os value is rejected."""
+        with pytest.raises(ValidationError, match="os values"):
+            AgentProfile(name="x", os=["Solaris"])
+
+    def test_invalid_save_user_credentials_rejected(self):
+        """Test invalid save_user_credentials is rejected."""
+        with pytest.raises(ValidationError, match="save_user_credentials"):
+            AgentProfile(name="x", save_user_credentials="9")
+
+    def test_tunnel_mtu_range_enforced(self):
+        """Test tunnel_mtu outside 1000-1420 is rejected."""
+        with pytest.raises(ValidationError):
+            AgentProfile(name="x", tunnel_mtu=999)
+
+
+class TestTunnelProfileValidator:
+    """Test the TunnelProfile validator model."""
+
+    def test_to_sdk_model_folds_split_tunneling_flags(self):
+        """Test route/application flags fold into split_tunneling."""
+        profile = TunnelProfile(
+            name="corp-tunnel",
+            access_route=["10.0.0.0/8"],
+            exclude_access_route=["192.168.1.0/24"],
+            include_applications=["slack"],
+            exclude_applications=["spotify"],
+        )
+        sdk_data = profile.to_sdk_model()
+        assert sdk_data["split_tunneling"] == {
+            "access_route": ["10.0.0.0/8"],
+            "exclude_access_route": ["192.168.1.0/24"],
+            "include_applications": ["slack"],
+            "exclude_applications": ["spotify"],
+        }
+
+    def test_to_sdk_model_explicit_split_tunneling_wins(self):
+        """Test explicit split_tunneling takes precedence over convenience flags."""
+        explicit = {"access_route": ["172.16.0.0/12"]}
+        profile = TunnelProfile(
+            name="corp-tunnel",
+            access_route=["10.0.0.0/8"],
+            split_tunneling=explicit,
+        )
+        assert profile.to_sdk_model()["split_tunneling"] == explicit
+
+    def test_invalid_folder_rejected(self):
+        """Test folder other than 'Mobile Users' is rejected."""
+        with pytest.raises(ValidationError, match="Mobile Users"):
+            TunnelProfile(name="x", folder="Shared")
+
+    def test_name_max_length_enforced(self):
+        """Test name longer than 31 chars is rejected."""
+        with pytest.raises(ValidationError):
+            TunnelProfile(name="x" * 32)
+
+
+class TestAgentProfileCommands:
+    """Test the agent profile commands."""
+
+    def test_set_agent_profile(self, runner, monkeypatch):
+        """Test creating an agent profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured = {}
+
+        def mock_create(*args, **kwargs):
+            captured.update(kwargs)
+            return {
+                "id": "ap-corp",
+                "folder": kwargs.get("folder"),
+                "name": kwargs.get("name"),
+                "gp_app_config": kwargs.get("gp_app_config"),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_agent_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_agent_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder", "Mobile Users",
+                "--name", "corp-app-settings",
+                "--connect-method", "user-logon",
+                "--tunnel-mtu", "1400",
+                "--os", "Windows",
+                "--os", "Mac",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created agent profile" in result.stdout
+        assert captured["gp_app_config"] == {
+            "config": [
+                {"name": "connect-method", "value": ["user-logon"]},
+                {"name": "tunnel-mtu", "value": [1400]},
+            ]
+        }
+        assert captured["os"] == ["Windows", "Mac"]
+
+    def test_set_agent_profile_update(self, runner, monkeypatch):
+        """Test updating an agent profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {"id": "ap-corp", "name": kwargs.get("name"), "__action__": "updated"}
+
+        monkeypatch.setattr(scm_client, "create_agent_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_agent_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--name", "corp-app-settings", "--save-user-credentials", "1"],
+        )
+
+        assert result.exit_code == 0
+        assert "Updated agent profile" in result.stdout
+
+    def test_set_agent_profile_no_change(self, runner, monkeypatch):
+        """Test set agent profile with no changes."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {"id": "ap-corp", "name": kwargs.get("name"), "__action__": "no_change"}
+
+        monkeypatch.setattr(scm_client, "create_agent_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_agent_profile)
+
+        result = runner.invoke(test_app, ["--name", "corp-app-settings"])
+
+        assert result.exit_code == 0
+        assert "No changes needed" in result.stdout
+
+    def test_set_agent_profile_invalid_folder(self, runner, monkeypatch):
+        """Test set agent profile with invalid folder fails validation."""
+        test_app = typer.Typer()
+        test_app.command()(set_agent_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Shared", "--name", "corp-app-settings"],
+        )
+
+        assert result.exit_code == 1
+        assert "Validation error" in result.output
+
+    def test_set_agent_profile_error(self, runner, monkeypatch):
+        """Test set agent profile with API error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(scm_client, "create_agent_profile", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_agent_profile)
+
+        result = runner.invoke(test_app, ["--name", "fail-profile"])
+
+        assert result.exit_code == 1
+
+    def test_show_agent_profile_list(self, runner, monkeypatch):
+        """Test listing agent profiles."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {"id": "ap-1", "folder": "Mobile Users", "name": "corp-app-settings", "os": ["Windows"]},
+                {"id": "ap-2", "folder": "Mobile Users", "name": "byod-app-settings", "os": ["iOS", "Android"]},
+            ]
+
+        monkeypatch.setattr(scm_client, "list_agent_profiles", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_agent_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "corp-app-settings" in result.stdout
+        assert "byod-app-settings" in result.stdout
+
+    def test_show_agent_profile_detail(self, runner, monkeypatch):
+        """Test showing a specific agent profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "ap-corp",
+                "folder": "Mobile Users",
+                "name": "corp-app-settings",
+                "os": ["Windows", "Mac"],
+                "save_user_credentials": "0",
+                "gp_app_config": {"config": [{"name": "connect-method", "value": ["user-logon"]}]},
+            }
+
+        monkeypatch.setattr(scm_client, "get_agent_profile", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_agent_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "corp-app-settings"],
+        )
+
+        assert result.exit_code == 0
+        assert "corp-app-settings" in result.stdout
+        assert "Windows, Mac" in result.stdout
+        assert "connect-method" in result.stdout
+
+    def test_show_agent_profile_empty(self, runner, monkeypatch):
+        """Test listing agent profiles when none exist."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_agent_profiles", lambda *a, **kw: [])
+
+        test_app = typer.Typer()
+        test_app.command()(show_agent_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "No agent profiles found" in result.stdout
+
+    def test_delete_agent_profile(self, runner, monkeypatch):
+        """Test deleting an agent profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "delete_agent_profile", lambda *a, **kw: True)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_agent_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "corp-app-settings", "--force"],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted agent profile" in result.stdout
+
+    def test_delete_agent_profile_error(self, runner, monkeypatch):
+        """Test deleting an agent profile with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("Not found")
+
+        monkeypatch.setattr(scm_client, "delete_agent_profile", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_agent_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "nonexistent", "--force"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_load_agent_profile(self, runner, monkeypatch, tmp_path):
+        """Test loading agent profiles from YAML."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_content = """
+agent_profiles:
+  - name: corp-app-settings
+    folder: "Mobile Users"
+    connect_method: user-logon
+    os:
+      - Windows
+  - name: byod-app-settings
+    folder: "Mobile Users"
+    save_user_credentials: "3"
+"""
+        test_file = tmp_path / "agent_profiles.yml"
+        test_file.write_text(yaml_content)
+
+        def mock_create(*args, **kwargs):
+            return {"name": kwargs.get("name"), "folder": kwargs.get("folder"), "__action__": "created"}
+
+        monkeypatch.setattr(scm_client, "create_agent_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_agent_profile)
+
+        result = runner.invoke(test_app, ["--file", str(test_file)])
+
+        assert result.exit_code == 0
+        assert "Created agent profile" in result.stdout
+        assert "2 created" in result.stdout
+
+    def test_load_agent_profile_dry_run(self, runner, tmp_path):
+        """Test loading agent profiles in dry run mode."""
+        yaml_content = """
+agent_profiles:
+  - name: corp-app-settings
+    folder: "Mobile Users"
+"""
+        test_file = tmp_path / "agent_profiles.yml"
+        test_file.write_text(yaml_content)
+
+        test_app = typer.Typer()
+        test_app.command()(load_agent_profile)
+
+        result = runner.invoke(test_app, ["--file", str(test_file), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+    def test_backup_agent_profile(self, runner, monkeypatch, tmp_path):
+        """Test backing up agent profiles."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {"id": "ap-1", "folder": "Mobile Users", "name": "corp-app-settings", "os": ["Windows"]},
+            ]
+
+        monkeypatch.setattr(scm_client, "list_agent_profiles", mock_list)
+        monkeypatch.chdir(tmp_path)
+
+        test_app = typer.Typer()
+        test_app.command()(backup_agent_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "Successfully backed up" in result.stdout
+        assert "1 agent profiles" in result.stdout
+
+
+class TestTunnelProfileCommands:
+    """Test the tunnel profile commands."""
+
+    def test_set_tunnel_profile(self, runner, monkeypatch):
+        """Test creating a tunnel profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        captured = {}
+
+        def mock_create(*args, **kwargs):
+            captured.update(kwargs)
+            return {
+                "id": "tp-corp",
+                "folder": kwargs.get("folder"),
+                "name": kwargs.get("name"),
+                "__action__": "created",
+            }
+
+        monkeypatch.setattr(scm_client, "create_tunnel_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_tunnel_profile)
+
+        result = runner.invoke(
+            test_app,
+            [
+                "--folder", "Mobile Users",
+                "--name", "corp-tunnel",
+                "--access-route", "10.0.0.0/8",
+                "--no-direct-access-to-local-network",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Created tunnel profile" in result.stdout
+        assert captured["split_tunneling"] == {"access_route": ["10.0.0.0/8"]}
+        assert captured["no_direct_access_to_local_network"] is True
+
+    def test_set_tunnel_profile_update(self, runner, monkeypatch):
+        """Test updating a tunnel profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {"id": "tp-corp", "name": kwargs.get("name"), "__action__": "updated"}
+
+        monkeypatch.setattr(scm_client, "create_tunnel_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_tunnel_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--name", "corp-tunnel", "--retrieve-framed-ip-address"],
+        )
+
+        assert result.exit_code == 0
+        assert "Updated tunnel profile" in result.stdout
+
+    def test_set_tunnel_profile_no_change(self, runner, monkeypatch):
+        """Test set tunnel profile with no changes."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_create(*args, **kwargs):
+            return {"id": "tp-corp", "name": kwargs.get("name"), "__action__": "no_change"}
+
+        monkeypatch.setattr(scm_client, "create_tunnel_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(set_tunnel_profile)
+
+        result = runner.invoke(test_app, ["--name", "corp-tunnel"])
+
+        assert result.exit_code == 0
+        assert "No changes needed" in result.stdout
+
+    def test_set_tunnel_profile_invalid_folder(self, runner):
+        """Test set tunnel profile with invalid folder fails validation."""
+        test_app = typer.Typer()
+        test_app.command()(set_tunnel_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Shared", "--name", "corp-tunnel"],
+        )
+
+        assert result.exit_code == 1
+        assert "Validation error" in result.output
+
+    def test_set_tunnel_profile_error(self, runner, monkeypatch):
+        """Test set tunnel profile with API error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("API error")
+
+        monkeypatch.setattr(scm_client, "create_tunnel_profile", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(set_tunnel_profile)
+
+        result = runner.invoke(test_app, ["--name", "fail-tunnel"])
+
+        assert result.exit_code == 1
+
+    def test_show_tunnel_profile_list(self, runner, monkeypatch):
+        """Test listing tunnel profiles."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {"id": "tp-1", "folder": "Mobile Users", "name": "corp-tunnel"},
+                {"id": "tp-2", "folder": "Mobile Users", "name": "byod-tunnel", "no_direct_access_to_local_network": True},
+            ]
+
+        monkeypatch.setattr(scm_client, "list_tunnel_profiles", mock_list)
+
+        test_app = typer.Typer()
+        test_app.command()(show_tunnel_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "corp-tunnel" in result.stdout
+        assert "byod-tunnel" in result.stdout
+
+    def test_show_tunnel_profile_detail(self, runner, monkeypatch):
+        """Test showing a specific tunnel profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_get(*args, **kwargs):
+            return {
+                "id": "tp-corp",
+                "folder": "Mobile Users",
+                "name": "corp-tunnel",
+                "no_direct_access_to_local_network": False,
+                "split_tunneling": {"access_route": ["10.0.0.0/8"]},
+            }
+
+        monkeypatch.setattr(scm_client, "get_tunnel_profile", mock_get)
+
+        test_app = typer.Typer()
+        test_app.command()(show_tunnel_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "corp-tunnel"],
+        )
+
+        assert result.exit_code == 0
+        assert "corp-tunnel" in result.stdout
+        assert "10.0.0.0/8" in result.stdout
+
+    def test_show_tunnel_profile_empty(self, runner, monkeypatch):
+        """Test listing tunnel profiles when none exist."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "list_tunnel_profiles", lambda *a, **kw: [])
+
+        test_app = typer.Typer()
+        test_app.command()(show_tunnel_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "No tunnel profiles found" in result.stdout
+
+    def test_delete_tunnel_profile(self, runner, monkeypatch):
+        """Test deleting a tunnel profile."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        monkeypatch.setattr(scm_client, "delete_tunnel_profile", lambda *a, **kw: True)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_tunnel_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "corp-tunnel", "--force"],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted tunnel profile" in result.stdout
+
+    def test_delete_tunnel_profile_error(self, runner, monkeypatch):
+        """Test deleting a tunnel profile with an error."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_error(*args, **kwargs):
+            raise Exception("Not found")
+
+        monkeypatch.setattr(scm_client, "delete_tunnel_profile", mock_error)
+
+        test_app = typer.Typer()
+        test_app.command()(delete_tunnel_profile)
+
+        result = runner.invoke(
+            test_app,
+            ["--folder", "Mobile Users", "--name", "nonexistent", "--force"],
+        )
+
+        assert result.exit_code == 1
+
+    def test_load_tunnel_profile(self, runner, monkeypatch, tmp_path):
+        """Test loading tunnel profiles from YAML."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        yaml_content = """
+tunnel_profiles:
+  - name: corp-tunnel
+    folder: "Mobile Users"
+    access_route:
+      - 10.0.0.0/8
+  - name: byod-tunnel
+    folder: "Mobile Users"
+    no_direct_access_to_local_network: true
+"""
+        test_file = tmp_path / "tunnel_profiles.yml"
+        test_file.write_text(yaml_content)
+
+        def mock_create(*args, **kwargs):
+            return {"name": kwargs.get("name"), "folder": kwargs.get("folder"), "__action__": "created"}
+
+        monkeypatch.setattr(scm_client, "create_tunnel_profile", mock_create)
+
+        test_app = typer.Typer()
+        test_app.command()(load_tunnel_profile)
+
+        result = runner.invoke(test_app, ["--file", str(test_file)])
+
+        assert result.exit_code == 0
+        assert "Created tunnel profile" in result.stdout
+        assert "2 created" in result.stdout
+
+    def test_load_tunnel_profile_dry_run(self, runner, tmp_path):
+        """Test loading tunnel profiles in dry run mode."""
+        yaml_content = """
+tunnel_profiles:
+  - name: corp-tunnel
+    folder: "Mobile Users"
+"""
+        test_file = tmp_path / "tunnel_profiles.yml"
+        test_file.write_text(yaml_content)
+
+        test_app = typer.Typer()
+        test_app.command()(load_tunnel_profile)
+
+        result = runner.invoke(test_app, ["--file", str(test_file), "--dry-run"])
+
+        assert result.exit_code == 0
+        assert "Dry run mode" in result.stdout
+
+    def test_backup_tunnel_profile(self, runner, monkeypatch, tmp_path):
+        """Test backing up tunnel profiles."""
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_list(*args, **kwargs):
+            return [
+                {"id": "tp-1", "folder": "Mobile Users", "name": "corp-tunnel", "split_tunneling": {"access_route": ["10.0.0.0/8"]}},
+            ]
+
+        monkeypatch.setattr(scm_client, "list_tunnel_profiles", mock_list)
+        monkeypatch.chdir(tmp_path)
+
+        test_app = typer.Typer()
+        test_app.command()(backup_tunnel_profile)
+
+        result = runner.invoke(test_app, ["--folder", "Mobile Users"])
+
+        assert result.exit_code == 0
+        assert "Successfully backed up" in result.stdout
+        assert "1 tunnel profiles" in result.stdout


### PR DESCRIPTION
## What

CLI coverage for the SDK 0.15.0 mobile-agent `agent_profile` and `tunnel_profile` services, following the existing `auth_setting` end-to-end pattern (validator → sdk_client wrapper → Typer commands).

## Commands added

- `scm set|delete|show|backup|load mobile-agent agent-profile`
- `scm set|delete|show|backup|load mobile-agent tunnel-profile`

## Notes

- Both resources are folder-only and restricted to `Mobile Users` (validated CLI-side for fast failure; no `--snippet`/`--device`).
- No ID-based API endpoints: delete addresses by name+folder; upsert is fetch → merge → `update(dict)` (handles agent-profile updates returning 200 with no body by re-fetching).
- Tunnel-profile create/update send folder as query param only — never in the body.
- `set` exposes common flags (`--connect-method`, `--tunnel-mtu`, `--os`, split-tunnel route/application lists) that fold into `gp_app_config` / `split_tunneling`; full nested config supported via `load` YAML.
- Shared files (`validators.py`, `sdk_client.py`, `mobile_agent.py`, `mkdocs.yml`) touched append-only in delimited blocks, plus one import-line extension in `mobile_agent.py`.

## Validation

- `make quality` green (flake8, yamllint, ruff format, mypy, pytest: 994 passed / 29 skipped)
- 37 new tests in `tests/test_mobile_agent_profile_commands.py` (set created/updated/no_change/error/validation, show list/detail/empty, delete ok/error, load + dry-run, backup, validator folding rules)
- Smoke: all 10 new `--help` screens render

🤖 Generated with [Claude Code](https://claude.com/claude-code)