### PR TITLE
docs(theme): apply Gruvbox dark design system to docs-site

### DIFF
--- a/.changeset/0004-gruvbox-docs-theme.md
+++ b/.changeset/0004-gruvbox-docs-theme.md
@@ -1,0 +1,5 @@
+---
+"pan-scm-cli": patch
+---
+
+Restyle the documentation site with the Gruvbox dark (hard-contrast) theme: warm, low-glare, terminal-adjacent. Vendors the design tokens (colors, typography, spacing, effects, fonts) and maps them onto Docusaurus/Infima, adds matching admonition rails, card, navbar, sidebar, and a Gruvbox Prism code-syntax theme. The docs are now dark-only.

--- a/docs-site/docusaurus.config.ts
+++ b/docs-site/docusaurus.config.ts
@@ -1,8 +1,27 @@
-import {themes as prismThemes} from 'prism-react-renderer';
 import type {Config} from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
+import type {PrismTheme} from 'prism-react-renderer';
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
+
+// Gruvbox dark (hard contrast) Prism theme — mirrors tokens/colors.css
+// (--code-* syntax tokens). prism-react-renderer applies inline styles, so the
+// syntax palette must live here rather than in custom.css.
+const gruvboxDark: PrismTheme = {
+  plain: {color: '#ebdbb2', backgroundColor: '#282828'},
+  styles: [
+    {types: ['comment', 'prolog', 'cdata'], style: {color: '#928374', fontStyle: 'italic'}},
+    {types: ['punctuation'], style: {color: '#bdae93'}},
+    {types: ['keyword', 'atrule', 'selector', 'important'], style: {color: '#fb4934'}},
+    {types: ['string', 'char', 'attr-value', 'inserted'], style: {color: '#b8bb26'}},
+    {types: ['function', 'function-name'], style: {color: '#b8bb26'}},
+    {types: ['number', 'boolean', 'constant', 'symbol'], style: {color: '#d3869b'}},
+    {types: ['operator', 'entity', 'url', 'variable'], style: {color: '#fe8019'}},
+    {types: ['class-name', 'tag', 'property'], style: {color: '#fabd2f'}},
+    {types: ['builtin', 'namespace', 'attr-name'], style: {color: '#8ec07c'}},
+    {types: ['deleted'], style: {color: '#fb4934'}},
+  ],
+};
 
 const config: Config = {
   title: 'SCM CLI',
@@ -65,8 +84,11 @@ const config: Config = {
 
   themeConfig: {
     image: 'img/logo.png',
+    // The Gruvbox design system is dark, hard-contrast only.
     colorMode: {
-      respectPrefersColorScheme: true,
+      defaultMode: 'dark',
+      disableSwitch: true,
+      respectPrefersColorScheme: false,
     },
     navbar: {
       title: 'SCM CLI',
@@ -119,8 +141,8 @@ const config: Config = {
       copyright: `Copyright © ${new Date().getFullYear()} cdot65. Built with Docusaurus.`,
     },
     prism: {
-      theme: prismThemes.github,
-      darkTheme: prismThemes.dracula,
+      theme: gruvboxDark,
+      darkTheme: gruvboxDark,
       additionalLanguages: ['bash', 'json', 'yaml', 'python', 'toml'],
     },
   } satisfies Preset.ThemeConfig,

--- a/docs-site/src/css/custom.css
+++ b/docs-site/src/css/custom.css
@@ -1,30 +1,237 @@
 /**
- * Any CSS included here will be global. The classic template
- * bundles Infima by default. Infima is a CSS framework designed to
- * work well for content-centric websites.
+ * Gruvbox Docs theme for Docusaurus.
+ * Implements the "Gruvbox Docs Design System" (Claude Design):
+ * Gruvbox dark, hard-contrast — warm, low-glare, terminal-adjacent.
+ *
+ * Token layers are vendored under ./tokens and mapped onto Infima below.
+ * The site is dark-only by design; see colorMode in docusaurus.config.ts.
  */
 
-/* You can override the default Infima variables here. */
-:root {
-  --ifm-color-primary: #2e8555;
-  --ifm-color-primary-dark: #29784c;
-  --ifm-color-primary-darker: #277148;
-  --ifm-color-primary-darkest: #205d3b;
-  --ifm-color-primary-light: #33925d;
-  --ifm-color-primary-lighter: #359962;
-  --ifm-color-primary-lightest: #3cad6e;
-  --ifm-code-font-size: 95%;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
+/* Fonts first, then variable layers (colors must precede consumers). */
+@import './tokens/fonts.css';
+@import './tokens/colors.css';
+@import './tokens/typography.css';
+@import './tokens/spacing.css';
+@import './tokens/effects.css';
+
+/* ============================================================
+   Map Gruvbox tokens -> Infima. Applied to both :root and the
+   dark attribute so our values win over Infima's dark defaults.
+   ============================================================ */
+:root,
+[data-theme='dark'] {
+  /* Brand primary = Gruvbox bright yellow */
+  --ifm-color-primary: #fabd2f;
+  --ifm-color-primary-dark: #f4b417;
+  --ifm-color-primary-darker: #e9ab12;
+  --ifm-color-primary-darkest: #c08d0f;
+  --ifm-color-primary-light: #fbc647;
+  --ifm-color-primary-lighter: #fbcb55;
+  --ifm-color-primary-lightest: #fcd87f;
+
+  /* Surfaces & text */
+  --ifm-background-color: var(--color-bg);
+  --ifm-background-surface-color: var(--color-surface);
+  --ifm-color-content: var(--color-text);
+  --ifm-color-content-secondary: var(--color-text-muted);
+  --ifm-font-color-base: var(--color-text);
+  --ifm-heading-color: var(--color-text-strong);
+  --ifm-hr-background-color: var(--color-border);
+  --ifm-toc-border-color: var(--color-border);
+  --ifm-table-border-color: var(--color-border);
+  --ifm-table-stripe-background: var(--color-surface);
+
+  /* Typography */
+  --ifm-font-family-base: var(--font-sans);
+  --ifm-font-family-monospace: var(--font-mono);
+  --ifm-font-size-base: 18px;
+  --ifm-line-height-base: 1.7;
+  --ifm-heading-font-family: var(--font-sans);
+  --ifm-heading-font-weight: var(--weight-bold);
+  --ifm-heading-line-height: var(--leading-tight);
+  --ifm-h1-font-size: var(--text-h1);
+  --ifm-h2-font-size: var(--text-h2);
+  --ifm-h3-font-size: var(--text-h3);
+  --ifm-h4-font-size: var(--text-h4);
+
+  /* Links */
+  --ifm-link-color: var(--color-link);
+  --ifm-link-hover-color: var(--color-link-hover);
+  --ifm-link-hover-decoration: underline;
+
+  /* Inline code */
+  --ifm-code-font-size: 0.875em;
+  --ifm-code-background: var(--color-surface-2);
+  --ifm-code-color: var(--gb-aqua-bright);
+  --ifm-code-border-radius: var(--radius-sm);
+  --docusaurus-highlighted-code-line-bg: rgba(250, 189, 47, 0.12);
+
+  /* Geometry */
+  --ifm-global-radius: var(--radius-md);
+  --ifm-card-border-radius: var(--radius-lg);
+  --ifm-global-shadow-lw: var(--shadow-sm);
+  --ifm-global-shadow-md: var(--shadow-md);
+  --ifm-global-shadow-tl: var(--shadow-lg);
+
+  /* Navbar */
+  --ifm-navbar-height: var(--navbar-height);
+  --ifm-navbar-background-color: var(--color-bg-elevated);
+  --ifm-navbar-link-color: var(--color-text);
+  --ifm-navbar-link-hover-color: var(--color-primary);
+  --ifm-navbar-shadow: 0 1px 0 var(--color-border);
+
+  /* Sidebar / menu */
+  --ifm-menu-color: var(--color-text-muted);
+  --ifm-menu-color-active: var(--color-primary);
+  --ifm-menu-color-background-active: var(--color-surface-2);
+  --ifm-menu-color-background-hover: var(--color-surface-2);
+
+  /* TOC */
+  --ifm-toc-link-color: var(--color-text-muted);
+
+  /* Footer */
+  --ifm-footer-background-color: var(--color-bg-elevated);
+  --ifm-footer-color: var(--color-text-muted);
+  --ifm-footer-link-color: var(--color-text-muted);
+  --ifm-footer-title-color: var(--color-text-strong);
+
+  /* Blockquote */
+  --ifm-blockquote-color: var(--color-text-muted);
+  --ifm-blockquote-border-color: var(--color-border-strong);
+
+  /* Layout width from the design system */
+  --ifm-container-width-xl: var(--layout-max);
 }
 
-/* For readability concerns, you should choose a lighter palette in dark mode. */
-[data-theme='dark'] {
-  --ifm-color-primary: #25c2a0;
-  --ifm-color-primary-dark: #21af90;
-  --ifm-color-primary-darker: #1fa588;
-  --ifm-color-primary-darkest: #1a8870;
-  --ifm-color-primary-light: #29d5b0;
-  --ifm-color-primary-lighter: #32d8b4;
-  --ifm-color-primary-lightest: #4fddbf;
-  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
+/* ============================================================
+   Element + component polish
+   ============================================================ */
+
+/* Mono breadcrumbs + TOC heading for the terminal/docs vibe. */
+.breadcrumbs__item {
+  font-family: var(--font-mono);
+}
+.table-of-contents > li > .table-of-contents__link {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-eyebrow);
+  color: var(--color-text-muted);
+}
+
+/* Prose column: relaxed leading for long reading sessions. */
+.markdown {
+  line-height: var(--leading-relaxed);
+}
+.markdown h1:first-child {
+  font-size: var(--text-display);
+}
+
+/* Active sidebar item gets the 3px yellow accent rail. */
+.menu__link--active:not(.menu__link--sublist) {
+  box-shadow: inset var(--border-width-accent) 0 0 var(--color-primary);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-strong);
+}
+
+/* Navbar active link in brand yellow. */
+.navbar__link--active {
+  color: var(--color-primary);
+}
+
+/* Cards: flat matte surface, crisp top edge, lift on hover. */
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-sm), var(--edge-top);
+  transition: transform var(--duration-base) var(--ease-standard),
+    box-shadow var(--duration-base) var(--ease-standard);
+}
+a.card:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md), var(--edge-top);
+}
+
+/* Code blocks: hairline border around gruvbox bg0. */
+div[class*='codeBlockContainer'] {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+/* Buttons: square-ish, snappy. */
+.button {
+  border-radius: var(--radius-sm);
+  transition: var(--transition-base);
+}
+.button--primary {
+  --ifm-button-color: var(--color-on-primary);
+  color: var(--color-on-primary);
+}
+.button--primary:hover {
+  background-color: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
+}
+
+/* ============================================================
+   Admonitions — 3px left rail + faded gruvbox tint per type.
+   Docusaurus maps: note->secondary, tip->success, info->info,
+   warning->warning, danger->danger.
+   ============================================================ */
+.theme-admonition {
+  border: 1px solid var(--color-border);
+  border-left-width: var(--border-width-accent);
+  border-radius: var(--radius-md);
+  box-shadow: none;
+}
+.theme-admonition.alert--secondary {
+  background: var(--color-note-bg);
+  border-left-color: var(--color-note-accent);
+}
+.theme-admonition.alert--success {
+  background: var(--color-tip-bg);
+  border-left-color: var(--color-tip-accent);
+}
+.theme-admonition.alert--info {
+  background: var(--color-info-bg);
+  border-left-color: var(--color-info-accent);
+}
+.theme-admonition.alert--warning {
+  background: var(--color-warning-bg);
+  border-left-color: var(--color-warning-accent);
+}
+.theme-admonition.alert--danger {
+  background: var(--color-danger-bg);
+  border-left-color: var(--color-danger-accent);
+}
+
+/* ============================================================
+   Focus, selection, scrollbars (from the design base layer)
+   ============================================================ */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+.navbar__link:focus-visible,
+.menu__link:focus-visible,
+.pagination-nav__link:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+  border-radius: var(--radius-sm);
+}
+
+::selection {
+  background: rgba(250, 189, 47, 0.25);
+}
+
+* {
+  scrollbar-color: var(--gb-bg3) transparent;
+}
+::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+::-webkit-scrollbar-thumb {
+  background: var(--gb-bg3);
+  border-radius: var(--radius-pill);
+  border: 2px solid transparent;
+  background-clip: content-box;
 }

--- a/docs-site/src/css/tokens/colors.css
+++ b/docs-site/src/css/tokens/colors.css
@@ -1,0 +1,106 @@
+/* ============================================================
+   Gruvbox Dark — Hard Contrast palette
+   Source palette: github.com/morhetz/gruvbox
+   Vendored from the "Gruvbox Docs Design System" (Claude Design).
+   These are the raw brand hues. Semantic aliases live below.
+   ============================================================ */
+:root {
+  /* --- Backgrounds (dark, hard contrast) --- */
+  --gb-bg0-hard: #1d2021; /* hard contrast base */
+  --gb-bg0:      #282828; /* default base */
+  --gb-bg0-soft: #32302f; /* soft contrast base */
+  --gb-bg1:      #3c3836;
+  --gb-bg2:      #504945;
+  --gb-bg3:      #665c54;
+  --gb-bg4:      #7c6f64;
+
+  /* --- Foregrounds --- */
+  --gb-fg0: #fbf1c7;
+  --gb-fg1: #ebdbb2; /* default text */
+  --gb-fg2: #d5c4a1;
+  --gb-fg3: #bdae93;
+  --gb-fg4: #a89984;
+
+  --gb-gray: #928374;
+
+  /* --- Accents: bright (used on dark bg) --- */
+  --gb-red-bright:    #fb4934;
+  --gb-green-bright:  #b8bb26;
+  --gb-yellow-bright: #fabd2f;
+  --gb-blue-bright:   #83a598;
+  --gb-purple-bright: #d3869b;
+  --gb-aqua-bright:   #8ec07c;
+  --gb-orange-bright: #fe8019;
+
+  /* --- Accents: neutral (deeper, for fills/borders) --- */
+  --gb-red:    #cc241d;
+  --gb-green:  #98971a;
+  --gb-yellow: #d79921;
+  --gb-blue:   #458588;
+  --gb-purple: #b16286;
+  --gb-aqua:   #689d6a;
+  --gb-orange: #d65d0e;
+
+  /* --- Faded (subdued tints for backgrounds of admonitions etc) --- */
+  --gb-red-faded:    #722529;
+  --gb-green-faded:  #4c4a17;
+  --gb-yellow-faded: #5a4111;
+  --gb-blue-faded:   #2e4045;
+  --gb-purple-faded: #4a2f3c;
+  --gb-aqua-faded:   #34402f;
+  --gb-orange-faded: #5a2f12;
+
+  /* ============================================================
+     Semantic aliases — reference these in components
+     ============================================================ */
+  --color-bg:            var(--gb-bg0-hard);
+  --color-bg-elevated:   var(--gb-bg0);
+  --color-surface:       var(--gb-bg0-soft);
+  --color-surface-2:     var(--gb-bg1);
+  --color-surface-3:     var(--gb-bg2);
+  --color-border:        var(--gb-bg2);
+  --color-border-strong: var(--gb-bg3);
+
+  --color-text:          var(--gb-fg1);
+  --color-text-strong:   var(--gb-fg0);
+  --color-text-muted:    var(--gb-fg4);
+  --color-text-faint:    var(--gb-gray);
+
+  --color-primary:        var(--gb-yellow-bright);
+  --color-primary-hover:  #ffc94d;
+  --color-primary-press:  var(--gb-yellow);
+  --color-on-primary:     var(--gb-bg0-hard);
+
+  --color-link:        var(--gb-blue-bright);
+  --color-link-hover:  var(--gb-aqua-bright);
+
+  --color-accent-green:  var(--gb-green-bright);
+  --color-accent-orange: var(--gb-orange-bright);
+  --color-accent-purple: var(--gb-purple-bright);
+  --color-accent-aqua:   var(--gb-aqua-bright);
+
+  /* Admonition semantics (Docusaurus note/tip/info/warning/danger) */
+  --color-note-accent:   var(--gb-blue-bright);
+  --color-note-bg:       var(--gb-blue-faded);
+  --color-tip-accent:    var(--gb-green-bright);
+  --color-tip-bg:        var(--gb-green-faded);
+  --color-info-accent:   var(--gb-aqua-bright);
+  --color-info-bg:       var(--gb-aqua-faded);
+  --color-warning-accent: var(--gb-yellow-bright);
+  --color-warning-bg:     var(--gb-yellow-faded);
+  --color-danger-accent:  var(--gb-red-bright);
+  --color-danger-bg:      var(--gb-red-faded);
+
+  /* Syntax-highlight tokens (Prism / code blocks) */
+  --code-bg:       var(--gb-bg0);
+  --code-text:     var(--gb-fg1);
+  --code-comment:  var(--gb-gray);
+  --code-keyword:  var(--gb-red-bright);
+  --code-string:   var(--gb-green-bright);
+  --code-function: var(--gb-green-bright);
+  --code-number:   var(--gb-purple-bright);
+  --code-operator: var(--gb-orange-bright);
+  --code-class:    var(--gb-yellow-bright);
+  --code-builtin:  var(--gb-aqua-bright);
+  --code-punctuation: var(--gb-fg3);
+}

--- a/docs-site/src/css/tokens/effects.css
+++ b/docs-site/src/css/tokens/effects.css
@@ -1,0 +1,25 @@
+/* ============================================================
+   Shadows, transitions, focus — tuned for a dark theme.
+   Vendored from the "Gruvbox Docs Design System" (Claude Design).
+   ============================================================ */
+:root {
+  /* Shadows: low spread, dark, with a 1px top highlight via inset */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.4);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.45);
+  --shadow-lg: 0 12px 32px rgba(0,0,0,0.55);
+  --shadow-focus: 0 0 0 3px rgba(250,189,47,0.35); /* yellow ring */
+
+  /* Inset hairline that gives dark cards a crisp top edge */
+  --edge-top: inset 0 1px 0 rgba(255,255,255,0.04);
+
+  /* Transitions — quick, no bounce. Docs feel snappy, not playful. */
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);
+  --duration-fast: 120ms;
+  --duration-base: 180ms;
+  --duration-slow: 280ms;
+  --transition-base: all var(--duration-base) var(--ease-standard);
+
+  /* Focus ring */
+  --focus-ring: var(--shadow-focus);
+}

--- a/docs-site/src/css/tokens/fonts.css
+++ b/docs-site/src/css/tokens/fonts.css
@@ -1,0 +1,7 @@
+/* ============================================================
+   Webfonts — IBM Plex Sans + JetBrains Mono (Google Fonts CDN)
+   Vendored from the "Gruvbox Docs Design System" (Claude Design).
+   To self-host, drop the .woff2 files under static/fonts/ and
+   replace this @import with @font-face rules pointing at them.
+   ============================================================ */
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400&family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap');

--- a/docs-site/src/css/tokens/spacing.css
+++ b/docs-site/src/css/tokens/spacing.css
@@ -1,0 +1,36 @@
+/* ============================================================
+   Spacing, radii, layout — 4px base grid
+   Vendored from the "Gruvbox Docs Design System" (Claude Design).
+   ============================================================ */
+:root {
+  --space-0:  0;
+  --space-1:  0.25rem;  /* 4px */
+  --space-2:  0.5rem;   /* 8px */
+  --space-3:  0.75rem;  /* 12px */
+  --space-4:  1rem;     /* 16px */
+  --space-5:  1.5rem;   /* 24px */
+  --space-6:  2rem;     /* 32px */
+  --space-7:  2.5rem;   /* 40px */
+  --space-8:  3rem;     /* 48px */
+  --space-10: 4rem;     /* 64px */
+  --space-12: 6rem;     /* 96px */
+
+  /* Radii — docs UI is mostly square with gentle softening */
+  --radius-none: 0;
+  --radius-sm: 3px;
+  --radius-md: 5px;
+  --radius-lg: 8px;
+  --radius-pill: 999px;
+
+  /* Borders */
+  --border-width: 1px;
+  --border-width-accent: 3px; /* admonition left bars, active nav */
+
+  /* Layout */
+  --layout-max: 1280px;     /* full content shell */
+  --layout-doc: 75ch;       /* readable doc column */
+  --sidebar-width: 280px;
+  --toc-width: 220px;
+  --navbar-height: 60px;
+  --content-pad: var(--space-6);
+}

--- a/docs-site/src/css/tokens/typography.css
+++ b/docs-site/src/css/tokens/typography.css
@@ -1,0 +1,54 @@
+/* ============================================================
+   Typography tokens
+   Body/UI: IBM Plex Sans  ·  Code/labels: JetBrains Mono
+   Vendored from the "Gruvbox Docs Design System" (Claude Design).
+   ============================================================ */
+:root {
+  --font-sans: "IBM Plex Sans", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+
+  /* Family roles */
+  --font-body:    var(--font-sans);
+  --font-heading: var(--font-sans);
+  --font-code:    var(--font-mono);
+  --font-eyebrow: var(--font-mono); /* small uppercase labels */
+
+  /* Type scale (1.250 major third, 16px base) */
+  --text-xs:   0.75rem;   /* 12px */
+  --text-sm:   0.875rem;  /* 14px */
+  --text-base: 1rem;      /* 16px */
+  --text-md:   1.125rem;  /* 18px */
+  --text-lg:   1.25rem;   /* 20px */
+  --text-xl:   1.5rem;    /* 24px */
+  --text-2xl:  1.953rem;  /* ~31px */
+  --text-3xl:  2.441rem;  /* ~39px */
+  --text-4xl:  3.052rem;  /* ~49px */
+  --text-5xl:  3.815rem;  /* ~61px */
+
+  /* Weights */
+  --weight-regular: 400;
+  --weight-medium:  500;
+  --weight-semibold: 600;
+  --weight-bold:    700;
+
+  /* Line heights */
+  --leading-tight:   1.15;
+  --leading-snug:    1.3;
+  --leading-normal:  1.6;
+  --leading-relaxed: 1.75; /* doc body copy */
+
+  /* Letter spacing */
+  --tracking-tight:  -0.02em;
+  --tracking-normal: 0;
+  --tracking-wide:   0.04em;
+  --tracking-eyebrow: 0.12em; /* uppercase mono labels */
+
+  /* Semantic text roles */
+  --text-display: var(--text-4xl);
+  --text-h1: var(--text-3xl);
+  --text-h2: var(--text-2xl);
+  --text-h3: var(--text-xl);
+  --text-h4: var(--text-lg);
+  --text-body-size: var(--text-md);
+  --text-small: var(--text-sm);
+}


### PR DESCRIPTION
Implements the **Gruvbox Docs Design System** (Claude Design project `1b33a43d…`) on the Docusaurus site.

## What
- **Vendored design tokens** under `docs-site/src/css/tokens/` — `colors.css` (Gruvbox dark hard-contrast palette + semantic aliases), `typography.css` (IBM Plex Sans + JetBrains Mono, type scale), `spacing.css` (4px grid, radii, layout), `effects.css` (shadows, transitions, focus ring), `fonts.css` (Google Fonts).
- **`custom.css`** maps the tokens onto Infima: backgrounds/text, brand yellow primary, fonts (18px body), links, inline code, geometry, navbar, sidebar, TOC, footer, blockquote. Plus component polish: admonitions with 3px left rails + faded gruvbox tints per type, cards (matte surface + hover lift), focus ring, brand selection, gruvbox scrollbars, mono breadcrumbs/TOC.
- **`docusaurus.config.ts`**: a Gruvbox **Prism** theme for code syntax (prism-react-renderer uses inline styles, so the syntax palette must live in config), and the site defaults to **dark-only** (`defaultMode: dark`, `disableSwitch: true`) since the brand is dark hard-contrast.

## Design decisions / notes
- **Dark-only**: the design system has no light variant, so I disabled the light/dark toggle. Easy to revert if you want a light mode later.
- **No component swizzling**: Docusaurus already provides admonitions, code blocks, tabs, pagination, navbar — themed via CSS/config here rather than replacing the React components. The DS's React primitives are prototyping aids.
- **Fonts** load from Google Fonts CDN (as the DS ships). Can self-host under `static/fonts/` later.
- **Logo** left as-is (the DS logo is a generated `~` stand-in).

## Verification
`npm run build` succeeds; confirmed gruvbox palette, both fonts, and the Prism code background all compile into the output. Not visually spot-checked in a browser — recommend `npm run serve` for a look.

Changeset included (`patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)