### PR TITLE
fix(docs): commit cli/local page dropped by overbroad gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,13 +96,15 @@ venv.bak/
 
 # Virtualenv
 # http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+# Root-anchored so they only match a venv at the repo root, not nested
+# directories like docs-site/docs/cli/local/.
 .Python
-[Bb]in
-[Ii]nclude
-[Ll]ib
-[Ll]ib64
-[Ll]ocal
-[Ss]cripts
+/[Bb]in
+/[Ii]nclude
+/[Ll]ib
+/[Ll]ib64
+/[Ll]ocal
+/[Ss]cripts
 pyvenv.cfg
 pip-selfcheck.json
 

--- a/docs-site/docs/cli/local/index.md
+++ b/docs-site/docs/cli/local/index.md
@@ -1,0 +1,39 @@
+# Local Config
+
+Manage local device configuration versions and downloads.
+
+## Commands
+
+### List Config Versions
+
+```bash
+scm local list --device 007951000123456
+```
+
+Lists available configuration versions for a device, showing version number, timestamp, serial number, and MD5 hash.
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--device`, `-d` | Yes | Device serial number (14-15 digits) |
+
+### Download Config
+
+```bash
+# Output to stdout
+scm local download --device 007951000123456 --version 42
+
+# Save to file
+scm local download --device 007951000123456 --version 42 --output config.xml
+```
+
+Downloads a specific configuration version as XML. Outputs to stdout by default; use `--output` to write to a file.
+
+**Options:**
+
+| Option | Required | Description |
+|--------|----------|-------------|
+| `--device`, `-d` | Yes | Device serial number (14-15 digits) |
+| `--version`, `-v` | Yes | Config version number |
+| `--output`, `-o` | No | Output file path (default: stdout) |


### PR DESCRIPTION
## Problem

The GitHub Pages deploy for #230 **failed** ([run](https://github.com/cdot65/pan-scm-cli/actions/runs/28287070201)):

```
Invalid sidebar file at "sidebars.ts".
These sidebar document ids do not exist:
- cli/local/index
```

## Root cause

The repo's `.gitignore` carried legacy **unanchored** virtualenv patterns (`[Bb]in`, `[Ii]nclude`, `[Ll]ib`, `[Ll]ib64`, `[Ll]ocal`, `[Ss]cripts`). The `[Ll]ocal` pattern matched `docs-site/docs/cli/local/` anywhere in the tree, so `cli/local/index.md` was silently never committed in #230. It built locally (file on disk, macOS) but was absent on the CI runner — the sidebar referenced a doc id that didn't exist.

## Fix

- Root-anchor those six patterns (`/[Ll]ocal`, etc.) so they only match a venv at the repo root, not nested doc dirs.
- Add the missing `docs-site/docs/cli/local/index.md`.

## Verification

Built in a **clean git worktree** (tracked files only, replicating CI) — `npm ci && npm run build` succeeds, `cli/local/index` present. This is the check that the original local build couldn't catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)