### PR TITLE
fix: remove silent mock-mode fallback on credential failure (#243)

### DIFF
--- a/.changeset/0005-explicit-mock-mode.md
+++ b/.changeset/0005-explicit-mock-mode.md
@@ -1,0 +1,5 @@
+---
+"pan-scm-cli": minor
+---
+
+Mock mode is now explicit. Commands no longer silently fall back to mock data when credentials are missing or invalid — they exit with code 1 and actionable remediation steps. To run without credentials (testing, demos), set `SCM_MOCK=1` or use the `--mock` flag where available. This prevents pipelines from reporting fake success when authentication is broken.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,7 +196,7 @@ scm context current
 
 **Environment variable overrides:** `SCM_CLIENT_ID`, `SCM_CLIENT_SECRET`, `SCM_TSG_ID` (useful for CI/CD).
 
-**Mock mode:** Append `--mock` to most commands to test without API credentials.
+**Mock mode:** Set `SCM_MOCK=1` (or use `--mock` where available) to test without API credentials. Missing credentials without explicit mock mode fail with exit code 1 — there is no silent fallback.
 
 **Note:** Legacy config files (`~/.scm-cli/config.yaml`, `.secrets.yaml`) are no longer supported — use contexts.
 
@@ -810,7 +810,7 @@ Env vars: `PANOS_HOST`, `PANOS_USER`, `PANOS_PASSWORD`.
 8. **HTTP server profiles require `http_method`.**
 9. **Log forwarding profile match lists require `filter`** despite SDK docs.
 10. **`--force` skips confirmation prompts** — use on `delete`/`commit` when non-interactive.
-11. **`--mock`** is available on most commands for testing without credentials.
+11. **Mock mode is explicit:** set `SCM_MOCK=1` (or `--mock` where available) to test without credentials; missing credentials otherwise exit 1.
 12. **Security rule ordering matters** — use `scm move security rule` to reorder.
 13. **Rulebase options:** `pre` (before default), `post` (after), `default` (the default rulebase).
 14. **Color names are case-sensitive in the API** but case-insensitive in the CLI validator.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ scm context current
 
 **Environment variable overrides:** `SCM_CLIENT_ID`, `SCM_CLIENT_SECRET`, `SCM_TSG_ID` (useful for CI/CD).
 
-**Mock mode:** Append `--mock` to most commands to test without API credentials.
+**Mock mode:** Set `SCM_MOCK=1` (or use `--mock` where available) to test without API credentials. Missing credentials without explicit mock mode fail with exit code 1 — there is no silent fallback.
 
 **Note:** Legacy config files (`~/.scm-cli/config.yaml`, `.secrets.yaml`) are no longer supported — use contexts.
 
@@ -810,7 +810,7 @@ Env vars: `PANOS_HOST`, `PANOS_USER`, `PANOS_PASSWORD`.
 8. **HTTP server profiles require `http_method`.**
 9. **Log forwarding profile match lists require `filter`** despite SDK docs.
 10. **`--force` skips confirmation prompts** — use on `delete`/`commit` when non-interactive.
-11. **`--mock`** is available on most commands for testing without credentials.
+11. **Mock mode is explicit:** set `SCM_MOCK=1` (or `--mock` where available) to test without credentials; missing credentials otherwise exit 1.
 12. **Security rule ordering matters** — use `scm move security rule` to reorder.
 13. **Rulebase options:** `pre` (before default), `post` (after), `default` (the default rulebase).
 14. **Color names are case-sensitive in the API** but case-insensitive in the CLI validator.

--- a/docs-site/docs/guide/configuration.md
+++ b/docs-site/docs/guide/configuration.md
@@ -68,13 +68,29 @@ $ scm context create fedramp \
 SCM_API_BASE_URL="https://api.example.paloaltonetworks.com" scm context test
 ```
 
-### Authentication Fallback
+### Missing Credentials
 
-If no credentials are configured, the CLI automatically enters mock mode:
+If no credentials are configured, commands fail with a clear error (exit code 1)
+and remediation steps — the CLI never silently falls back to mock data:
 
 ```bash
 $ scm show object address --folder Shared
-⚠️  No API credentials found. Using mock mode.
+
+❌ Authentication not configured: Missing required authentication parameters: client_id, client_secret, tsg_id
+
+To fix this issue:
+  1. Create a context: scm context create <name> --client-id <id> --client-secret <secret> --tsg-id <tsg>
+  2. Switch context: scm context use <name>
+  3. Or use environment variables: SCM_CLIENT_ID, SCM_CLIENT_SECRET, SCM_TSG_ID
+```
+
+### Mock Mode
+
+To test commands without credentials or API calls, opt in explicitly with the
+`SCM_MOCK` environment variable (or the `--mock` flag where available):
+
+```bash
+$ SCM_MOCK=1 scm show object address --folder Shared
 ```
 
 ## Examples

--- a/src/scm_cli/utils/sdk_client.py
+++ b/src/scm_cli/utils/sdk_client.py
@@ -26,6 +26,21 @@ from .context import get_current_context
 # Create logger (will be configured in __init__)
 logger = logging.getLogger(__name__)
 
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def mock_mode_requested() -> bool:
+    """Return True if mock mode was explicitly requested.
+
+    Mock mode activates only via the SCM_MOCK environment variable —
+    never as a silent fallback for missing credentials. The environment
+    is read directly (not through Dynaconf) so the check stays accurate
+    even after settings have been loaded and cached.
+    """
+    import os
+
+    return os.environ.get("SCM_MOCK", "").strip().lower() in _TRUTHY
+
 
 class SCMClient:
     """Client for the SCM SDK.
@@ -78,6 +93,15 @@ class SCMClient:
             self.logger.info("No context set, using environment variables or default settings")
 
         self._bearer_token_mode = False
+
+        if mock_mode_requested():
+            # Explicit mock mode: no API client, methods return mock data.
+            self.logger.info("Mock mode enabled (SCM_MOCK) — no API calls will be made")
+            # The following mock credentials are used only in mock mode for testing purposes and do not represent real secrets.
+            self.client_id = "mock-client-id"
+            self.client_secret = "mock-client"  # noqa: S105
+            self.tsg_id = "mock-tsg-id"
+            return
 
         try:
             # Check for bearer token auth mode first
@@ -159,13 +183,25 @@ class SCMClient:
                 self.client = Scm(**scm_kwargs)
                 self.logger.info(f"Successfully initialized SDK client for TSG ID: {self.tsg_id}")
         except (ValueError, AuthenticationError) as e:
-            self.logger.warning(f"Failed to initialize SDK client: {str(e)}")
-            self.logger.warning("Using mock mode with dummy credentials")
-            # The following mock credentials are used only in mock mode for testing purposes and do not represent real secrets.
-            self.client_id = "mock-client-id"
-            self.client_secret = "mock-client"  # noqa: S105
-            self.tsg_id = "mock-tsg-id"
-            # In mock mode, methods will return mock data instead of making API calls
+            import sys
+
+            print(f"\n❌ Authentication not configured: {e}", file=sys.stderr)
+            print(f"\nCurrent context: {current_context or 'None set'}", file=sys.stderr)
+            print("\nTo fix this issue:", file=sys.stderr)
+            print(
+                "  1. Create a context: scm context create <name> --client-id <id> --client-secret <secret> --tsg-id <tsg>",
+                file=sys.stderr,
+            )
+            print("  2. Switch context: scm context use <name>", file=sys.stderr)
+            print(
+                "  3. Or use environment variables: SCM_CLIENT_ID, SCM_CLIENT_SECRET, SCM_TSG_ID",
+                file=sys.stderr,
+            )
+            print(
+                "\nFor testing without credentials, set SCM_MOCK=1 to enable mock mode.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from e
         except (APIError, InvalidClientError) as e:
             # Handle authentication failures gracefully
             error_msg = str(e)
@@ -18218,7 +18254,9 @@ class LazyClient:
         self._client = None
 
     def __getattr__(self, name):
-        """Initialize client on first access."""
+        """Initialize client on first access (never for dunder lookups)."""
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         if self._client is None:
             self._client = SCMClient()
         return getattr(self._client, name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,10 @@ def mock_dynaconf_settings(monkeypatch):
     monkeypatch.setenv("SCM_SCM_CLIENT_SECRET", "test-client-secret")
     monkeypatch.setenv("SCM_SCM_TSG_ID", "test-tsg-id")
     monkeypatch.setenv("SCM_LOG_LEVEL", "DEBUG")
+    # Mock mode must now be requested explicitly (no silent fallback on
+    # missing credentials), so opt the whole suite in. Tests that exercise
+    # real-client init delete SCM_MOCK and patch Scm/credentials themselves.
+    monkeypatch.setenv("SCM_MOCK", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_context_endpoint_overrides.py
+++ b/tests/test_context_endpoint_overrides.py
@@ -318,6 +318,8 @@ class TestEndpointsReachScmInit:
         import scm_cli.utils.sdk_client as sdk_module
         from scm_cli.utils.context import get_context_aware_settings
 
+        # These tests exercise real client init, so opt out of suite-wide mock mode
+        monkeypatch.delenv("SCM_MOCK", raising=False)
         monkeypatch.setattr(sdk_module, "Scm", FakeScm)
         monkeypatch.setattr(sdk_module, "settings", get_context_aware_settings())
         import scm_cli.utils.config as cfg_mod

--- a/tests/test_mock_mode.py
+++ b/tests/test_mock_mode.py
@@ -1,0 +1,91 @@
+"""Tests for explicit mock-mode handling in SCMClient.
+
+Mock mode must only activate when explicitly requested (SCM_MOCK env var or
+`mock: true` in settings). Missing credentials must fail loudly with exit
+code 1 — never silently fall back to mock data.
+"""
+
+import pytest
+
+from src.scm_cli.main import app
+
+CRED_ENV_VARS = [
+    "SCM_CLIENT_ID",
+    "SCM_CLIENT_SECRET",
+    "SCM_TSG_ID",
+    "SCM_SCM_CLIENT_ID",
+    "SCM_SCM_CLIENT_SECRET",
+    "SCM_SCM_TSG_ID",
+]
+
+
+@pytest.fixture
+def no_credentials(monkeypatch):
+    """Blank out all credential env vars and disable explicit mock mode."""
+    for var in CRED_ENV_VARS:
+        monkeypatch.setenv(var, "")
+    monkeypatch.delenv("SCM_MOCK", raising=False)
+
+
+class TestNoCredentialsFailsLoudly:
+    """Without credentials and without explicit mock, the client must exit 1."""
+
+    def test_client_init_raises_system_exit(self, no_credentials, capsys):
+        from src.scm_cli.utils.sdk_client import SCMClient
+
+        with pytest.raises(SystemExit) as exc_info:
+            SCMClient()
+
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "scm context create" in err
+        assert "SCM_MOCK" in err
+
+    def test_cli_command_exits_1_without_creds(self, runner, no_credentials):
+        result = runner.invoke(app, ["show", "object", "address", "--folder", "Texas"])
+
+        assert result.exit_code == 1
+        # No fake data may reach stdout
+        assert "mock-address" not in result.output
+
+    def test_commit_exits_1_without_creds(self, runner, no_credentials):
+        result = runner.invoke(app, ["commit", "--folder", "Texas", "--description", "x", "--force"])
+
+        assert result.exit_code == 1
+        assert "mock-job-99999" not in result.output
+
+
+class TestExplicitMockMode:
+    """SCM_MOCK enables mock mode explicitly, with or without credentials."""
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on"])
+    def test_scm_mock_truthy_enables_mock(self, monkeypatch, no_credentials, value):
+        from src.scm_cli.utils.sdk_client import SCMClient
+
+        monkeypatch.setenv("SCM_MOCK", value)
+        client = SCMClient()
+
+        assert client.mock is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_scm_mock_falsy_does_not_enable_mock(self, monkeypatch, no_credentials, value):
+        from src.scm_cli.utils.sdk_client import SCMClient
+
+        monkeypatch.setenv("SCM_MOCK", value)
+        with pytest.raises(SystemExit):
+            SCMClient()
+
+    def test_scm_mock_wins_over_real_credentials(self, monkeypatch):
+        from src.scm_cli.utils.sdk_client import SCMClient
+
+        monkeypatch.setenv("SCM_MOCK", "1")
+        client = SCMClient()
+
+        assert client.mock is True
+
+    def test_mock_commands_work_with_scm_mock(self, runner, monkeypatch, no_credentials):
+        monkeypatch.setenv("SCM_MOCK", "1")
+        result = runner.invoke(app, ["commit", "--folder", "Texas", "--description", "x", "--force"])
+
+        assert result.exit_code == 0
+        assert "mock-job-99999" in result.output

--- a/tests/test_mock_mode.py
+++ b/tests/test_mock_mode.py
@@ -25,6 +25,13 @@ def no_credentials(monkeypatch):
     for var in CRED_ENV_VARS:
         monkeypatch.setenv(var, "")
     monkeypatch.delenv("SCM_MOCK", raising=False)
+    # The autouse reset fixture only handles the installed-package namespace;
+    # these CLI tests exercise the src.* namespace singleton, so reset it too.
+    import src.scm_cli.utils.sdk_client as src_sdk_module
+
+    src_sdk_module.scm_client._client = None
+    yield
+    src_sdk_module.scm_client._client = None
 
 
 class TestNoCredentialsFailsLoudly:
@@ -49,7 +56,7 @@ class TestNoCredentialsFailsLoudly:
         assert "mock-address" not in result.output
 
     def test_commit_exits_1_without_creds(self, runner, no_credentials):
-        result = runner.invoke(app, ["commit", "--folder", "Texas", "--description", "x", "--force"])
+        result = runner.invoke(app, ["commit", "--folder", "Texas", "--description", "x"])
 
         assert result.exit_code == 1
         assert "mock-job-99999" not in result.output
@@ -85,7 +92,7 @@ class TestExplicitMockMode:
 
     def test_mock_commands_work_with_scm_mock(self, runner, monkeypatch, no_credentials):
         monkeypatch.setenv("SCM_MOCK", "1")
-        result = runner.invoke(app, ["commit", "--folder", "Texas", "--description", "x", "--force"])
+        result = runner.invoke(app, ["commit", "--folder", "Texas", "--description", "x"])
 
         assert result.exit_code == 0
         assert "mock-job-99999" in result.output

--- a/tests/test_sdk_client_with_dynaconf.py
+++ b/tests/test_sdk_client_with_dynaconf.py
@@ -1,11 +1,16 @@
 """Tests for the SDK client with dynaconf integration."""
 
+import pytest
+
 from scm_cli.utils.config import settings
 from scm_cli.utils.sdk_client import SCMClient
 
 
 def test_sdk_client_init_with_credentials(monkeypatch):
     """Test that SCMClient initializes correctly with dynaconf credentials."""
+    # Real-client init path: opt out of suite-wide mock mode
+    monkeypatch.delenv("SCM_MOCK", raising=False)
+
     # Set environment variables directly with monkeypatch
     monkeypatch.setenv("SCM_SCM_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("SCM_SCM_CLIENT_SECRET", "test-client-secret")
@@ -26,21 +31,29 @@ def test_sdk_client_init_with_credentials(monkeypatch):
     assert client.tsg_id == "test-tsg-id"
 
 
-def test_sdk_client_fallback_to_mock_credentials(monkeypatch):
-    """Test that SCMClient falls back to mock credentials when none are available."""
-    # Unset environment variables
-    monkeypatch.setenv("SCM_SCM_CLIENT_ID", "")
-    monkeypatch.setenv("SCM_SCM_CLIENT_SECRET", "")
-    monkeypatch.setenv("SCM_SCM_TSG_ID", "")
+def test_sdk_client_explicit_mock_uses_mock_credentials(monkeypatch):
+    """Test that SCMClient uses mock credentials when mock mode is explicit."""
+    monkeypatch.setenv("SCM_MOCK", "1")
 
-    # Force settings reload
-    settings.reload()
-
-    # Create a new client instance
     client = SCMClient()
 
-    # Check if mock credentials are used
     assert client.client_id == "mock-client-id"
     assert client.client_secret == "mock-client"
     assert client.tsg_id == "mock-tsg-id"
     assert client.client is None  # No real client should be created
+
+
+def test_sdk_client_no_credentials_exits(monkeypatch):
+    """Test that SCMClient exits instead of silently falling back to mock."""
+    monkeypatch.delenv("SCM_MOCK", raising=False)
+    monkeypatch.setenv("SCM_SCM_CLIENT_ID", "")
+    monkeypatch.setenv("SCM_SCM_CLIENT_SECRET", "")
+    monkeypatch.setenv("SCM_SCM_TSG_ID", "")
+    monkeypatch.setenv("SCM_CLIENT_ID", "")
+    monkeypatch.setenv("SCM_CLIENT_SECRET", "")
+    monkeypatch.setenv("SCM_TSG_ID", "")
+
+    settings.reload()
+
+    with pytest.raises(SystemExit):
+        SCMClient()


### PR DESCRIPTION
## Summary
Mock mode is now explicit-only. Missing/invalid credentials exit 1 with remediation steps instead of silently returning fake success data. `SCM_MOCK=1` (env) enables mock mode deliberately.

## Changes
- `SCMClient.__init__`: explicit `mock_mode_requested()` check (SCM_MOCK env); auth failure path now prints actionable error to stderr and exits 1
- `LazyClient.__getattr__`: no longer initializes the client on dunder lookups (fixes pytest-collection side effect)
- Test suite opts into mock via `SCM_MOCK=1` in the autouse fixture; real-client-init tests opt out explicitly
- Docs: configuration guide, CLAUDE.md/AGENTS.md mock notes; changeset added

## Testing
- New tests/test_mock_mode.py: 15 tests (no-creds exit-1 unit + CLI paths, SCM_MOCK truthy/falsy matrix, mock-wins-over-creds)
- Full suite: 1146 passed, 29 skipped
- E2E verified in clean HOME: no creds → exit 1 + guidance; SCM_MOCK=1 → mock commit works
- lint/ruff/mypy clean; docs build (strict) passes

## Checklist
- [x] Tests written first (TDD)
- [x] All tests passing
- [x] Lint/format/typecheck clean
- [x] Documentation updated
- [x] Changeset added

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)