### PR TITLE
fix: add confirmation prompt + --force to zone/ipsec-crypto-profile/nat-rule deletes (#244)

### DIFF
--- a/.changeset/0006-network-delete-confirmations.md
+++ b/.changeset/0006-network-delete-confirmations.md
@@ -1,0 +1,5 @@
+---
+"pan-scm-cli": patch
+---
+
+`scm delete network zone`, `scm delete network ipsec-crypto-profile`, and `scm delete network nat-rule` now ask for confirmation before deleting, matching every other delete command. Pass `--force` to skip the prompt (the flag was already documented but previously unimplemented).

--- a/src/scm_cli/commands/network.py
+++ b/src/scm_cli/commands/network.py
@@ -1095,11 +1095,14 @@ def backup_security_zone(
 def delete_zone(
     folder: str = FOLDER_OPTION,
     name: str = NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a security zone.
 
     Example: scm delete network zone --folder Texas --name trust
     """
+    if not force:
+        typer.confirm(f"Delete zone '{name}' from folder '{folder}'?", abort=True)
     # Call the SDK client to delete the zone
     result = scm_client.delete_zone(folder=folder, name=name)
 
@@ -1473,11 +1476,14 @@ def backup_ipsec_crypto_profile(
 def delete_ipsec_crypto_profile(
     folder: str = IPSEC_FOLDER_OPTION,
     name: str = IPSEC_NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete an IPsec crypto profile.
 
     Example: scm delete network ipsec-crypto-profile --folder Texas --name my-profile
     """
+    if not force:
+        typer.confirm(f"Delete IPsec crypto profile '{name}' from folder '{folder}'?", abort=True)
     result = scm_client.delete_ipsec_crypto_profile(folder=folder, name=name)
 
     if result:
@@ -1734,11 +1740,14 @@ def backup_nat_rule(
 def delete_nat_rule(
     folder: str = NAT_FOLDER_OPTION,
     name: str = NAT_NAME_OPTION,
+    force: bool = typer.Option(False, "--force", help="Skip confirmation prompt"),
 ):
     """Delete a NAT rule.
 
     Example: scm delete network nat-rule --folder Texas --name outbound-nat
     """
+    if not force:
+        typer.confirm(f"Delete NAT rule '{name}' from folder '{folder}'?", abort=True)
     result = scm_client.delete_nat_rule(folder=folder, name=name)
 
     if result:

--- a/tests/test_network_commands.py
+++ b/tests/test_network_commands.py
@@ -226,6 +226,7 @@ class TestZoneCommands:
                 "test-folder",
                 "--name",
                 "test-zone",
+                "--force",
             ],
         )
 
@@ -849,6 +850,7 @@ class TestIPsecCryptoProfileCommands:
                 "Texas",
                 "--name",
                 "test-profile",
+                "--force",
             ],
         )
 
@@ -1169,6 +1171,7 @@ class TestNATRuleCommands:
                 "Texas",
                 "--name",
                 "outbound-nat",
+                "--force",
             ],
         )
 
@@ -2961,3 +2964,60 @@ class TestQosRuleCommands:
         result = runner.invoke(test_app, ["--file", str(yaml_file)])
         assert result.exit_code == 0
         assert "Created QoS rule" in result.stdout
+
+
+class TestDeleteConfirmations:
+    """Deletes must prompt for confirmation unless --force is given.
+
+    Covers the three delete commands that historically deleted immediately:
+    zone, ipsec-crypto-profile, and nat-rule.
+    """
+
+    CASES = [
+        (delete_zone, "delete_zone", "test-zone"),
+        (delete_ipsec_crypto_profile, "delete_ipsec_crypto_profile", "test-profile"),
+        (delete_nat_rule, "delete_nat_rule", "outbound-nat"),
+    ]
+
+    def _make_app(self, command, client_method, monkeypatch, calls):
+        from scm_cli.utils.sdk_client import scm_client
+
+        def mock_delete(*args, **kwargs):
+            calls.append(kwargs)
+            return True
+
+        monkeypatch.setattr(scm_client, client_method, mock_delete)
+        test_app = typer.Typer()
+        test_app.command()(command)
+        return test_app
+
+    def test_prompt_decline_aborts_without_deleting(self, runner, monkeypatch):
+        for command, client_method, name in self.CASES:
+            calls = []
+            test_app = self._make_app(command, client_method, monkeypatch, calls)
+
+            result = runner.invoke(test_app, ["--folder", "Texas", "--name", name], input="n\n")
+
+            assert result.exit_code != 0, f"{client_method}: declining must not exit 0"
+            assert calls == [], f"{client_method}: delete must not be called on decline"
+
+    def test_prompt_accept_deletes(self, runner, monkeypatch):
+        for command, client_method, name in self.CASES:
+            calls = []
+            test_app = self._make_app(command, client_method, monkeypatch, calls)
+
+            result = runner.invoke(test_app, ["--folder", "Texas", "--name", name], input="y\n")
+
+            assert result.exit_code == 0, f"{client_method}: accepting must delete"
+            assert len(calls) == 1, f"{client_method}: delete must be called once"
+
+    def test_force_skips_prompt(self, runner, monkeypatch):
+        for command, client_method, name in self.CASES:
+            calls = []
+            test_app = self._make_app(command, client_method, monkeypatch, calls)
+
+            result = runner.invoke(test_app, ["--folder", "Texas", "--name", name, "--force"])
+
+            assert result.exit_code == 0, f"{client_method}: --force must delete"
+            assert len(calls) == 1
+            assert "?" not in result.stdout, f"{client_method}: --force must not prompt"

--- a/tests/test_network_commands.py
+++ b/tests/test_network_commands.py
@@ -257,6 +257,7 @@ class TestZoneCommands:
                 "test-folder",
                 "--name",
                 "test-zone",
+                "--force",
             ],
         )
 
@@ -1198,6 +1199,7 @@ class TestNATRuleCommands:
                 "Texas",
                 "--name",
                 "outbound-nat",
+                "--force",
             ],
         )
 

--- a/tests/test_network_commands_env.py
+++ b/tests/test_network_commands_env.py
@@ -65,7 +65,7 @@ class TestZoneCommands:
         with patch("scm_cli.commands.network.scm_client") as mock_client:
             mock_client.delete_zone.return_value = True
 
-            result = runner.invoke(app, ["delete", "network", "zone", "--folder", "Shared", "--name", "test-zone"])
+            result = runner.invoke(app, ["delete", "network", "zone", "--folder", "Shared", "--name", "test-zone", "--force"])
 
             assert result.exit_code == 0
             assert "Deleted zone" in result.stdout


### PR DESCRIPTION
## Summary
The 3 remaining delete commands that destroyed objects with no confirmation now prompt like the other 73, with `--force` to skip (flag was documented but unimplemented).

## Changes
- `delete network zone` / `ipsec-crypto-profile` / `nat-rule`: `typer.confirm(..., abort=True)` unless `--force`

## Testing
- New TestDeleteConfirmations: decline-aborts, accept-deletes, force-skips-prompt for all 3
- Existing delete tests updated to pass --force
- Full suite: 1133 passed, 29 skipped; lint/ruff/mypy clean
- Docs already documented --force — code now matches

## Checklist
- [x] Tests written first (TDD)
- [x] All tests passing
- [x] Lint/format/typecheck clean
- [x] Changeset added

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)